### PR TITLE
Update golang version for installing packages

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -4,7 +4,7 @@ FROM centos:centos7 as build
 # Add everything
 ADD . /usr/src/multus-cni
 
-ENV INSTALL_PKGS "git golang-1.13.10-0.el7.x86_64"
+ENV INSTALL_PKGS "git golang-1.15.13-0.el7.x86_64"
 RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO && \
     curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo && \
     yum install -y $INSTALL_PKGS && \


### PR DESCRIPTION
Addresses #693 

Before change, docker build would fail with following error
```
#7 567.3 go: github.com/k8snetworkplumbingwg/network-attachment-definition-client@v1.1.1-0.20210510153419-66a699ae3b05 requires
#7 567.3  k8s.io/code-generator@v0.18.3 requires
#7 567.3  golang.org/x/mod@v0.3.1-0.20200828183125-ce943fd02449: invalid version: git fetch --unshallow -f origin in /root/go/pkg/mod/cache/vcs/13df7481b5cc3358460b717a6142fe8dbaae7652e5d05689849f419ffd40ac12: exit status 128:
#7 567.3  fatal: git fetch-pack: expected shallow list
------
executor failed running [/bin/sh -c rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO &&     curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo &&     yum install -y $INSTALL_PKGS &&     rpm -V $INSTALL_PKGS &&     cd /usr/src/multus-cni &&     ./hack/build-go.sh]: exit code: 1
```

After updating golang to latest version, docker build succeeds 