### PR TITLE
deployment, thick: remove extra multus-cni-config mountpoint

### DIFF
--- a/deployments/multus-daemonset-thick-plugin.yml
+++ b/deployments/multus-daemonset-thick-plugin.yml
@@ -142,8 +142,6 @@ spec:
               mountPath: /host/etc/cni/net.d
             - name: cnibin
               mountPath: /host/opt/cni/bin
-            - name: multus-cfg
-              mountPath: /tmp/multus-conf
       initContainers:
         - name: install-multus-binary
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:stable


### PR DESCRIPTION
This volume was removed since multus now requires the default cluster
network CNI configuration to be available. As such, the volume as
removed, but we unfortunately forgot to remove to remove the volume
mount.

Without this change, the following error occurs when provisioning the `deployments/multus-daemonset-thick-plugin.yml ` daemonset spec:

```bash
$ kubectl apply -f ../multus-cni/deployments/multus-daemonset-thick-plugin.yml 
Warning: resource customresourcedefinitions/network-attachment-definitions.k8s.cni.cncf.io is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
customresourcedefinition.apiextensions.k8s.io/network-attachment-definitions.k8s.cni.cncf.io configured
Warning: resource clusterroles/multus is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
clusterrole.rbac.authorization.k8s.io/multus configured
Warning: resource clusterrolebindings/multus is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
clusterrolebinding.rbac.authorization.k8s.io/multus configured
serviceaccount/multus created
The DaemonSet "kube-multus-ds" is invalid: spec.template.spec.containers[0].volumeMounts[2].name: Not found: "multus-cfg"

```

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>