### PR TITLE
Retry on multiple error types with backoff

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -44,6 +44,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+const (
+	shortPollDuration = 250 * time.Millisecond
+	shortPollTimeout = 2500 * time.Millisecond
+)
+
 var (
 	version = "master@git"
 	commit  = "unknown commit"
@@ -551,9 +556,7 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 			var waitErr error
 			// in case of a retriable error, retry 10 times with 0.25 sec interval
 			if isCriticalRequestRetriable(err) {
-				pollDuration := 250 * time.Millisecond
-				pollTimeout := 2500 * time.Millisecond
-				waitErr = wait.PollImmediate(pollDuration, pollTimeout, func() (bool, error) {
+				waitErr = wait.PollImmediate(shortPollDuration, shortPollTimeout, func() (bool, error) {
 					pod, err = kubeClient.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 					return pod != nil, err
 				})
@@ -778,9 +781,7 @@ func CmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) er
 			var waitErr error
 			// in case of a retriable error, retry 10 times with 0.25 sec interval
 			if isCriticalRequestRetriable(err) {
-				pollDuration := 250 * time.Millisecond
-				pollTimeout := 2500 * time.Millisecond
-				waitErr = wait.PollImmediate(pollDuration, pollTimeout, func() (bool, error) {
+				waitErr = wait.PollImmediate(shortPollDuration, shortPollTimeout, func() (bool, error) {
 					pod, err = kubeClient.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 					return pod != nil, err
 				})

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -549,10 +549,10 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		pod, err = kubeClient.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 		if err != nil {
 			var waitErr error
-			// in case of a retriable error, retry 10 times with 0.5 sec interval
+			// in case of a retriable error, retry 10 times with 0.25 sec interval
 			if isCriticalRequestRetriable(err) {
-				pollDuration := 500 * time.Millisecond
-				pollTimeout := 5 * time.Second
+				pollDuration := 250 * time.Millisecond
+				pollTimeout := 2500 * time.Millisecond
 				waitErr = wait.PollImmediate(pollDuration, pollTimeout, func() (bool, error) {
 					pod, err = kubeClient.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 					return pod != nil, err
@@ -776,10 +776,10 @@ func CmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) er
 		pod, err = kubeClient.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 		if err != nil {
 			var waitErr error
-			// in case of a retriable error, retry 10 times with 0.5 sec interval
+			// in case of a retriable error, retry 10 times with 0.25 sec interval
 			if isCriticalRequestRetriable(err) {
-				pollDuration := 500 * time.Millisecond
-				pollTimeout := 5 * time.Second
+				pollDuration := 250 * time.Millisecond
+				pollTimeout := 2500 * time.Millisecond
 				waitErr = wait.PollImmediate(pollDuration, pollTimeout, func() (bool, error) {
 					pod, err = kubeClient.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 					return pod != nil, err


### PR DESCRIPTION
Use exponential backoff when retrying to retrieve the pod for both ADD/DEL commands.

The retries occur when getting the pod information fails with either of the following errors:
  - service unavailable
  - server internal error
  - connection reset
  - connection refused

Fixes: https://github.com/k8snetworkplumbingwg/multus-cni/issues/649
