### PR TITLE
check version incompatibility

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -139,10 +139,14 @@ func main() {
 			configurationOptions = append(
 				configurationOptions, config.WithReadinessFileIndicator(*readinessIndicator))
 		}
-		multusConfig := config.NewMultusConfig(multusPluginName, *cniVersion, *multusKubeconfig, configurationOptions...)
+
+		multusConfig, err := config.NewMultusConfig(multusPluginName, *cniVersion, *multusKubeconfig, configurationOptions...)
+		if err != nil {
+			_ = logging.Errorf("Failed to create multus config: %v", err)
+			os.Exit(3)
+		}
 
 		var configManager *config.Manager
-		var err error
 		if *multusMasterCni == "" {
 			configManager, err = config.NewManager(*multusConfig, *multusAutoconfigDir)
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gopkg.in/k8snetworkplumbingwg/multus-cni.v3
 go 1.16
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/fsnotify/fsnotify v1.4.9

--- a/pkg/config/generator_test.go
+++ b/pkg/config/generator_test.go
@@ -238,6 +238,22 @@ func invalidDelegateCNIVersion(delegateCNIVersion, multusCNIVersion string) erro
 	return fmt.Errorf("delegate cni version is %s while top level cni version is %s", delegateCNIVersion, multusCNIVersion)
 }
 
+func TestVersionIncompatibility(t *testing.T) {
+	const delegateCNIVersion = "0.3.0"
+
+	primaryCNIConfigOld := primaryCNIConfig
+	tmpVer := primaryCNIConfig["cniVersion"]
+	primaryCNIConfig["cniVersion"] = delegateCNIVersion
+	_, err := newMultusConfigWithDelegates(
+		primaryCNIName,
+		cniVersion,
+		kubeconfig,
+		primaryCNIConfigOld)
+	primaryCNIConfig["cniVersion"] = tmpVer
+
+	assertError(t, invalidDelegateCNIVersion(delegateCNIVersion, cniVersion), err)
+}
+
 func TestMultusConfigWithOverriddenName(t *testing.T) {
 	newNetworkName := "mega-net-2000"
 	multusConfig, _ := newMultusConfigWithDelegates(

--- a/pkg/config/generator_test.go
+++ b/pkg/config/generator_test.go
@@ -45,46 +45,51 @@ var primaryCNIConfig = map[string]interface{}{
 	"logfile-maxage":     5,
 }
 
-func newMultusConfigWithDelegates(pluginName string, cniVersion string, kubeconfig string, primaryCNIPluginConfig interface{}, configOptions ...Option) *MultusConf {
-	multusConfig := NewMultusConfig(pluginName, cniVersion, kubeconfig, configOptions...)
-	multusConfig.Delegates = []interface{}{primaryCNIPluginConfig}
-	return multusConfig
+func newMultusConfigWithDelegates(pluginName string, cniVersion string, kubeconfig string, primaryCNIPluginConfig interface{}, configOptions ...Option) (*MultusConf, error) {
+	multusConfig, err := NewMultusConfig(pluginName, cniVersion, kubeconfig, configOptions...)
+	if err != nil {
+		return multusConfig, err
+	}
+	return multusConfig, multusConfig.Mutate(withDelegates(primaryCNIPluginConfig.(map[string]interface{})))
 }
 
 func TestBasicMultusConfig(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig)
+	assertError(t, err, nil)
 	expectedResult := "{\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithNamespaceIsolation(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig,
 		WithNamespaceIsolation())
+	assertError(t, err, nil)
 	expectedResult := "{\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"namespaceIsolation\":true,\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithReadinessIndicator(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig,
 		WithReadinessFileIndicator("/a/b/u/it-lives"))
+	assertError(t, err, nil)
 	expectedResult := "{\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"readinessindicatorfile\":\"/a/b/u/it-lives\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithLoggingConfiguration(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
@@ -92,96 +97,104 @@ func TestMultusConfigWithLoggingConfiguration(t *testing.T) {
 		WithLogLevel("notice"),
 		WithLogToStdErr(),
 		WithLogFile("/u/y/w/log.1"))
+	assertError(t, err, nil)
 	expectedResult := "{\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"logFile\":\"/u/y/w/log.1\",\"logLevel\":\"notice\",\"logToStderr\":true,\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithGlobalNamespace(t *testing.T) {
 	const globalNamespace = "come-along-ns"
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig,
 		WithGlobalNamespaces(globalNamespace))
