### PR TITLE
multus cni: add / remove single network / interface

### DIFF
--- a/pkg/k8sclient/netconfgen.go
+++ b/pkg/k8sclient/netconfgen.go
@@ -1,0 +1,132 @@
+package k8sclient
+
+import (
+	"fmt"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/logging"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/types"
+	v1 "k8s.io/api/core/v1"
+)
+
+// NetConfGenerator generates the delegates that go in the multus configuration
+// struct.
+type NetConfGenerator struct {
+	clientInfo  *ClientInfo
+	conf        *types.NetConf
+	pod         *v1.Pod
+	networks    []*types.NetworkSelectionElement
+	resourceMap map[string]*types.ResourceInfo
+}
+
+// NewHotplugNetConfGenerator creates a multus netconf generator for the hotplug scenario.
+func NewHotplugNetConfGenerator(clientInfo *ClientInfo, initialConf *types.NetConf, pod *v1.Pod, resourceMap map[string]*types.ResourceInfo, networkName string, ifaceName string) (*NetConfGenerator, error) {
+	podNetworks, err := GetPodNetwork(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	network, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName(networkName, ifaceName))
+	if err != nil {
+		return nil, &NoK8sNetworkError{
+			message: fmt.Sprintf("could not find network: %s; iface: %s in the pod's annotations", networkName, ifaceName)}
+	}
+
+	initialConf.Delegates = []*types.DelegateNetConf{}
+	return &NetConfGenerator{
+		clientInfo:  clientInfo,
+		conf:        initialConf,
+		pod:         pod,
+		networks:    []*types.NetworkSelectionElement{network},
+		resourceMap: resourceMap,
+	}, nil
+}
+
+// NewHotUnplugNetConfGenerator creates a multus netconf generator for the hot-unplug scenario.
+func NewHotUnplugNetConfGenerator(clientInfo *ClientInfo, initialConf *types.NetConf, pod *v1.Pod, resourceMap map[string]*types.ResourceInfo, networkName string, ifaceName string) (*NetConfGenerator, error) {
+	podNetworks, err := GetPodNetworkFromStatus(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	network, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName(networkName, ifaceName))
+	if err != nil {
+		return nil, &NoK8sNetworkError{
+			message: fmt.Sprintf("could not find network: %s; iface: %s in the pod's annotations", networkName, ifaceName)}
+	}
+
+	initialConf.Delegates = []*types.DelegateNetConf{}
+	return &NetConfGenerator{
+		clientInfo:  clientInfo,
+		conf:        initialConf,
+		pod:         pod,
+		networks:    []*types.NetworkSelectionElement{network},
+		resourceMap: resourceMap,
+	}, nil
+}
+
+func filterNetworkByNetAndIfaceName(networkName string, ifaceName string) func(net types.NetworkSelectionElement) bool {
+	return func(net types.NetworkSelectionElement) bool {
+		if net.Name == networkName && net.InterfaceRequest == ifaceName {
+			return true
+		}
+		return false
+	}
+}
+
+// NewNetConfGenerator returns a multus netconf generator for use on pod
+// creation / deletion.
+func NewNetConfGenerator(clientInfo *ClientInfo, initialConf *types.NetConf, pod *v1.Pod, resourceMap map[string]*types.ResourceInfo) (*NetConfGenerator, error) {
+	networks, err := GetPodNetwork(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NetConfGenerator{
+		clientInfo:  clientInfo,
+		conf:        initialConf,
+		pod:         pod,
+		networks:    networks,
+		resourceMap: resourceMap,
+	}, nil
+}
+
+func (cg *NetConfGenerator) generate() (*types.NetConf, error) {
+	delegates, err := cg.computeDelegates()
+	if err != nil {
+		return nil, err
+	}
+	cg.conf.Delegates = append(cg.conf.Delegates, delegates...)
+	cg.handleDefaultRoute()
+	return cg.conf, nil
+}
+
+func (cg *NetConfGenerator) computeDelegates() ([]*types.DelegateNetConf, error) {
+	if cg.networks != nil {
+		delegates, err := GetNetworkDelegates(cg.clientInfo, cg.pod, cg.networks, cg.conf, cg.resourceMap)
+		if err != nil {
+			if _, ok := err.(*NoK8sNetworkError); ok {
+				return nil, nil
+			}
+			return nil, logging.Errorf("TryLoadPodDelegates: error in getting k8s network for pod: %v", err)
+		}
+
+		return delegates, nil
+	}
+
+	return nil, nil
+}
+
+func (cg *NetConfGenerator) handleDefaultRoute() {
+	// Check gatewayRequest is configured in delegates
+	// and mark its config if gateway filter is required
+	isGatewayConfigured := false
+	for _, delegate := range cg.conf.Delegates {
+		if delegate.GatewayRequest != nil {
+			isGatewayConfigured = true
+			break
+		}
+	}
+
+	if isGatewayConfigured == true {
+		types.CheckGatewayConfig(cg.conf.Delegates)
+	}
+}

--- a/pkg/k8sclient/netconfgen_test.go
+++ b/pkg/k8sclient/netconfgen_test.go
@@ -1,0 +1,284 @@
+package k8sclient
+
+import (
+	"fmt"
+	"io/ioutil"
+	v1 "k8s.io/api/core/v1"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+
+	testutils "gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/testing"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/types"
+)
+
+func TestNetconfGenerator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "k8sclient")
+}
+
+var _ = Describe("Test NetconfGeneration operations", func() {
+	var clientInfo *ClientInfo
+	var tmpDir string
+	var args *skel.CmdArgs
+	var k8sArgs *types.K8sArgs
+	var pod *v1.Pod
+	var podNetworks []*types.NetworkSelectionElement
+
+	const fakePodName = "testPod"
+	const newNetSpec = `
+{
+    "cniVersion": "0.3.1",
+    "plugins": [
+        {
+            "type": "macvlan",
+            "capabilities": { "ips": true },
+            "master": "eth1",
+            "mode": "bridge",
+            "ipam": { "type": "static"}
+        }, {
+            "type": "tuning"
+        }
+    ]
+}`
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = ioutil.TempDir("", "multus_tmp")
+		Expect(err).NotTo(HaveOccurred())
+
+		args = &skel.CmdArgs{
+			// Values come from NewFakePod()
+			Args: fmt.Sprintf("K8S_POD_NAME=%s;K8S_POD_NAMESPACE=%s;K8S_POD_UID=%s", fakePodName, "test", "testUID"),
+		}
+	})
+
+	BeforeEach(func() {
+		clientInfo = NewFakeClientInfo()
+		_, err := clientInfo.AddNetAttachDef(testutils.NewFakeNetAttachDef("test", "newnet", newNetSpec))
+		Expect(err).NotTo(HaveOccurred())
+
+		k8sArgs, err = GetK8sArgs(args)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	Context("focusing on the CNCF *network* annotation list - i.e. for hot-plugging new interfaces", func() {
+		When("a pod's annotation's list is empty", func() {
+			BeforeEach(func() {
+				fakePod := testutils.NewFakePod(fakePodName, "", "")
+				_, err := clientInfo.AddPod(fakePod)
+				Expect(err).NotTo(HaveOccurred())
+
+				pod, err = clientInfo.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
+				Expect(err).NotTo(HaveOccurred())
+				podNetworks, err = GetPodNetwork(pod)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("the netconfig generator cannot create a delegate", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet", "pluggediface1"))
+				Expect(err).To(MatchError(&NoK8sNetworkError{message: "could not find pod network matching the provided predicate"}))
+				Expect(networks).To(BeNil())
+			})
+		})
+
+		When("a pod's annotation's list features an element", func() {
+			BeforeEach(func() {
+				podsNetworks := `[{ "name": "newnet", "ips": [ "10.10.10.10/24" ], "interface": "pluggediface1", "namespace": "default" }]`
+				fakePod := testutils.NewFakePod(fakePodName, podsNetworks, "")
+				_, err := clientInfo.AddPod(fakePod)
+				Expect(err).NotTo(HaveOccurred())
+
+				pod, err = clientInfo.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
+				Expect(err).NotTo(HaveOccurred())
+				podNetworks, err = GetPodNetwork(pod)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("the netconfig generator finds a NetworkSelectionElement when the correct network + iface name are requested", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet", "pluggediface1"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(networks).To(Equal(&types.NetworkSelectionElement{
+					Name:             "newnet",
+					Namespace:        "default",
+					IPRequest:        []string{"10.10.10.10/24"},
+					InterfaceRequest: "pluggediface1",
+				}))
+			})
+
+			It("the netconfig generator does not find a NetworkSelectionElement when the wrong *interface* name is requested", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet", "pluggediface2"))
+				Expect(err).To(MatchError(&NoK8sNetworkError{message: "could not find pod network matching the provided predicate"}))
+				Expect(networks).To(BeNil())
+			})
+
+			It("the netconfig generator does not find a NetworkSelectionElement when the wrong *network* name is requested", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet2", "pluggediface1"))
+				Expect(err).To(MatchError(&NoK8sNetworkError{message: "could not find pod network matching the provided predicate"}))
+				Expect(networks).To(BeNil())
+			})
+		})
+
+		When("a pod's annotation's list features multiple elements", func() {
+			BeforeEach(func() {
+				podsNetworks := `[
+{ "name": "macvlan1-config", "ips": [ "10.1.1.11/24" ] },
+{ "name": "newnet", "ips": [ "10.10.10.10/24" ], "interface": "pluggediface1", "namespace": "default" },
+{ "name": "newnet", "ips": [ "10.10.10.11/24" ], "interface": "pluggediface2", "namespace": "default" }]`
+				fakePod := testutils.NewFakePod(fakePodName, podsNetworks, "")
+				_, err := clientInfo.AddPod(fakePod)
+				Expect(err).NotTo(HaveOccurred())
+
+				pod, err = clientInfo.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
+				Expect(err).NotTo(HaveOccurred())
+				podNetworks, err = GetPodNetwork(pod)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("filters the *first* network + interface pair", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet", "pluggediface1"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(networks).To(Equal(
+					&types.NetworkSelectionElement{
+						Name:             "newnet",
+						Namespace:        "default",
+						IPRequest:        []string{"10.10.10.10/24"},
+						InterfaceRequest: "pluggediface1",
+					}))
+			})
+
+			It("filters the *second* network + interface pair", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet", "pluggediface2"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(networks).To(Equal(
+					&types.NetworkSelectionElement{
+						Name:             "newnet",
+						Namespace:        "default",
+						IPRequest:        []string{"10.10.10.11/24"},
+						InterfaceRequest: "pluggediface2",
+					}))
+			})
+		})
+	})
+
+	Context("focusing on the CNCF network *status* annotation list - i.e. for hot-unplugging existing interfaces", func() {
+		const (
+			netName = "newnet"
+			nsName  = "ns1"
+		)
+
+		When("a pod's annotation's list is empty", func() {
+			BeforeEach(func() {
+				fakePod := testutils.NewFakePod(fakePodName, "", "")
+				_, err := clientInfo.AddPod(fakePod)
+				Expect(err).NotTo(HaveOccurred())
+
+				pod, err = clientInfo.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		When("a pod's annotation's list features an element", func() {
+			BeforeEach(func() {
+				fakePod := testutils.NewFakePod(fakePodName, "", "")
+				netStatus := netv1.NetworkStatus{
+					Name:      networkName(nsName, netName),
+					Interface: "pluggediface1",
+					IPs:       []string{"10.10.10.10/24"},
+				}
+				Expect(testutils.WithNetworkStatusAnnotation(netStatus)(fakePod)).To(Succeed())
+				_, err := clientInfo.AddPod(fakePod)
+				Expect(err).NotTo(HaveOccurred())
+
+				pod, err = clientInfo.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
+				Expect(err).NotTo(HaveOccurred())
+				podNetworks, err = GetPodNetworkFromStatus(pod)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("the netconfig generator finds a NetworkSelectionElement when the correct network + iface name are requested", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet", "pluggediface1"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(networks).To(Equal(&types.NetworkSelectionElement{
+					Name:             netName,
+					Namespace:        nsName,
+					IPRequest:        []string{"10.10.10.10/24"},
+					InterfaceRequest: "pluggediface1",
+				}))
+			})
+
+			It("the netconfig generator does not find a NetworkSelectionElement when the wrong *interface* name is requested", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet", "pluggediface2"))
+				Expect(err).To(MatchError(&NoK8sNetworkError{message: "could not find pod network matching the provided predicate"}))
+				Expect(networks).To(BeNil())
+			})
+
+			It("the netconfig generator does not find a NetworkSelectionElement when the wrong *network* name is requested", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet2", "pluggediface1"))
+				Expect(err).To(MatchError(&NoK8sNetworkError{message: "could not find pod network matching the provided predicate"}))
+				Expect(networks).To(BeNil())
+			})
+		})
+
+		When("a pod's annotation's list features multiple elements", func() {
+			BeforeEach(func() {
+				iface1NetStatus := netv1.NetworkStatus{
+					Name:      networkName(nsName, netName),
+					Interface: "pluggediface1",
+					IPs:       []string{"10.10.10.10/24"},
+				}
+				iface2NetStatus := netv1.NetworkStatus{
+					Name:      networkName(nsName, netName),
+					Interface: "pluggediface2",
+					IPs:       []string{"10.10.10.11/24"},
+				}
+				fakePod := testutils.NewFakePod(fakePodName, "", "")
+				Expect(testutils.WithNetworkStatusAnnotation(iface1NetStatus, iface2NetStatus)(fakePod)).To(Succeed())
+				_, err := clientInfo.AddPod(fakePod)
+				Expect(err).NotTo(HaveOccurred())
+
+				pod, err = clientInfo.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
+				Expect(err).NotTo(HaveOccurred())
+				podNetworks, err = GetPodNetworkFromStatus(pod)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("filters the *first* network + interface pair", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet", "pluggediface1"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(networks).To(Equal(
+					&types.NetworkSelectionElement{
+						Name:             netName,
+						Namespace:        nsName,
+						IPRequest:        []string{"10.10.10.10/24"},
+						InterfaceRequest: "pluggediface1",
+					}))
+			})
+
+			It("filters the *second* network + interface pair", func() {
+				networks, err := FilterNetwork(podNetworks, filterNetworkByNetAndIfaceName("newnet", "pluggediface2"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(networks).To(Equal(
+					&types.NetworkSelectionElement{
+						Name:             netName,
+						Namespace:        nsName,
+						IPRequest:        []string{"10.10.10.11/24"},
+						InterfaceRequest: "pluggediface2",
+					}))
+			})
+		})
+	})
+})
+
+func networkName(namespace string, networkName string) string {
+	return fmt.Sprintf("%s/%s", namespace, networkName)
+}

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -106,6 +106,19 @@ func NewFakePod(name string, netAnnotation string, defaultNetAnnotation string) 
 	return pod
 }
 
