### PR TITLE
Describe additional condition when using clusterNetwork

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,7 +60,7 @@ User should chose following parameters combination (`clusterNetwork`+`defaultNet
 Multus will find network for clusterNetwork/defaultNetworks as following sequences:
 
 1. CRD object for given network name, in 'kube-system' namespace
-1. CNI json config file in `confDir`. Given name should be without extention, like .conf/.conflist. (e.g. "test" for "test.conf")
+1. CNI json config file in `confDir`. Given name should be without extention, like .conf/.conflist. (e.g. "test" for "test.conf"). The given name for `clusterNetwork` should match the value for `name` key in the config file (e.g. `"name": "test"` in "test.conf" when `"clusterNetwork": "test"`)
 1. Directory for CNI json config file. Multus will find alphabetically first file for the network
 1. Multus failed to find network. Multus raise error message
 


### PR DESCRIPTION
This PR adds description about a condition that needs to be satisfied when configuring `clusterNetwork` to refer to a CNI JSON config file in `confDir`. I was trying to use `clsuterNetwork` config, but failed for a while as the file name set for `clusterNetwork` didn't match the value for `name` key in the file. It would be helpful to describe the condition currently undocumented.