### PR TITLE
Update golang version (at least >= 1.16)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.16.x, 1.17.x]
         goarch: [386, amd64, arm, arm64, ppc64le, s390x]
         os: [ubuntu-latest] #, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.16.x, 1.17.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -1,16 +1,11 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM centos:centos7 as build
+FROM golang:1.17.1 as build
 
 # Add everything
 ADD . /usr/src/multus-cni
 
-ENV INSTALL_PKGS "git golang-1.15.13-0.el7.x86_64"
-RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO && \
-    curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo && \
-    yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    cd /usr/src/multus-cni && \
-    ./hack/build-go.sh
+RUN  cd /usr/src/multus-cni && \
+     ./hack/build-go.sh
 
 FROM centos:centos7
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni

--- a/deployments/Dockerfile.arm32
+++ b/deployments/Dockerfile.arm32
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM golang:1.13.4 as build
+FROM golang:1.17.1 as build
 
 # Add everything
 ADD . /usr/src/multus-cni

--- a/deployments/Dockerfile.arm64
+++ b/deployments/Dockerfile.arm64
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM golang:1.13.4 as build
+FROM golang:1.17.1 as build
 
 # Add everything
 ADD . /usr/src/multus-cni

--- a/deployments/Dockerfile.openshift
+++ b/deployments/Dockerfile.openshift
@@ -1,5 +1,5 @@
 # This dockerfile is specific to building Multus for OpenShift
-FROM openshift/origin-release:golang-1.15 as builder
+FROM openshift/origin-release:golang-1.16 as builder
 
 ADD . /usr/src/multus-cni
 

--- a/deployments/Dockerfile.ppc64le
+++ b/deployments/Dockerfile.ppc64le
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM centos:centos7 as build
+FROM golang:1.17.1 as build
 
 # Add everything
 ADD . /usr/src/multus-cni
@@ -7,13 +7,8 @@ ADD . /usr/src/multus-cni
 ENV GOARCH "ppc64le"
 ENV GOOS "linux"
 
-ENV INSTALL_PKGS "git golang"
-RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO && \
-    curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo && \
-    yum install -y $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    cd /usr/src/multus-cni && \
-    ./hack/build-go.sh
+RUN  cd /usr/src/multus-cni && \
+     ./hack/build-go.sh
 
 # build ppc container
 FROM ppc64le/centos:latest

--- a/deployments/Dockerfile.s390x
+++ b/deployments/Dockerfile.s390x
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM golang:1.13 as build
+FROM golang:1.17 as build
 
 # Add everything
 ADD . /usr/src/multus-cni


### PR DESCRIPTION
Currently golang community supports 1.16 and later, hence, need
to update golang version in our build pipeline. This change
updates golang version to 1.17/1.16.