### PR TITLE
Correcting Dockerfile path for manual e2e tests

### DIFF
--- a/e2e/setup_cluster.sh
+++ b/e2e/setup_cluster.sh
@@ -10,7 +10,7 @@ running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || t
 if [ "${running}" != 'true' ]; then
   # run registry and push the multus image
   docker run -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" registry:2
-  docker build -t localhost:5000/multus:e2e ..
+  docker build -t localhost:5000/multus:e2e -f ../deployments/Dockerfile ..
   docker push localhost:5000/multus:e2e
 fi
 reg_host="${reg_name}"


### PR DESCRIPTION
Setting up for manual e2e-tests fails due to that the multus container image is not built. This works fine in CI since this part is done separately within the github action.

This is a minor change to use the new location of the Dockerfile when running the e2e-tests manually.