### PR TITLE
CI, e2e tests: fix legacy

### DIFF
--- a/.github/workflows/legacy-kind-e2e.yml
+++ b/.github/workflows/legacy-kind-e2e.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Setup cluster
         working-directory: ./e2e
-        run: ./setup_cluster.sh
+        run: MULTUS_MANIFEST=legacy-multus-daemonset.yml ./setup_cluster.sh
 
       - name: Test simple pod
         working-directory: ./e2e

--- a/e2e/legacy-multus-daemonset.yml
+++ b/e2e/legacy-multus-daemonset.yml
@@ -182,41 +182,6 @@ spec:
           - name: cnibin
             mountPath: /host/opt/cni/bin
             mountPropagation: Bidirectional
-      - name: generate-kubeconfig
-        image: localhost:5000/multus:e2e
-        command:
-          - "/usr/src/multus-cni/bin/generate-kubeconfig"
-        args:
-          - "-k8s-service-host=$(KUBERNETES_SERVICE_HOST)"
-          - "-k8s-service-port=$(KUBERNETES_SERVICE_PORT)"
-        resources:
-          requests:
-            cpu: "10m"
-            memory: "15Mi"
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - name: cni
-            mountPath: /host/etc/cni/net.d
-            mountPropagation: Bidirectional
-      - name: generate-multus-config
-        image: localhost:5000/multus:e2e
-        command:
-          - "/usr/src/multus-cni/bin/generate-multus-cni-config"
-        args:
-          - "-cni-version=0.3.1"
-          - "-cni-config-dir=/host/etc/cni/net.d"
-          - "-multus-autoconfig-dir=/host/etc/cni/net.d"
-        resources:
-          requests:
-            cpu: "10m"
-            memory: "15Mi"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: cni
-          mountPath: /host/etc/cni/net.d
-          mountPropagation: Bidirectional
       volumes:
         - name: cni
           hostPath:

--- a/e2e/setup_cluster.sh
+++ b/e2e/setup_cluster.sh
@@ -7,6 +7,11 @@ export PATH=${PATH}:./bin
 # Defaults to `docker`.
 OCI_BIN="${OCI_BIN:-docker}"
 
+# define the deployment spec to use when deploying multus.
+# Acceptable values are `legacy-multus-daemonset.yml`. `multus-daemonset.yml`.
+# Defaults to `multus-daemonset.yml`.
+MULTUS_MANIFEST="${MULTUS_MANIFEST:-multus-daemonset.yml}"
+
 kind_network='kind'
 reg_name='kind-registry'
 reg_port='5000'
@@ -67,7 +72,7 @@ kind export kubeconfig
 sudo env PATH=${PATH} koko -p "$worker1_pid,eth1" -p "$worker2_pid,eth1"
 sleep 1
 kubectl -n kube-system wait --for=condition=available deploy/coredns --timeout=300s
-kubectl create -f multus-daemonset.yml
+kubectl create -f "$MULTUS_MANIFEST"
 sleep 1
 kubectl -n kube-system wait --for=condition=ready -l name=multus pod --timeout=300s
 kubectl create -f cni-install.yml


### PR DESCRIPTION
Our CI is currently mistakenly executing the thick img on the e2e
legacy lanes. Furthermore, the e2e daemonset spec provided features
(and uses) the kubeconfig / multus conf generation binaries
provided only on the thick image.

This commit addresses these by enabling the e2e `setup_cluster.sh`
script user to specify the path to the desired deployment
configuration.

Github workflows are updated accordingly.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>