### PR TITLE
Upgrades to all Dockerfiles. Make Golang version consistent across images.

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -4,7 +4,7 @@ FROM centos:centos7 as build
 # Add everything
 ADD . /usr/src/multus-cni
 
-ENV INSTALL_PKGS "git golang-1.15.13-0.el7.x86_64"
+ENV INSTALL_PKGS "git golang-1.16.6-0.el7.x86_64"
 RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO && \
     curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo && \
     yum install -y $INSTALL_PKGS && \
@@ -15,6 +15,7 @@ RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO && \
 FROM centos:centos7
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+RUN yum update
 WORKDIR /
 
 ADD ./images/entrypoint.sh /

--- a/deployments/Dockerfile.arm32
+++ b/deployments/Dockerfile.arm32
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM golang:1.13.4 as build
+FROM golang:1.16.6 as build
 
 # Add everything
 ADD . /usr/src/multus-cni
@@ -14,6 +14,7 @@ RUN  cd /usr/src/multus-cni && \
 FROM arm32v7/centos:7
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+RUN yum update
 
 WORKDIR /
 ADD ./images/entrypoint.sh /

--- a/deployments/Dockerfile.arm64
+++ b/deployments/Dockerfile.arm64
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM golang:1.13.4 as build
+FROM golang:1.16.6 as build
 
 # Add everything
 ADD . /usr/src/multus-cni
@@ -14,6 +14,7 @@ RUN  cd /usr/src/multus-cni && \
 FROM arm64v8/centos:7
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+RUN yum update
 
 WORKDIR /
 ADD ./images/entrypoint.sh /

--- a/deployments/Dockerfile.openshift
+++ b/deployments/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # This dockerfile is specific to building Multus for OpenShift
-FROM openshift/origin-release:golang-1.15 as builder
+FROM openshift/origin-release:golang-1.16 as builder
 
 ADD . /usr/src/multus-cni
 
@@ -7,7 +7,7 @@ WORKDIR /usr/src/multus-cni
 ENV GO111MODULE=off
 RUN ./hack/build-go.sh
 
-FROM openshift/origin-base
+FROM openshift/origin-base:v3.11
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 RUN mkdir -p /usr/src/multus-cni/images && mkdir -p /usr/src/multus-cni/bin
 COPY --from=builder /usr/src/multus-cni/bin/multus /usr/src/multus-cni/bin

--- a/deployments/Dockerfile.ppc64le
+++ b/deployments/Dockerfile.ppc64le
@@ -7,7 +7,7 @@ ADD . /usr/src/multus-cni
 ENV GOARCH "ppc64le"
 ENV GOOS "linux"
 
-ENV INSTALL_PKGS "git golang"
+ENV INSTALL_PKGS "git golang-1.16.6-0.el7.x86_64"
 RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO && \
     curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo && \
     yum install -y $INSTALL_PKGS && \
@@ -19,6 +19,7 @@ RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO && \
 FROM ppc64le/centos:latest
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+RUN yum update
 
 WORKDIR /
 ADD ./images/entrypoint.sh /

--- a/deployments/Dockerfile.s390x
+++ b/deployments/Dockerfile.s390x
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM golang:1.13 as build
+FROM golang:1.16 as build
 
 # Add everything
 ADD . /usr/src/multus-cni
@@ -14,6 +14,7 @@ RUN  cd /usr/src/multus-cni && \
 FROM s390x/python:3-slim
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+RUN apt-get update && apt-get upgrade -y
 WORKDIR /
 ADD ./images/entrypoint.sh /
 


### PR DESCRIPTION
* Looking at the different Dockerfiles I noticed that all of them were using different versions of Golang, from 1.13 to 1.15. This PR takes care of using the same version (1.16, same as go.mod file) across all the images.
* This PR also takes care of running `yum update` on the final image to take care of any last minute package updates to the base image.
* The image for `openshift/origin-base` used hasn't been updated in 2 years, updated the tag to `v3.11` which is the latest available, but I have no way of testing this.

On a note, is there a reason the final images use CentOS instead of Alpine or Google/Distroless ?

This PR may fix some of the issues presented in #700 