+	assertError(t, err, nil)
 	expectedResult := "{\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"globalNamespaces\":\"come-along-ns\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithAdditionalBinDir(t *testing.T) {
 	const anotherCNIBinDir = "a-dir-somewhere"
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig,
 		WithAdditionalBinaryFileDir(anotherCNIBinDir))
+	assertError(t, err, nil)
 	expectedResult := "{\"binDir\":\"a-dir-somewhere\",\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithCapabilities(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig,
 		withCapabilities(
 			documentHelper(`{"capabilities": {"portMappings": true}}`)))
+	assertError(t, err, nil)
 	expectedResult := "{\"capabilities\":{\"portMappings\":true},\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithMultipleCapabilities(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig,
 		withCapabilities(
 			documentHelper(`{"capabilities": {"portMappings": true, "tuning": true}}`)))
+	assertError(t, err, nil)
 	expectedResult := "{\"capabilities\":{\"portMappings\":true,\"tuning\":true},\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithMultipleCapabilitiesFilterOnlyEnabled(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig,
 		withCapabilities(
 			documentHelper(`{"capabilities": {"portMappings": true, "tuning": false}}`)))
+	assertError(t, err, nil)
 	expectedResult := "{\"capabilities\":{\"portMappings\":true},\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithMultipleCapabilitiesDefinedOnAPlugin(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig,
 		withCapabilities(
 			documentHelper(`{"plugins": [ {"capabilities": {"portMappings": true, "tuning": true}} ] }`)))
+	assertError(t, err, nil)
 	expectedResult := "{\"capabilities\":{\"portMappings\":true,\"tuning\":true},\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithCapabilitiesDefinedOnMultiplePlugins(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
 		primaryCNIConfig,
 		withCapabilities(
 			documentHelper(`{"plugins": [ {"capabilities": { "portMappings": true }}, {"capabilities": { "tuning": true }} ]}`)))
