### PR TITLE
[WIP] Add deviceId into network status annotation

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -536,7 +536,7 @@ func cmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		//create the network status, only in case Multus as kubeconfig
 		if n.Kubeconfig != "" && kc != nil {
 			if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAME), n.SystemNamespaces) {
-				delegateNetStatus, err := nadutils.CreateNetworkStatus(tmpResult, delegate.Conf.Name, delegate.MasterPlugin)
+				delegateNetStatus, err := nadutils.CreateNetworkStatusWithDeviceID(tmpResult, delegate.Conf.Name, delegate.DeviceID, delegate.MasterPlugin)
 				if err != nil {
 					return nil, cmdErr(k8sArgs, "error setting network status: %v", err)
 				}

--- a/types/conf.go
+++ b/types/conf.go
@@ -73,6 +73,7 @@ func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID st
 			if err != nil {
 				return nil, logging.Errorf("LoadDelegateNetConf: failed to add deviceID in NetConfList bytes: %v", err)
 			}
+			delegateConf.DeviceID = deviceID
 		}
 		if net != nil && net.CNIArgs != nil {
 			bytes, err = addCNIArgsInConfList(bytes, net.CNIArgs)
@@ -86,6 +87,7 @@ func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID st
 			if err != nil {
 				return nil, logging.Errorf("LoadDelegateNetConf: failed to add deviceID in NetConf bytes: %v", err)
 			}
+			delegateConf.DeviceID = deviceID
 		}
 		if net != nil && net.CNIArgs != nil {
 			bytes, err = addCNIArgsInConfig(bytes, net.CNIArgs)

--- a/types/types.go
+++ b/types/types.go
@@ -100,6 +100,7 @@ type DelegateNetConf struct {
 	PortMappingsRequest []*PortMapEntry `json:"-"`
 	BandwidthRequest    *BandwidthEntry `json:"-"`
 	GatewayRequest      []net.IP        `json:"default-route,omitempty"`
+	DeviceID            string          `json:"deviceID,omitempty"`
 	IsFilterGateway     bool
 	// MasterPlugin is only used internal housekeeping
 	MasterPlugin bool `json:"-"`


### PR DESCRIPTION
This PR adds PCI deviceId of a network (if any) into network status annotation so that pod application can query it via downward API. 
 
Issue: https://github.com/intel/network-resources-injector/issues/20
Depends On: https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/pull/21

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>