+// WithNetworkStatusAnnotation annotates a pod with the supplied CNCF
+// `network-status`.
+func WithNetworkStatusAnnotation(status ...netv1.NetworkStatus) func(pod *v1.Pod) error {
+	return func(pod *v1.Pod) error {
+		statusBytes, err := json.Marshal(&status)
+		if err != nil {
+			return err
+		}
+		pod.Annotations["k8s.v1.cni.cncf.io/network-status"] = string(statusBytes)
+		return nil
+	}
+}
+
 // EnsureCIDR parses/verify CIDR ip string and convert to net.IPNet
 func EnsureCIDR(cidr string) *net.IPNet {
 	ip, net, err := net.ParseCIDR(cidr)

--- a/pkg/types/extractors.go
+++ b/pkg/types/extractors.go
@@ -1,0 +1,128 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/logging"
+	"net"
+	"regexp"
+	"strings"
+)
+
+// ParsePodNetworkAnnotation returns a list of *NetworkSelectionElement
+func ParsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*NetworkSelectionElement, error) {
+	var networks []*NetworkSelectionElement
+
+	logging.Debugf("ParsePodNetworkAnnotation: %s, %s", podNetworks, defaultNamespace)
+	if podNetworks == "" {
+		return nil, logging.Errorf("ParsePodNetworkAnnotation: pod annotation does not have \"network\" as key")
+	}
+
+	if strings.IndexAny(podNetworks, "[{\"") >= 0 {
+		if err := json.Unmarshal([]byte(podNetworks), &networks); err != nil {
+			return nil, logging.Errorf("ParsePodNetworkAnnotation: failed to parse pod Network Attachment Selection Annotation JSON format: %v", err)
+		}
+		for i, network := range networks {
+			split := strings.Split(network.Name, "/")
+			if len(split) > 1 {
+				networks[i].Namespace = split[0]
+				networks[i].Name = split[1]
+			}
+		}
+	} else {
+		// Comma-delimited list of network attachment object names
+		for _, item := range strings.Split(podNetworks, ",") {
+			// Remove leading and trailing whitespace.
+			item = strings.TrimSpace(item)
+
+			// Parse network name (i.e. <namespace>/<network name>@<ifname>)
+			netNsName, networkName, netIfName, err := parsePodNetworkObjectName(item)
+			if err != nil {
+				return nil, logging.Errorf("ParsePodNetworkAnnotation: %v", err)
+			}
+
+			networks = append(networks, &NetworkSelectionElement{
+				Name:             networkName,
+				Namespace:        netNsName,
+				InterfaceRequest: netIfName,
+			})
+		}
+	}
+
+	for _, n := range networks {
+		if n.Namespace == "" {
+			n.Namespace = defaultNamespace
+		}
+		if n.MacRequest != "" {
+			// validate MAC address
+			if _, err := net.ParseMAC(n.MacRequest); err != nil {
+				return nil, logging.Errorf("ParsePodNetworkAnnotation: failed to mac: %v", err)
+			}
+		}
+		if n.InfinibandGUIDRequest != "" {
+			// validate GUID address
+			if _, err := net.ParseMAC(n.InfinibandGUIDRequest); err != nil {
+				return nil, logging.Errorf("ParsePodNetworkAnnotation: failed to validate infiniband GUID: %v", err)
+			}
+		}
+		if n.IPRequest != nil {
+			for _, ip := range n.IPRequest {
+				// validate IP address
+				if strings.Contains(ip, "/") {
+					if _, _, err := net.ParseCIDR(ip); err != nil {
+						return nil, logging.Errorf("failed to parse CIDR %q: %v", ip, err)
+					}
+				} else if net.ParseIP(ip) == nil {
+					return nil, logging.Errorf("failed to parse IP address %q", ip)
+				}
+			}
+		}
+		// compatibility pre v3.2, will be removed in v4.0
+		if n.DeprecatedInterfaceRequest != "" && n.InterfaceRequest == "" {
+			n.InterfaceRequest = n.DeprecatedInterfaceRequest
+		}
+	}
+
+	return networks, nil
+}
+
+func parsePodNetworkObjectName(podnetwork string) (string, string, string, error) {
+	var netNsName string
+	var netIfName string
+	var networkName string
+
+	logging.Debugf("parsePodNetworkObjectName: %s", podnetwork)
+	slashItems := strings.Split(podnetwork, "/")
+	if len(slashItems) == 2 {
+		netNsName = strings.TrimSpace(slashItems[0])
+		networkName = slashItems[1]
+	} else if len(slashItems) == 1 {
+		networkName = slashItems[0]
+	} else {
+		return "", "", "", logging.Errorf("parsePodNetworkObjectName: Invalid network object (failed at '/')")
+	}
+
+	atItems := strings.Split(networkName, "@")
+	networkName = strings.TrimSpace(atItems[0])
+	if len(atItems) == 2 {
+		netIfName = strings.TrimSpace(atItems[1])
+	} else if len(atItems) != 1 {
+		return "", "", "", logging.Errorf("parsePodNetworkObjectName: Invalid network object (failed at '@')")
+	}
+
+	// Check and see if each item matches the specification for valid attachment name.
+	// "Valid attachment names must be comprised of units of the DNS-1123 label format"
+	// [a-z0-9]([-a-z0-9]*[a-z0-9])?
+	// And we allow at (@), and forward slash (/) (units separated by commas)
+	// It must start and end alphanumerically.
+	allItems := []string{netNsName, networkName, netIfName}
+	for i := range allItems {
+		matched, _ := regexp.MatchString("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", allItems[i])
+		if !matched && len([]rune(allItems[i])) > 0 {
+			return "", "", "", logging.Errorf(fmt.Sprintf("parsePodNetworkObjectName: Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'", allItems[i]))
+		}
+	}
+
+	logging.Debugf("parsePodNetworkObjectName: parsed: %s, %s, %s", netNsName, networkName, netIfName)
+	return netNsName, networkName, netIfName, nil
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -158,6 +158,13 @@ type K8sArgs struct {
 	K8S_POD_NAMESPACE          types.UnmarshallableString //revive:disable-line
 	K8S_POD_INFRA_CONTAINER_ID types.UnmarshallableString //revive:disable-line
 	K8S_POD_UID                types.UnmarshallableString //revive:disable-line
+	K8S_POD_NETWORK            types.UnmarshallableString //revive:disable-line
+}
+
+// IsMutatingRunningPod indicates if Multus is supposed to add / remove an
+// interface to / from a running pod.
+func (k *K8sArgs) IsMutatingRunningPod() bool {
+	return k.K8S_POD_NETWORK != ""
 }
 
 // ResourceInfo is struct to hold Pod device allocation information

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -167,6 +167,12 @@ func (k *K8sArgs) IsMutatingRunningPod() bool {
 	return k.K8S_POD_NETWORK != ""
 }
 
+// NetworkToAddOrRemove returns the name of the network for which an interface
+// will be created and added to the pod, or removed from it.
+func (k *K8sArgs) NetworkToAddOrRemove() string {
+	return string(k.K8S_POD_NETWORK)
+}
+
 // ResourceInfo is struct to hold Pod device allocation information
 type ResourceInfo struct {
 	Index     int

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,98 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, false)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, true)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, pending bool, focused bool) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	if pending {
+		ginkgo.PDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else if focused {
+		ginkgo.FDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else {
+		ginkgo.Describe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	}
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,78 @@
+package table
+
+import (
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description string
+	Parameters  []interface{}
+	Pending     bool
+	Focused     bool
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	if t.Pending {
+		ginkgo.PIt(t.Description)
+		return
+	}
+
+	values := make([]reflect.Value, len(t.Parameters))
+	iBodyType := itBody.Type()
+	for i, param := range t.Parameters {
+		if param == nil {
+			inType := iBodyType.In(i)
+			values[i] = reflect.Zero(inType)
+		} else {
+			values[i] = reflect.ValueOf(param)
+		}
+	}
+
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		ginkgo.FIt(t.Description, body)
+	} else {
+		ginkgo.It(t.Description, body)
+	}
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, false}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, true}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}


### PR DESCRIPTION
This PR will grant multus the ability to process a **single**
network/interface pair when a CNI `ADD` / `DELETE` is processed.

This is a first required step to add / remove network interfaces to / from
running PODs.

Multus will differentiate which operation to perform based on the
presence of the `K8S_POD_NETWORK` entry in the `k8sArgs`
args structure: when **it is present**, we will consider load the 
corresponding delegate and add (or remove ...) that secondary 
network interface.

This new entry will be in the `<network name>` format (since the
k8sArgs structure already features an entry for the namespace).
