### PR TITLE
[logging] Adds a method for using specific messaging for known errors

### DIFF
--- a/logging/known_errors.go
+++ b/logging/known_errors.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+  "fmt"
+  "strings"
+)
+
+// knownErrorPatterns is a list of all known error patterns
+var knownErrorPatterns = []string{
+  "error dialing DHCP daemon",
+}
+
+// getKnownErrorMessage returns
+func getKnownErrorMessage(patternkey string) (string, error) {
+  messages := map[string]string{
+    "error dialing DHCP daemon": "please check that the dhcp cni daemon is running and is properly configured.",
+  }
+
+  if val, ok := messages[patternkey]; ok {
+    return val, nil
+  }
+
+  return "", fmt.Errorf("Known error key '" + patternkey + "' does not have a message")
+
+}
+
+// detectKnownErrors detects the first known error given n number of stringers as passed to the logging methods
+func addKnownErrorMessage(a ...interface{}) string {
+  var knownerrormessage string
+  var err error
+
+  for _, eachstringer := range a {
+    for _, eachknownerror := range knownErrorPatterns {
+      if strings.Contains(fmt.Sprintf("%s", eachstringer), eachknownerror) {
+        knownerrormessage, err = getKnownErrorMessage(eachknownerror)
+        if err != nil {
+          Errorf("error getting known error message: %s", err)
+        }
+        knownerrormessage = knownerrormessage + " (" + knownerrormessage + ") "
+        continue
+      }
+    }
+  }
+  return knownerrormessage
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -88,6 +88,7 @@ func Verbosef(format string, a ...interface{}) {
 
 // Errorf prints logging if logging level >= error
 func Errorf(format string, a ...interface{}) error {
+	format = addKnownErrorMessage(a) + format
 	printf(ErrorLevel, format, a...)
 	return fmt.Errorf(format, a...)
 }

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -15,10 +15,10 @@
 package logging
 
 import (
-	"testing"
-
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"testing"
 )
 
 func TestLogging(t *testing.T) {
@@ -79,4 +79,24 @@ var _ = Describe("logging operations", func() {
 		currentLevel := loggingLevel
 		Expect(currentLevel).To(Equal(GetLoggingLevel()))
 	})
+
+	It("Detects a known error", func() {
+		newerror := Errorf("Testing 123", fmt.Errorf("error dialing DHCP daemon: dial unix /run/cni/dhcp.sock: connect: no such file or directory"))
+		Expect(newerror.Error()).To(ContainSubstring("please check that the dhcp cni daemon is running and is properly configured."))
+	})
+
+	It("Properly errors when an error message is not set for a pattern", func() {
+		_, err := getKnownErrorMessage("intentionally unset error pattern")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Has a message set for each error pattern that is set", func() {
+		// If this fails, it probably means you added the error pattern, but, not the error message.
+		for _, errorpattern := range knownErrorPatterns {
+			message, err := getKnownErrorMessage(errorpattern)
+			Expect(message).NotTo(HaveLen(0))
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
 })


### PR DESCRIPTION
This introduces a new set of "known errors" -- a series of known errors that may occur, especially related to usage. 

The goal is to add some actionable instructions for users when they encounter something that we know to occur with some frequency. In this case, we start with a single known error -- that error being when the DHCP CNI daemon isn't running the DHCP IPAM CNI plugin returns an error stating so much. Here, we instruct the user to make sure the DHCP CNI daemon is running.

The downside is that this makes the error messages even longer for the time being. However, I'm hopeful that in the future this makes for a way to shorten at least some known error messages.