+	assertError(t, err, nil)
 	expectedResult := "{\"capabilities\":{\"portMappings\":true,\"tuning\":true},\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
 func TestMultusConfigWithCapabilitiesDefinedOnMultiplePluginsFilterOnlyEnabled(t *testing.T) {
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, err := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,
@@ -202,13 +215,32 @@ func TestMultusConfigWithCapabilitiesDefinedOnMultiplePluginsFilterOnlyEnabled(t
         }
     ]
 }`)))
+	assertError(t, err, nil)
 	expectedResult := "{\"capabilities\":{\"portMappings\":true},\"cniVersion\":\"0.4.0\",\"delegates\":[{\"cniVersion\":\"1.0.0\",\"dns\":\"{}\",\"ipam\":\"{}\",\"logFile\":\"/var/log/ovn-kubernetes/ovn-k8s-cni-overlay.log\",\"logLevel\":\"5\",\"logfile-maxage\":5,\"logfile-maxbackups\":5,\"logfile-maxsize\":100,\"name\":\"ovn-kubernetes\",\"type\":\"ovn-k8s-cni-overlay\"}],\"kubeconfig\":\"/a/b/c/kubeconfig.kubeconfig\",\"name\":\"multus-cni-network\",\"type\":\"myCNI\"}"
 	newTestCase(t, multusConfig.Generate).assertResult(expectedResult)
 }
 
+func assertError(t *testing.T, actual error, expected error) {
+	if actual != nil && expected != nil {
+		if actual.Error() != expected.Error() {
+			t.Fatalf("multus config generation failed.\nExpected:\n%v\nbut GOT:\n%v", expected.Error(), actual.Error())
+		}
+	}
+
+	if actual == nil && expected != nil {
+		t.Fatalf("multus config generation failed.\nExpected:\n%v\nbut didn't get error", expected.Error())
+	} else if actual != nil && expected == nil {
+		t.Fatalf("multus config generation failed.\nDidn't expect error\nbut GOT: %v\n", actual.Error())
+	}
+}
+
+func invalidDelegateCNIVersion(delegateCNIVersion, multusCNIVersion string) error {
+	return fmt.Errorf("delegate cni version is %s while top level cni version is %s", delegateCNIVersion, multusCNIVersion)
+}
+
 func TestMultusConfigWithOverriddenName(t *testing.T) {
 	newNetworkName := "mega-net-2000"
-	multusConfig := newMultusConfigWithDelegates(
+	multusConfig, _ := newMultusConfigWithDelegates(
 		primaryCNIName,
 		cniVersion,
 		kubeconfig,

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -78,8 +78,9 @@ func newManager(config MultusConf, multusConfigDir string, defaultCNIPluginName 
 	}
 
 	if err := configManager.loadPrimaryCNIConfigFromFile(); err != nil {
-		return nil, fmt.Errorf("failed to load the primary CNI configuration as a multus delegate")
+		return nil, fmt.Errorf("failed to load the primary CNI configuration as a multus delegate with error '%v'", err)
 	}
+
 	return configManager, nil
 }
 
@@ -88,8 +89,7 @@ func (m *Manager) loadPrimaryCNIConfigFromFile() error {
 	if err != nil {
 		return logging.Errorf("failed to access the primary CNI configuration from %s: %v", m.primaryCNIConfigPath, err)
 	}
-	m.loadPrimaryCNIConfigurationData(primaryCNIConfigData)
-	return nil
+	return m.loadPrimaryCNIConfigurationData(primaryCNIConfigData)
 }
 
 // OverrideNetworkName overrides the name of the multus configuration with the
@@ -104,15 +104,14 @@ func (m *Manager) OverrideNetworkName() error {
 	if networkName == "" {
 		return fmt.Errorf("the primary CNI Configuration does not feature the network name: %v", m.cniConfigData)
 	}
-	m.multusConfig.Mutate(WithOverriddenName(networkName))
-	return nil
+	return m.multusConfig.Mutate(WithOverriddenName(networkName))
 }
 
-func (m *Manager) loadPrimaryCNIConfigurationData(primaryCNIConfigData interface{}) {
+func (m *Manager) loadPrimaryCNIConfigurationData(primaryCNIConfigData interface{}) error {
 	cniConfigData := primaryCNIConfigData.(map[string]interface{})
 
 	m.cniConfigData = cniConfigData
-	m.multusConfig.Mutate(
+	return m.multusConfig.Mutate(
 		withDelegates(cniConfigData),
 		withCapabilities(cniConfigData))
 }

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -61,7 +61,7 @@ var _ = Describe(suiteName, func() {
 		defaultCniConfig = fmt.Sprintf("%s/%s", multusConfigDir, primaryCNIPluginName)
 		Expect(ioutil.WriteFile(defaultCniConfig, []byte(primaryCNIPluginTemplate), userRWPermission)).To(Succeed())
 
-		multusConf := NewMultusConfig(
+		multusConf, _ := NewMultusConfig(
 			primaryCNIName,
 			cniVersion,
 			kubeconfig)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,6 +4,7 @@ github.com/Microsoft/go-winio/pkg/guid
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
+## explicit
 github.com/blang/semver
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2


### PR DESCRIPTION
When nested CNI version is 0.3.1 or less while the top level CNI version
is 0.4.0, error out. Version 0.3.1 or less doesn't support the CHECK
command. This closes issue #737.