### PR TITLE
Use MULTUS_MASTER_CNI_FILE_NAME as MASTER_PLUGIN as is, if specified

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -268,7 +268,7 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
   tries=0
   while [ $found_master == false ]; do
     if [ "$MULTUS_MASTER_CNI_FILE_NAME" != "" ]; then
-        MASTER_PLUGIN="$(ls $MULTUS_AUTOCONF_DIR/$MULTUS_MASTER_CNI_FILE_NAME)" || true
+        MASTER_PLUGIN="$MULTUS_MASTER_CNI_FILE_NAME"
     else
         MASTER_PLUGIN="$(ls $MULTUS_AUTOCONF_DIR | grep -E '\.conf(list)?$' | grep -Ev '00-multus\.conf' | head -1)"
     fi
@@ -284,6 +284,7 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
         exit 1;
       fi
     else
+      log "Using MASTER_PLUGIN: $MASTER_PLUGIN"
 
       found_master=true
 


### PR DESCRIPTION
Before change, specifying MULTUS_MASTER_CNI_FILE_NAME would not properly generate multus conf as the file path was wrong 
Multus pod logs would show following error
```
kubectl logs -f pod/kube-multus-ds-8zs2t -n kube-system
2021-07-12T16:50:00+0000 Generating Multus configuration file using files in /host/etc/cni/net.d...
2021-07-12T16:50:00+0000 Using MASTER_PLUGIN: /host/etc/cni/net.d/10-aws.conflist -> this should take only filename and not entire path 
cat: /host/etc/cni/net.d//host/etc/cni/net.d/10-aws.conflist: No such file or directory -> Incorrect file path 
Traceback (most recent call last):
  File "/tmp/tmp.zngU7gWnzK", line 2, in <module>
    conf = json.load(sys.stdin)
  File "/usr/lib64/python2.7/json/__init__.py", line 290, in load
    **kw)
  File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```
After change , multus conf can be correctly generated when MULTUS_MASTER_CNI_FILE_NAME is specified 
```
kubectl logs -f pod/kube-multus-ds-bvdtp -n kube-system
2021-07-12T16:54:22+0000 Generating Multus configuration file using files in /host/etc/cni/net.d...
2021-07-12T16:54:22+0000 Using MASTER_PLUGIN: 10-aws.conflist
2021-07-12T16:54:22+0000 Nested capabilities string: "capabilities": {"portMappings": true},
2021-07-12T16:54:22+0000 Using /host/etc/cni/net.d/10-aws.conflist as a source to generate the Multus configuration
2021-07-12T16:54:22+0000 Config file created @ /host/etc/cni/net.d/00-multus.conf
{ "cniVersion": "0.3.1", "name": "multus-cni-network", "type": "multus", "capabilities": {"portMappings": true}, "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig", "delegates": [ { "cniVersion": "0.3.1", "name": "aws-cni", "plugins": [ { "name": "aws-cni", "type": "aws-cni", "vethPrefix": "eni", "mtu": "9001", "pluginLogFile": "/var/log/aws-routed-eni/plugin.log", "pluginLogLevel": "DEBUG" }, { "type": "portmap", "capabilities": {"portMappings": true}, "snat": true } ] } ] }
2021-07-12T16:54:22+0000 Entering sleep (success)...
```
