### PR TITLE
[WIP] build nw status with every container interfaces

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -656,12 +656,13 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		// create the network status, only in case Multus as kubeconfig
 		if n.Kubeconfig != "" && kc != nil {
 			if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAME), n.SystemNamespaces) {
-				delegateNetStatus, err := nadutils.CreateNetworkStatus(tmpResult, delegate.Name, delegate.MasterPlugin, devinfo)
+				delegateNetStatuses, err := nadutils.CreateNetworkStatus(tmpResult, delegate.Name, delegate.MasterPlugin, devinfo)
 				if err != nil {
 					return nil, cmdErr(k8sArgs, "error setting network status: %v", err)
 				}
-
-				netStatus = append(netStatus, *delegateNetStatus)
+				for _, delegateNetStatus := range delegateNetStatuses {
+					netStatus = append(netStatus, *delegateNetStatus)
+				}
 			}
 		} else if devinfo != nil {
 			// Warn that devinfo exists but could not add it to downwards API


### PR DESCRIPTION
This patch is to update nw status with all relevant information
when pod container has secondary interface with its vlan sub
interfaces.

Here is a multi interface use case described in this ovs-cni [PR](https://github.com/kubevirt/ovs-cni/pull/151)

This PR depends on API changes in network-attachment-definition-client [PR](https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/pull/36)

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>