### PR TITLE
Refactor multus as a thick plugin

### DIFF
--- a/cmd/shim/shim.go
+++ b/cmd/shim/shim.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a "Multi-plugin".The delegate concept referred from CNI project
+// It reads other plugin netconf, and then invoke them, e.g.
+// flannel or sriov plugin.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	cniversion "github.com/containernetworking/cni/pkg/version"
+
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/cni"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/multus"
+)
+
+const (
+	defaultMultusRunDir = "/var/run/multus-cni/"
+	socketDirVarName    = "socketDir"
+)
+
+func main() {
+	// Init command line flags to clear vendored packages' one, especially in init()
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	// add version flag
+	versionOpt := false
+	flag.BoolVar(&versionOpt, "version", false, "Show application version")
+	flag.BoolVar(&versionOpt, "v", false, "Show application version")
+
+	runDir := flag.String(socketDirVarName, defaultMultusRunDir, "point to socket")
+	flag.Parse()
+	if versionOpt == true {
+		fmt.Printf("%s\n", multus.PrintVersionString())
+		return
+	}
+
+	p := cni.Plugin{SocketPath: cni.SocketPath(*runDir)}
+	skel.PluginMain(
+		p.CmdAdd,
+		p.CmdCheck,
+		p.CmdDel,
+		cniversion.All, "meta-plugin that delegates to other CNI plugins")
+}

--- a/cmd/shim/shim.go
+++ b/cmd/shim/shim.go
@@ -30,11 +30,6 @@ import (
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/multus"
 )
 
-const (
-	defaultMultusRunDir = "/var/run/multus-cni/"
-	socketDirVarName    = "socketDir"
-)
-
 func main() {
 	// Init command line flags to clear vendored packages' one, especially in init()
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -44,17 +39,21 @@ func main() {
 	flag.BoolVar(&versionOpt, "version", false, "Show application version")
 	flag.BoolVar(&versionOpt, "v", false, "Show application version")
 
-	runDir := flag.String(socketDirVarName, defaultMultusRunDir, "point to socket")
 	flag.Parse()
 	if versionOpt == true {
 		fmt.Printf("%s\n", multus.PrintVersionString())
 		return
 	}
 
-	p := cni.Plugin{SocketPath: cni.SocketPath(*runDir)}
 	skel.PluginMain(
-		p.CmdAdd,
-		p.CmdCheck,
-		p.CmdDel,
+		func(args *skel.CmdArgs) error {
+			return cni.CmdAdd(args)
+		},
+		func(args *skel.CmdArgs) error {
+			return cni.CmdCheck(args)
+		},
+		func(args *skel.CmdArgs) error {
+			return cni.CmdDel(args)
+		},
 		cniversion.All, "meta-plugin that delegates to other CNI plugins")
 }

--- a/deployments/multus-daemonset-thick-plugin.yml
+++ b/deployments/multus-daemonset-thick-plugin.yml
@@ -114,6 +114,7 @@ spec:
         name: multus
     spec:
       hostNetwork: true
+      hostPID: true
       tolerations:
         - operator: Exists
           effect: NoSchedule
@@ -130,6 +131,8 @@ spec:
             - "-multus-autoconfig-dir=/host/etc/cni/net.d"
             - "-multus-log-to-stderr=true"
             - "-multus-log-level=verbose"
+            - "-binDir=/host/opt/cni/bin"
+            - "-cniDir=/host/var/lib/cni/multus"
           resources:
             requests:
               cpu: "100m"
@@ -144,6 +147,11 @@ spec:
               mountPath: /host/etc/cni/net.d
             - name: cnibin
               mountPath: /host/opt/cni/bin
+            - name: host-var-run-multus-cni
+              mountPath: /host/var/run/multus-cni
+            - name: host-var-run-netns
+              mountPath: /var/run/netns
+              mountPropagation: HostToContainer
       initContainers:
         - name: install-multus-binary
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:thick
@@ -178,6 +186,21 @@ spec:
             - name: cni
               mountPath: /host/etc/cni/net.d
               mountPropagation: Bidirectional
+        - name: config-cni-socket-permissions
+            image: ghcr.io/k8snetworkplumbingwg/multus-cni:thick
+            command:
+              - "chmod"
+              - "0700"
+              - "/host/var/run/multus-cni"
+            resources:
+              requests:
+                cpu: "10m"
+                memory: "15Mi"
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - name: host-var-run-multus-cni
+                mountPath: /host/var/run/multus-cni
       terminationGracePeriodSeconds: 10
       volumes:
         - name: cni
@@ -186,4 +209,9 @@ spec:
         - name: cnibin
           hostPath:
             path: /opt/cni/bin
-
+        - name: host-var-run-multus-cni
+          hostPath:
+            path: /var/run/multus-cni
+        - name: host-var-run-netns
+          hostPath:
+            path: /var/run/netns/

--- a/docs/thick-plugin.md
+++ b/docs/thick-plugin.md
@@ -1,0 +1,77 @@
+# Multus Thick plugin
+
+Multus CNI can also be deployed using a thick plugin architecture, which is
+characterized by a client/server architecture.
+
+The client - which will be referred to as "shim" - is a binary executable
+located on the Kubernetes node's file-system that
+[speaks CNI](https://github.com/containernetworking/cni/blob/master/SPEC.md#section-2-execution-protocol):
+the runtime - Kubernetes - passes parameters to the plugin via environment
+variables and configuration - which is passed via stdin.
+The plugin returns a result on stdout on success, or an error on stderr if the
+operation fails. Configuration and results are a JSON encoded string.
+
+Once the shim is invoked by the runtime (Kubernetes) it will contact the
+multus-daemon (server) via a unix domain socket which is bind mounted to the
+host's file-system; the multus-daemon is the one that will do all the
+heavy-pulling: fetch the delegate CNI configuration from the corresponding
+`net-attach-def`, compute the `RuntimeConfig`, and finally, invoke the delegate.
+
+It will then return the result of the operation back to the client.
+
+Please refer to the diagram below for a visual representation of the flow
+described above:
+
+```
+┌─────────┐             ┌───────┐           ┌────────┐             ┌──────────┐
+│         │ cni ADD/DEL │       │ REST POST │        │ cni ADD/DEL │          │
+│ runtime ├────────────►│ shim  │===========│ daemon ├────────────►│ delegate │
+│         │<------------│       │           │        │<------------│          │
+└─────────┘             └───────┘           └────────┘             └──────────┘
+```
+
+## How to use it
+
+### Deployment
+
+There is a dedicated multus daemonset specification for users wanting to use
+this thick plugin variant. This reference deployment spec of multus can be
+deployed by following these commands:
+
+```bash
+kubectl apply -f deployments/multus-daemonset-thick-plugin.yml
+```
+
+### Command line parameters
+
+Multus thick plugin variant accepts the same
+[entrypoint arguments](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#entrypoint-script-parameters)
+its thin counterpart allows - with the following exceptions:
+
+- `skip-multus-binary-copy`
+- `restart-crio`
+- `cleanup-config-on-exit`
+- `rename-conf-file`
+
+It is important to refer that these are command line parameters to the golang
+binary; as such, they should be passed using a single dash ("-") e.g.
+`-additional-bin-dir=/opt/multus/bin`, `-multus-log-level=debug`, etc.
+
+Furthermore, it also accepts a new command line parameter, where the user
+specifies the path to the server configuration:
+
+- `config`: Defaults to `"/etc/cni/net.d/multus.d/daemon-config.json"`
+
+### Server configuration
+
+The server configuration is encoded in JSON, and allows the following keys:
+
+- `"confDir"`: specifies the path to the CNI configuration directory.
+- `"cniDir"`: specifies the path to the multus CNI cache.
+- `"binDir"`: specifies the path to the CNI binary executables.
+- `"logFile"`: specifies where the daemon log file will be persisted.
+- `"logLevel"`: indicates the logging level of the multus daemon. 
+- `"logToStderr"`: Whether or not to also log to stderr. Default to `true`.
+- `"socketDir"`: Specify the location where the unix domain socket used for
+client/server communication will be located. Defaults to `"/var/run/multus-cni/"`.
+

--- a/e2e/multus-daemonset.yml
+++ b/e2e/multus-daemonset.yml
@@ -145,6 +145,7 @@ spec:
         name: multus
     spec:
       hostNetwork: true
+      hostPID: true
       nodeSelector:
         kubernetes.io/arch: amd64
       tolerations:
@@ -164,6 +165,8 @@ spec:
         - "-multus-log-to-stderr=true"
         - "-multus-log-level=debug"
         - "-multus-log-file=/tmp/multus.log"
+        - "-binDir=/host/opt/cni/bin"
+        - "-cniDir=/host/var/lib/cni/multus"
         resources:
           requests:
             cpu: "100m"
@@ -180,12 +183,17 @@ spec:
           mountPath: /host/opt/cni/bin
         - name: multus-cfg
           mountPath: /tmp/multus-conf
+        - name: host-var-run-multus-cni
+          mountPath: /host/var/run/multus-cni
+        - name: host-var-run-netns
+          mountPath: /var/run/netns
+          mountPropagation: HostToContainer
       initContainers:
-      - name: install-multus-binary
+      - name: install-multus-shim
         image: localhost:5000/multus:e2e
         command:
           - "cp"
-          - "/usr/src/multus-cni/bin/multus"
+          - "/usr/src/multus-cni/bin/multus-shim"
           - "/host/opt/cni/bin/multus"
         resources:
           requests:
@@ -214,6 +222,21 @@ spec:
           - name: cni
             mountPath: /host/etc/cni/net.d
             mountPropagation: Bidirectional
+      - name: config-cni-socket-permissions
+        image: localhost:5000/multus:e2e
+        command:
+          - "chmod"
+          - "0700"
+          - "/host/var/run/multus-cni"
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "15Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: host-var-run-multus-cni
+            mountPath: /host/var/run/multus-cni
       volumes:
         - name: cni
           hostPath:
@@ -227,6 +250,12 @@ spec:
             items:
             - key: cni-conf.json
               path: 70-multus.conf
+        - name: host-var-run-multus-cni
+          hostPath:
+            path: /var/run/multus-cni
+        - name: host-var-run-netns
+          hostPath:
+            path: /var/run/netns/
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/e2e/multus-daemonset.yml
+++ b/e2e/multus-daemonset.yml
@@ -122,6 +122,26 @@ data:
       "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
     }
 ---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: multus-daemon-config
+  namespace: kube-system
+  labels:
+    tier: node
+    app: multus
+data:
+  daemon-config.json: |
+    {
+        "confDir": "/host/etc/cni/net.d",
+        "logToStderr": true,
+        "logLevel": "debug",
+        "logFile": "/tmp/multus.log",
+        "binDir": "/host/opt/cni/bin",
+        "cniDir": "/host/var/lib/cni/multus",
+        "socketDir": "/host/var/run/multus-cni/"
+    }
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -162,11 +182,6 @@ spec:
         - "-cni-version=0.3.1"
         - "-cni-config-dir=/host/etc/cni/net.d"
         - "-multus-autoconfig-dir=/host/etc/cni/net.d"
-        - "-multus-log-to-stderr=true"
-        - "-multus-log-level=debug"
-        - "-multus-log-file=/tmp/multus.log"
-        - "-binDir=/host/opt/cni/bin"
-        - "-cniDir=/host/var/lib/cni/multus"
         resources:
           requests:
             cpu: "100m"
@@ -181,13 +196,14 @@ spec:
           mountPath: /host/etc/cni/net.d
         - name: cnibin
           mountPath: /host/opt/cni/bin
-        - name: multus-cfg
-          mountPath: /tmp/multus-conf
         - name: host-var-run-multus-cni
           mountPath: /host/var/run/multus-cni
         - name: host-var-run-netns
           mountPath: /var/run/netns
           mountPropagation: HostToContainer
+        - name: multus-daemon-config
+          mountPath: /etc/cni/net.d/multus.d
+          readOnly: true
       initContainers:
       - name: install-multus-shim
         image: localhost:5000/multus:e2e
@@ -244,12 +260,12 @@ spec:
         - name: cnibin
           hostPath:
             path: /opt/cni/bin
-        - name: multus-cfg
+        - name: multus-daemon-config
           configMap:
-            name: multus-cni-config
+            name: multus-daemon-config
             items:
-            - key: cni-conf.json
-              path: 70-multus.conf
+            - key: daemon-config.json
+              path: daemon-config.json
         - name: host-var-run-multus-cni
           hostPath:
             path: /var/run/multus-cni

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/fsnotify/fsnotify v1.4.9
+	github.com/gorilla/mux v1.8.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.1-0.20210510153419-66a699ae3b05
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/errors v0.9.1
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852
 	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
 	google.golang.org/grpc v1.27.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.20.10

--- a/go.sum
+++ b/go.sum
@@ -310,6 +310,7 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -43,6 +43,7 @@ if [ "$GO111MODULE" == "off" ]; then
 	go build -o ${PWD}/bin/multus -tags no_openssl -ldflags "${LDFLAGS}" "$@" ${REPO_PATH}/cmd
 	go build -o ${PWD}/bin/generate-kubeconfig -tags no_openssl -ldflags "${LDFLAGS}" ${REPO_PATH}/cmd/config-generation
 	go build -o ${PWD}/bin/multus-daemon -tags no_openssl -ldflags "${LDFLAGS}" "$@" ${REPO_PATH}/cmd/controller/
+	go build -o ${PWD}/bin/multus-shim -tags no_openssl -ldflags "${LDFLAGS}" "$@" ${REPO_PATH}/cmd/shim/
 else
 	# build with go modules
 	export GO111MODULE=on
@@ -57,4 +58,6 @@ else
 	go build -o "${DEST_DIR}"/generate-kubeconfig -ldflags "${LDFLAGS}" ./cmd/config-generation
 	echo "Building multus controller"
 	go build -o "${DEST_DIR}"/multus-daemon -ldflags "${LDFLAGS}" ./cmd/controller/
+	echo "Building multus shim"
+	go build -o "${DEST_DIR}"/multus-shim -ldflags "${LDFLAGS}" ./cmd/shim/
 fi

--- a/pkg/cni/server.go
+++ b/pkg/cni/server.go
@@ -1,0 +1,312 @@
+// Copyright (c) 2021 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cni
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	cnicurrent "github.com/containernetworking/cni/pkg/types/current"
+	"github.com/gorilla/mux"
+
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/config"
+	k8s "gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/k8sclient"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/logging"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/multus"
+	multustypes "gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/types"
+)
+
+// HandleCNIRequest is the CNI server handler function; it is invoked whenever
+// a CNI request is processed.
+func HandleCNIRequest(request *PodRequest) ([]byte, error) {
+	var result []byte
+	var err error
+
+	logging.Verbosef("%+v %s starting CNI request %+v", request, request.Command, request)
+	switch request.Command {
+	case "ADD":
+		result, err = request.cmdAdd()
+	case "DEL":
+		err = request.cmdDelete()
+	case "CHECK":
+		err = request.cmdCheck()
+	default:
+	}
+	logging.Verbosef("%s finished CNI request %+v, result: %q, err: %v", request.Command, request, string(result), err)
+	if err != nil {
+		// Prefix errors with request info for easier failure debugging
+		return nil, fmt.Errorf("%+v ERRORED: %v", request, err)
+	}
+	return result, nil
+}
+
+// ServerListener creates a listener to a unix socket located in `socketPath`
+func ServerListener(socketPath string) (net.Listener, error) {
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, logging.Errorf("failed to listen on pod info socket: %v", err)
+	}
+	if err := os.Chmod(socketPath, config.UserRWPermission); err != nil {
+		_ = l.Close()
+		return nil, logging.Errorf("failed to listen on pod info socket: %v", err)
+	}
+	return l, nil
+}
+
+// NewCNIServer creates and returns a new Server object which will listen on a socket in the given path
+func NewCNIServer(rundir string) (*Server, error) {
+	kubeClient, err := k8s.InClusterK8sClient()
+	if err != nil {
+		return nil, fmt.Errorf("error getting k8s client: %v", err)
+	}
+
+	return newCNIServer(rundir, kubeClient, nil)
+}
+
+func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec) (*Server, error) {
+	router := mux.NewRouter()
+	s := &Server{
+		Server: http.Server{
+			Handler: router,
+		},
+		rundir:      rundir,
+		requestFunc: HandleCNIRequest,
+		kubeclient:  kubeClient,
+		exec:        exec,
+	}
+
+	router.NotFoundHandler = http.HandlerFunc(http.NotFound)
+	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		result, err := s.handleCNIRequest(r)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("%v", err), http.StatusBadRequest)
+			return
+		}
+
+		// Empty response JSON means success with no body
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(result); err != nil {
+			_ = logging.Errorf("Error writing HTTP response: %v", err)
+		}
+	}).Methods("POST")
+
+	return s, nil
+}
+
+func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
+	var cr Request
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(b, &cr); err != nil {
+		return nil, err
+	}
+	req, err := cniRequestToPodRequest(&cr, s.kubeclient, s.exec)
+	if err != nil {
+		return nil, err
+	}
+	defer req.cancel()
+
+	result, err := s.requestFunc(req)
+	if err != nil {
+		// Prefix error with request information for easier debugging
+		return nil, fmt.Errorf("%+v %v", req, err)
+	}
+	return result, nil
+}
+
+func cniRequestToPodRequest(cniRequest *Request, kubeclient *k8s.ClientInfo, exec invoke.Exec) (*PodRequest, error) {
+	cmd, ok := cniRequest.Env["CNI_COMMAND"]
+	if !ok {
+		return nil, fmt.Errorf("unexpected or missing CNI_COMMAND")
+	}
+
+	req := &PodRequest{
+		Command:    command(cmd),
+		kubeclient: kubeclient,
+		exec:       exec,
+	}
+
+	req.ContainerID, ok = cniRequest.Env["CNI_CONTAINERID"]
+	if !ok {
+		return nil, fmt.Errorf("missing CNI_CONTAINERID")
+	}
+	req.Netns, ok = cniRequest.Env["CNI_NETNS"]
+	if !ok {
+		return nil, fmt.Errorf("missing CNI_NETNS")
+	}
+
+	req.IfName, ok = cniRequest.Env["CNI_IFNAME"]
+	if !ok {
+		req.IfName = "eth0"
+	}
+
+	cniArgs, err := gatherCNIArgs(cniRequest.Env)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Namespace, ok = cniArgs["K8S_POD_NAMESPACE"]
+	if !ok {
+		return nil, fmt.Errorf("missing K8S_POD_NAMESPACE")
+	}
+
+	req.Name, ok = cniArgs["K8S_POD_NAME"]
+	if !ok {
+		return nil, fmt.Errorf("missing K8S_POD_NAME")
+	}
+
+	req.UID, err = podUID(kubeclient, cniArgs, req.Namespace, req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	req.SandboxID = cniRequest.Env["K8S_POD_INFRA_CONTAINER_ID"]
+
+	conf, err := multustypes.LoadNetConf(cniRequest.Config)
+	if err != nil {
+		return nil, fmt.Errorf("broken stdin args")
+	}
+
+	req.CNIConf = conf
+	req.timestamp = time.Now()
+	req.ctx, req.cancel = context.WithTimeout(context.Background(), time.Minute)
+	return req, nil
+}
+
+func gatherCNIArgs(env map[string]string) (map[string]string, error) {
+	cniArgs, ok := env["CNI_ARGS"]
+	if !ok {
+		return nil, fmt.Errorf("missing CNI_ARGS: '%s'", env)
+	}
+
+	mapArgs := make(map[string]string)
+	for _, arg := range strings.Split(cniArgs, ";") {
+		parts := strings.Split(arg, "=")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid CNI_ARG '%s'", arg)
+		}
+		mapArgs[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+	return mapArgs, nil
+}
+func podUID(kubeclient *k8s.ClientInfo, cniArgs map[string]string, podNamespace, podName string) (string, error) {
+	// UID may not be passed by all runtimes yet. Will be passed
+	// by CRIO 1.20+ and containerd 1.5+ soon.
+	// CRIO 1.20: https://github.com/cri-o/cri-o/pull/5029
+	// CRIO 1.21: https://github.com/cri-o/cri-o/pull/5028
+	// CRIO 1.22: https://github.com/cri-o/cri-o/pull/5026
+	// containerd 1.6: https://github.com/containerd/containerd/pull/5640
+	// containerd 1.5: https://github.com/containerd/containerd/pull/5643
+	uid, found := cniArgs["K8S_POD_UID"]
+	if !found {
+		pod, err := kubeclient.GetPod(podNamespace, podName)
+		if err != nil {
+			return "", fmt.Errorf("missing pod UID; attempted to recover it from the K8s API, but failed: %w", err)
+		}
+		return string(pod.UID), nil
+	}
+
+	return uid, nil
+}
+
+func (pr *PodRequest) cmdAdd() ([]byte, error) {
+	namespace := pr.Namespace
+	podName := pr.Name
+	if namespace == "" || podName == "" {
+		return nil, fmt.Errorf("required CNI variable missing")
+	}
+
+	pod, err := multus.GetPod(pr.kubeclient, pr.Namespace, pr.Name, pr.UID, false)
+	if err != nil {
+		return nil, fmt.Errorf("error getting pod [%s/%s]: %v", pr.Namespace, pr.Name, err)
+	}
+
+	result, err := multus.NewMultusCmd(
+		pr.ContainerID,
+		pr.SandboxID,
+		pr.IfName,
+		pr.Netns,
+		pr.Name,
+		pr.Namespace,
+		pr.UID,
+	).Add(pr.CNIConf, pod, pr.exec, pr.kubeclient)
+	if err != nil {
+		return nil, fmt.Errorf("error configuring pod [%s/%s] networking: %v", pr.Namespace, pr.Name, err)
+	}
+	return serializeResult(result)
+}
+
+func (pr *PodRequest) cmdDelete() error {
+	logging.Debugf("CmdDel: %+v", *pr.CNIConf)
+
+	pod, err := multus.GetPod(pr.kubeclient, pr.Namespace, pr.Name, pr.UID, true)
+	if err != nil {
+		return fmt.Errorf("error getting pod [%s/%s]: %v", pr.Namespace, pr.Name, err)
+	}
+
+	return multus.NewMultusCmd(
+		pr.ContainerID,
+		pr.SandboxID,
+		pr.IfName,
+		pr.Netns,
+		pr.Name,
+		pr.Namespace,
+		pr.UID,
+	).Delete(pr.CNIConf, pod, pr.exec, pr.kubeclient)
+}
+
+func (pr *PodRequest) cmdCheck() error {
+	namespace := pr.Namespace
+	podName := pr.Name
+	if namespace == "" || podName == "" {
+		return fmt.Errorf("required CNI variable missing")
+	}
+
+	logging.Debugf("CmdCheck for [%s/%s]. CNI conf: %+v", namespace, podName, *pr.CNIConf)
+
+	return multus.NewMultusCmd(
+		pr.ContainerID,
+		pr.SandboxID,
+		pr.IfName,
+		pr.Netns,
+		pr.Name,
+		pr.Namespace,
+		pr.UID).Check(pr.CNIConf, pr.exec)
+}
+
+func serializeResult(result cnitypes.Result) ([]byte, error) {
+	realResult, err := cnicurrent.NewResultFromResult(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate the CNI result: %w", err)
+	}
+
+	responseBytes, err := json.Marshal(&Response{Result: realResult})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal pod request response: %v", err)
+	}
+	return responseBytes, nil
+}

--- a/pkg/cni/server.go
+++ b/pkg/cni/server.go
@@ -245,7 +245,7 @@ func (pr *PodRequest) cmdAdd() ([]byte, error) {
 		return nil, fmt.Errorf("error getting pod [%s/%s]: %v", pr.Namespace, pr.Name, err)
 	}
 
-	result, err := multus.NewMultusCmd(
+	multusAddCmd := multus.NewCmd(
 		pr.ContainerID,
 		pr.SandboxID,
 		pr.IfName,
@@ -253,7 +253,8 @@ func (pr *PodRequest) cmdAdd() ([]byte, error) {
 		pr.Name,
 		pr.Namespace,
 		pr.UID,
-	).Add(pr.CNIConf, pod, pr.exec, pr.kubeclient)
+	)
+	result, err := multus.Add(multusAddCmd, pr.CNIConf, pod, pr.exec, pr.kubeclient)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring pod [%s/%s] networking: %v", pr.Namespace, pr.Name, err)
 	}
@@ -268,7 +269,7 @@ func (pr *PodRequest) cmdDelete() error {
 		return fmt.Errorf("error getting pod [%s/%s]: %v", pr.Namespace, pr.Name, err)
 	}
 
-	return multus.NewMultusCmd(
+	multusDeleteCmd := multus.NewCmd(
 		pr.ContainerID,
 		pr.SandboxID,
 		pr.IfName,
@@ -276,7 +277,8 @@ func (pr *PodRequest) cmdDelete() error {
 		pr.Name,
 		pr.Namespace,
 		pr.UID,
-	).Delete(pr.CNIConf, pod, pr.exec, pr.kubeclient)
+	)
+	return multus.Delete(multusDeleteCmd, pr.CNIConf, pod, pr.exec, pr.kubeclient)
 }
 
 func (pr *PodRequest) cmdCheck() error {
@@ -288,14 +290,15 @@ func (pr *PodRequest) cmdCheck() error {
 
 	logging.Debugf("CmdCheck for [%s/%s]. CNI conf: %+v", namespace, podName, *pr.CNIConf)
 
-	return multus.NewMultusCmd(
+	multusCheckCmd := multus.NewCmd(
 		pr.ContainerID,
 		pr.SandboxID,
 		pr.IfName,
 		pr.Netns,
 		pr.Name,
 		pr.Namespace,
-		pr.UID).Check(pr.CNIConf, pr.exec)
+		pr.UID)
+	return multus.Check(multusCheckCmd, pr.CNIConf, pr.exec)
 }
 
 func serializeResult(result cnitypes.Result) ([]byte, error) {

--- a/pkg/cni/shim.go
+++ b/pkg/cni/shim.go
@@ -1,0 +1,118 @@
+package cni
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/logging"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+)
+
+// CmdAdd implements the CNI spec ADD command handler
+func (p *Plugin) CmdAdd(args *skel.CmdArgs) error {
+	body, err := p.DoCNI("http://dummy/", newCNIRequest(args))
+	if err != nil {
+		return err
+	}
+
+	response := &Response{}
+	if err = json.Unmarshal(body, response); err != nil {
+		err = fmt.Errorf("failed to unmarshal response '%s': %v", string(body), err)
+		return err
+	}
+
+	logging.Verbosef("CmdAdd (shim): %s", string(body))
+	return cnitypes.PrintResult(response.Result, response.Result.CNIVersion)
+}
+
+// CmdCheck implements the CNI spec CHECK command handler
+func (p *Plugin) CmdCheck(args *skel.CmdArgs) error {
+	body, err := p.DoCNI("http://dummy/", newCNIRequest(args))
+	if err != nil {
+		return err
+	}
+
+	response := &Response{}
+	if err = json.Unmarshal(body, response); err != nil {
+		err = fmt.Errorf("failed to unmarshal response '%s': %v", string(body), err)
+		return err
+	}
+
+	logging.Verbosef("CmdAdd (shim): %s", string(body))
+	return cnitypes.PrintResult(response.Result, response.Result.CNIVersion)
+}
+
+// CmdDel implements the CNI spec DEL command handler
+func (p *Plugin) CmdDel(args *skel.CmdArgs) error {
+	body, err := p.DoCNI("http://dummy/", newCNIRequest(args))
+	if err != nil {
+		return err
+	}
+
+	response := &Response{}
+	if err = json.Unmarshal(body, response); err != nil {
+		err = fmt.Errorf("failed to unmarshal response '%s': %v", string(body), err)
+		return err
+	}
+
+	logging.Verbosef("CmdAdd (shim): %s", string(body))
+	return cnitypes.PrintResult(response.Result, response.Result.CNIVersion)
+}
+
+// Create and fill a Request with this Plugin's environment and stdin which
+// contain the CNI variables and configuration
+func newCNIRequest(args *skel.CmdArgs) *Request {
+	envMap := make(map[string]string)
+	for _, item := range os.Environ() {
+		idx := strings.Index(item, "=")
+		if idx > 0 {
+			envMap[strings.TrimSpace(item[:idx])] = item[idx+1:]
+		}
+	}
+
+	return &Request{
+		Env:    envMap,
+		Config: args.StdinData,
+	}
+}
+
+// DoCNI sends a CNI request to the CNI server via JSON + HTTP over a root-owned unix socket,
+// and returns the result
+func (p *Plugin) DoCNI(url string, req interface{}) ([]byte, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal CNI request %v: %v", req, err)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Dial: func(proto, addr string) (net.Conn, error) {
+				return net.Dial("unix", p.SocketPath)
+			},
+		},
+	}
+
+	resp, err := client.Post(url, "application/json", bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to send CNI request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CNI result: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("CNI request failed with status %v: '%s'", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}

--- a/pkg/cni/socket.go
+++ b/pkg/cni/socket.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2021 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cni
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const (
+	serverSocketName                   = "multus-cni.sock"
+	fullReadWriteExecutePermissions    = 0777
+	thickPluginSocketRunDirPermissions = 0700
+)
+
+// FilesystemPreRequirements ensures the target `rundir` features the correct
+// permissions.
+func FilesystemPreRequirements(rundir string) error {
+	socketpath := SocketPath(rundir)
+	if err := os.RemoveAll(rundir); err != nil && !os.IsNotExist(err) {
+		info, err := os.Stat(rundir)
+		if err != nil {
+			return fmt.Errorf("failed to stat old pod info socket directory %s: %v", rundir, err)
+		}
+		// Owner must be root
+		tmp := info.Sys()
+		statt, ok := tmp.(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("failed to read pod info socket directory stat info: %T", tmp)
+		}
+		if statt.Uid != 0 {
+			return fmt.Errorf("insecure owner of pod info socket directory %s: %v", rundir, statt.Uid)
+		}
+
+		// Check permissions
+		if info.Mode()&fullReadWriteExecutePermissions != thickPluginSocketRunDirPermissions {
+			return fmt.Errorf("insecure permissions on pod info socket directory %s: %v", rundir, info.Mode())
+		}
+
+		// Finally remove the socket file so we can re-create it
+		if err := os.Remove(socketpath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove old pod info socket %s: %v", socketpath, err)
+		}
+	}
+	if err := os.MkdirAll(rundir, thickPluginSocketRunDirPermissions); err != nil {
+		return fmt.Errorf("failed to create pod info socket directory %s: %v", rundir, err)
+	}
+	return nil
+}
+
+// SocketPath returns the path of the multus CNI socket
+func SocketPath(rundir string) string {
+	return filepath.Join(rundir, serverSocketName)
+}

--- a/pkg/cni/thick_cni_test.go
+++ b/pkg/cni/thick_cni_test.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2021 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cni
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+
+	netfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
+	k8s "gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/k8sclient"
+	testhelpers "gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/testing"
+)
+
+const suiteName = "Thick CNI architecture"
+
+func TestMultusThickCNIArchitecture(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, suiteName)
+}
+
+type fakeExec struct{}
+
+// ExecPlugin executes the plugin
+func (fe *fakeExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+	return []byte("{}"), nil
+}
+
+// FindInPath finds in path
+func (fe *fakeExec) FindInPath(plugin string, paths []string) (string, error) {
+	return "", nil
+}
+
+// Decode decodes
+func (fe *fakeExec) Decode(jsonBytes []byte) (version.PluginInfo, error) {
+	return nil, nil
+}
+
+var _ = Describe(suiteName, func() {
+	const thickCNISocketDirPath = "multus-cni-thick-arch-socket-path"
+
+	var thickPluginRunDir string
+
+	BeforeEach(func() {
+		var err error
+		thickPluginRunDir, err = ioutil.TempDir("", thickCNISocketDirPath)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(thickPluginRunDir)).To(Succeed())
+	})
+
+	Context("the directory does *not* exist", func() {
+		It("", func() {
+			Expect(FilesystemPreRequirements(thickPluginRunDir)).To(Succeed())
+		})
+	})
+
+	Context("the directory exists beforehand with the correct permissions", func() {
+		BeforeEach(func() {
+			Expect(os.MkdirAll(thickPluginRunDir, 0700)).To(Succeed())
+		})
+
+		It("verifies the filesystem requirements of the socket dir", func() {
+			Expect(FilesystemPreRequirements(thickPluginRunDir)).To(Succeed())
+		})
+	})
+
+	Context("CNI operations started from the shim", func() {
+		const (
+			containerID = "123456789"
+			ifaceName   = "eth0"
+			podName     = "my-little-pod"
+		)
+
+		const referenceConfig = `{
+	    "name": "node-cni-network",
+	    "type": "multus",
+	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "defaultnetworkwaitseconds": 3,
+	    "delegates": [{
+	        "name": "weave1",
+	        "cniVersion": "0.3.1",
+	        "type": "weave-net"
+	    }]}`
+
+		var (
+			cniServer *Server
+			K8sClient *k8s.ClientInfo
+			netns     ns.NetNS
+			shim      *Plugin
+		)
+
+		BeforeEach(func() {
+			var err error
+			K8sClient = fakeK8sClient(10)
+
+			cniServer, err = startCNIServer(thickPluginRunDir, K8sClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			shim = &Plugin{SocketPath: SocketPath(thickPluginRunDir)}
+
+			netns, err = testutils.NewNS()
+			Expect(err).NotTo(HaveOccurred())
+
+			// the namespace and podUID parameters below are hard-coded in the generation function
+			Expect(prepareCNIEnv(netns.Path(), "test", podName, "testUID")).To(Succeed())
+			Expect(createFakePod(K8sClient, podName)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			Expect(cniServer.Close()).To(Succeed())
+			Expect(teardownCNIEnv()).To(Succeed())
+			Expect(K8sClient.Client.CoreV1().Pods("test").Delete(
+				context.TODO(), podName, metav1.DeleteOptions{}))
+		})
+
+		It("ADD works successfully", func() {
+			Expect(
+				shim.CmdAdd(
+					cniCmdArgs(containerID, netns.Path(), ifaceName, referenceConfig))).To(Succeed())
+		})
+
+		It("DEL works successfully", func() {
+			Expect(
+				shim.CmdDel(
+					cniCmdArgs(containerID, netns.Path(), ifaceName, referenceConfig))).To(Succeed())
+		})
+
+		It("CHECK works successfully", func() {
+			Expect(
+				shim.CmdCheck(
+					cniCmdArgs(containerID, netns.Path(), ifaceName, referenceConfig))).To(Succeed())
+		})
+	})
+})
+
+func fakeK8sClient(buffSize int) *k8s.ClientInfo {
+	return &k8s.ClientInfo{
+		Client:        fake.NewSimpleClientset(),
+		NetClient:     netfake.NewSimpleClientset().K8sCniCncfIoV1(),
+		EventRecorder: record.NewFakeRecorder(buffSize),
+	}
+}
+
+func cniCmdArgs(containerID string, netnsPath string, ifName string, stdinData string) *skel.CmdArgs {
+	return &skel.CmdArgs{
+		ContainerID: containerID,
+		Netns:       netnsPath,
+		IfName:      ifName,
+		StdinData:   []byte(stdinData)}
+}
+
+func prepareCNIEnv(netnsPath string, namespaceName string, podName string, podUID string) error {
+	cniArgs := fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s;K8S_POD_INFRA_CONTAINER_ID=;K8S_POD_UID=%s", namespaceName, podName, podUID)
+	if err := os.Setenv("CNI_COMMAND", "ADD"); err != nil {
+		return err
+	}
+	if err := os.Setenv("CNI_CONTAINERID", "123456789"); err != nil {
+		return err
+	}
+	if err := os.Setenv("CNI_NETNS", netnsPath); err != nil {
+		return err
+	}
+	if err := os.Setenv("CNI_ARGS", cniArgs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func teardownCNIEnv() error {
+	if err := os.Unsetenv("CNI_COMMAND"); err != nil {
+		return err
+	}
+	if err := os.Unsetenv("CNI_CONTAINERID"); err != nil {
+		return err
+	}
+	if err := os.Unsetenv("CNI_NETNS"); err != nil {
+		return err
+	}
+	if err := os.Unsetenv("CNI_ARGS"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createFakePod(k8sClient *k8s.ClientInfo, podName string) error {
+	var err error
+	fakePod := testhelpers.NewFakePod(podName, "", "")
+	_, err = k8sClient.Client.CoreV1().Pods(fakePod.GetNamespace()).Create(
+		context.TODO(), fakePod, metav1.CreateOptions{})
+	return err
+}
+
+func startCNIServer(runDir string, k8sClient *k8s.ClientInfo) (*Server, error) {
+	const period = 0
+	Expect(FilesystemPreRequirements(runDir)).To(Succeed())
+	cniServer, err := newCNIServer(runDir, k8sClient, &fakeExec{})
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := ServerListener(SocketPath(runDir))
+	if err != nil {
+		return nil, fmt.Errorf("failed to start the CNI server using socket %s. Reason: %+v", SocketPath(runDir), err)
+	}
+
+	cniServer.SetKeepAlivesEnabled(false)
+	go utilwait.Forever(func() {
+		if err := cniServer.Serve(l); err != nil {
+			utilruntime.HandleError(fmt.Errorf("CNI server Serve() failed: %v", err))
+		}
+	}, period)
+	return cniServer, nil
+}

--- a/pkg/cni/types.go
+++ b/pkg/cni/types.go
@@ -11,26 +11,7 @@ import (
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/types"
 )
 
-type cniRequestFunc func(request *PodRequest) ([]byte, error)
-
-// Explicit type for CNI commands the server handles
-type command string
-
-// PodRequest represents a request for ADD / DEL / CHECK for a Pod
-type PodRequest struct {
-	// The CNI command of the operation
-	Command command
-
-	// embed the Kubernetes runtime args
-	types.K8sArgs
-
-	// embed the CniArgs
-	skel.CmdArgs
-
-	kubeClient *k8sclient.ClientInfo
-
-	exec invoke.Exec
-}
+type cniRequestFunc func(cmd string, k8sArgs *types.K8sArgs, cniCmdArgs *skel.CmdArgs, exec invoke.Exec, kubeClient *k8sclient.ClientInfo) ([]byte, error)
 
 // Request sent to the Server by the multus-shim
 type Request struct {

--- a/pkg/cni/types.go
+++ b/pkg/cni/types.go
@@ -1,14 +1,14 @@
 package cni
 
 import (
-	"context"
+	"net/http"
+
 	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
+
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/k8sclient"
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/types"
-	"net/http"
-	"time"
-
-	"github.com/containernetworking/cni/pkg/types/current"
 )
 
 type cniRequestFunc func(request *PodRequest) ([]byte, error)
@@ -20,31 +20,15 @@ type command string
 type PodRequest struct {
 	// The CNI command of the operation
 	Command command
-	// kubernetes namespace name
-	Namespace string
-	// kubernetes pod name
-	Name string
-	// kubernetes pod UID
-	UID string
-	// kubernetes container ID
-	SandboxID string
-	// CNI container ID
-	ContainerID string
-	// kernel network namespace path
-	Netns string
-	// Interface name to be configured
-	IfName string
-	// CNI conf obtained from stdin conf
-	CNIConf *types.NetConf
-	// Timestamp when the request was started
-	timestamp time.Time
-	// ctx is a context tracking this request's lifetime
-	ctx context.Context
-	// cancel should be called to cancel this request
-	cancel context.CancelFunc
-	// kubeclient has the kubernetes API client
-	kubeclient *k8sclient.ClientInfo
-	// exec execs
+
+	// embed the Kubernetes runtime args
+	types.K8sArgs
+
+	// embed the CniArgs
+	skel.CmdArgs
+
+	kubeClient *k8sclient.ClientInfo
+
 	exec invoke.Exec
 }
 
@@ -64,11 +48,6 @@ type Server struct {
 	rundir      string
 	kubeclient  *k8sclient.ClientInfo
 	exec        invoke.Exec
-}
-
-// Plugin represents the connection between the CNI shim and server.
-type Plugin struct {
-	SocketPath string
 }
 
 // Response represents the response (computed in the CNI server) for

--- a/pkg/cni/types.go
+++ b/pkg/cni/types.go
@@ -1,0 +1,78 @@
+package cni
+
+import (
+	"context"
+	"github.com/containernetworking/cni/pkg/invoke"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/k8sclient"
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/types"
+	"net/http"
+	"time"
+
+	"github.com/containernetworking/cni/pkg/types/current"
+)
+
+type cniRequestFunc func(request *PodRequest) ([]byte, error)
+
+// Explicit type for CNI commands the server handles
+type command string
+
+// PodRequest represents a request for ADD / DEL / CHECK for a Pod
+type PodRequest struct {
+	// The CNI command of the operation
+	Command command
+	// kubernetes namespace name
+	Namespace string
+	// kubernetes pod name
+	Name string
+	// kubernetes pod UID
+	UID string
+	// kubernetes container ID
+	SandboxID string
+	// CNI container ID
+	ContainerID string
+	// kernel network namespace path
+	Netns string
+	// Interface name to be configured
+	IfName string
+	// CNI conf obtained from stdin conf
+	CNIConf *types.NetConf
+	// Timestamp when the request was started
+	timestamp time.Time
+	// ctx is a context tracking this request's lifetime
+	ctx context.Context
+	// cancel should be called to cancel this request
+	cancel context.CancelFunc
+	// kubeclient has the kubernetes API client
+	kubeclient *k8sclient.ClientInfo
+	// exec execs
+	exec invoke.Exec
+}
+
+// Request sent to the Server by the multus-shim
+type Request struct {
+	// CNI environment variables, like CNI_COMMAND and CNI_NETNS
+	Env map[string]string `json:"env,omitempty"`
+	// CNI configuration passed via stdin to the CNI plugin
+	Config []byte `json:"config,omitempty"`
+}
+
+// Server represents an HTTP server listening to a unix socket. It will handle
+// the CNI shim requests issued when a pod is added / removed.
+type Server struct {
+	http.Server
+	requestFunc cniRequestFunc
+	rundir      string
+	kubeclient  *k8sclient.ClientInfo
+	exec        invoke.Exec
+}
+
+// Plugin represents the connection between the CNI shim and server.
+type Plugin struct {
+	SocketPath string
+}
+
+// Response represents the response (computed in the CNI server) for
+// ADD / DEL / CHECK for a Pod.
+type Response struct {
+	Result *current.Result
+}

--- a/pkg/config/generator.go
+++ b/pkg/config/generator.go
@@ -48,6 +48,7 @@ type MultusConf struct {
 	RawNonIsolatedNamespaces string          `json:"globalNamespaces,omitempty"`
 	ReadinessIndicatorFile   string          `json:"readinessindicatorfile,omitempty"`
 	Type                     string          `json:"type"`
+	CniDir                   string          `json:"cniDir,omitempty"`
 }
 
 // NewMultusConfig creates a basic configuration generator. It can be mutated
@@ -143,6 +144,14 @@ func WithAdditionalBinaryFileDir(directoryPath string) Option {
 func WithOverriddenName(networkName string) Option {
 	return func(conf *MultusConf) {
 		conf.Name = networkName
+	}
+}
+
+// WithCniDir mutates the inner state to set the
+// multus CNI cache directory
+func WithCniDir(cniDir string) Option {
+	return func(conf *MultusConf) {
+		conf.CniDir = cniDir
 	}
 }
 

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -29,7 +29,7 @@ import (
 const (
 	multusConfigFileName     = "00-multus.conf"
 	MultusDefaultNetworkName = "multus-cni-network"
-	userRWPermission         = 0600
+	UserRWPermission         = 0600
 )
 
 // Manager monitors the configuration of the primary CNI plugin, and
@@ -177,7 +177,7 @@ func (m Manager) MonitorDelegatedPluginConfiguration(shutDown chan struct{}, don
 // PersistMultusConfig persists the provided configuration to the disc, with
 // Read / Write permissions. The output file path is `<multus auto config dir>/00-multus.conf`
 func (m Manager) PersistMultusConfig(config string) error {
-	return ioutil.WriteFile(m.multusConfigFilePath, []byte(config), userRWPermission)
+	return ioutil.WriteFile(m.multusConfigFilePath, []byte(config), UserRWPermission)
 }
 
 func primaryCNIPluginName(multusAutoconfigDir string) (string, error) {

--- a/pkg/config/manager_test.go
+++ b/pkg/config/manager_test.go
@@ -59,7 +59,7 @@ var _ = Describe(suiteName, func() {
 
 	BeforeEach(func() {
 		defaultCniConfig = fmt.Sprintf("%s/%s", multusConfigDir, primaryCNIPluginName)
-		Expect(ioutil.WriteFile(defaultCniConfig, []byte(primaryCNIPluginTemplate), userRWPermission)).To(Succeed())
+		Expect(ioutil.WriteFile(defaultCniConfig, []byte(primaryCNIPluginTemplate), UserRWPermission)).To(Succeed())
 
 		multusConf := NewMultusConfig(
 			primaryCNIName,
@@ -104,7 +104,7 @@ var _ = Describe(suiteName, func() {
 
 		It("Trigger the re-generation of the Multus CNI configuration", func() {
 			newCNIConfig := "{\"cniVersion\":\"0.4.0\",\"dns\":{},\"ipam\":{},\"name\":\"yoyo-newnet\",\"type\":\"mycni\"}"
-			Expect(ioutil.WriteFile(defaultCniConfig, []byte(newCNIConfig), userRWPermission)).To(Succeed())
+			Expect(ioutil.WriteFile(defaultCniConfig, []byte(newCNIConfig), UserRWPermission)).To(Succeed())
 
 			multusCniConfigFile := fmt.Sprintf("%s/%s", multusConfigDir, multusConfigFileName)
 			Eventually(func() (string, error) {

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -623,7 +623,6 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 
 	var result, tmpResult cnitypes.Result
 	var netStatus []nettypes.NetworkStatus
-	cniArgs := os.Getenv("CNI_ARGS")
 	for idx, delegate := range n.Delegates {
 		ifName := getIfname(delegate, args.IfName, idx)
 		rt, cniDeviceInfoPath := types.CreateCNIRuntimeConf(args, k8sArgs, ifName, n.RuntimeConfig, delegate)
@@ -637,7 +636,7 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		}
 
 		netName := ""
-		tmpResult, err = delegateAdd(exec, kubeClient, pod, args.Netns, ifName, delegate, rt, n, cniArgs)
+		tmpResult, err = delegateAdd(exec, kubeClient, pod, args.Netns, ifName, delegate, rt, n, args.Args)
 		if err != nil {
 			// If the add failed, tear down all networks we already added
 			netName = delegate.Conf.Name

--- a/pkg/multus/multus_test.go
+++ b/pkg/multus/multus_test.go
@@ -231,7 +231,6 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 		var err error
 		testNS, err = testutils.NewNS()
 		Expect(err).NotTo(HaveOccurred())
-		os.Setenv("CNI_NETNS", testNS.Path())
 		os.Setenv("CNI_PATH", "/some/path")
 
 		tmpDir, err = ioutil.TempDir("", "multus_tmp")
@@ -323,10 +322,10 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 		}
 	})
 
-	It("executes delegates given faulty namespace", func() {
+	It("returns the previous result using CmdCheck", func() {
 		args := &skel.CmdArgs{
 			ContainerID: "123456789",
-			Netns:       "fsdadfad",
+			Netns:       testNS.Path(),
 			IfName:      "eth0",
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
@@ -344,7 +343,8 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 	    }]
 	}`),
 		}
-		// Netns is given garbage value
+
+		logging.SetLogLevel("verbose")
 
 		// Touch the default network file.
 		configPath := "/tmp/foo.multus.conf"
@@ -385,6 +385,10 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 		r := result.(*types020.Result)
 		// plugin 1 is the masterplugin
 		Expect(reflect.DeepEqual(r, expectedResult1)).To(BeTrue())
+
+		// Check is not supported until v 0.4.0
+		err = CmdCheck(args, fExec, nil)
+		Expect(err).To(HaveOccurred())
 
 		os.Setenv("CNI_COMMAND", "DEL")
 		os.Setenv("CNI_IFNAME", "eth0")
@@ -480,82 +484,6 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 		}
 	})
 
-	It("executes delegates given faulty namespace", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "123456789",
-			Netns:       "fsdadfad",
-			IfName:      "eth0",
-			StdinData: []byte(`{
-	    "name": "node-cni-network",
-	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
-	    "defaultnetworkwaitseconds": 3,
-	    "delegates": [{
-	        "name": "weave1",
-	        "cniVersion": "0.2.0",
-	        "type": "weave-net"
-	    },{
-	        "name": "other1",
-	        "cniVersion": "0.2.0",
-	        "type": "other-plugin"
-	    }]
-	}`),
-		}
-		// Netns is given garbage value
-
-		// Touch the default network file.
-		configPath := "/tmp/foo.multus.conf"
-		os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
-
-		fExec := &fakeExec{}
-		expectedResult1 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.2/24"),
-			},
-		}
-		expectedConf1 := `{
-	    "name": "weave1",
-	    "cniVersion": "0.2.0",
-	    "type": "weave-net"
-	}`
-		fExec.addPlugin020(nil, "eth0", expectedConf1, expectedResult1, nil)
-
-		expectedResult2 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.5/24"),
-			},
-		}
-		expectedConf2 := `{
-	    "name": "other1",
-	    "cniVersion": "0.2.0",
-	    "type": "other-plugin"
-	}`
-		fExec.addPlugin020(nil, "net1", expectedConf2, expectedResult2, nil)
-
-		os.Setenv("CNI_COMMAND", "ADD")
-		os.Setenv("CNI_IFNAME", "eth0")
-		result, err := CmdAdd(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.addIndex).To(Equal(len(fExec.plugins)))
-		r := result.(*types020.Result)
-		// plugin 1 is the masterplugin
-		Expect(reflect.DeepEqual(r, expectedResult1)).To(BeTrue())
-
-		os.Setenv("CNI_COMMAND", "DEL")
-		os.Setenv("CNI_IFNAME", "eth0")
-		err = CmdDel(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
-
-		// Cleanup default network file.
-		if _, errStat := os.Stat(configPath); errStat == nil {
-			errRemove := os.Remove(configPath)
-			Expect(errRemove).NotTo(HaveOccurred())
-		}
-	})
-
 	It("returns the previous result using CmdCheck", func() {
 		args := &skel.CmdArgs{
 			ContainerID: "123456789",
@@ -637,83 +565,6 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 		}
 	})
 
-	It("executes delegates given faulty namespace", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "123456789",
-			Netns:       "fsdadfad",
-			IfName:      "eth0",
-			StdinData: []byte(`{
-	    "name": "node-cni-network",
-	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
-	    "defaultnetworkwaitseconds": 3,
-	    "delegates": [{
-	        "name": "weave1",
-	        "cniVersion": "0.2.0",
-	        "type": "weave-net"
-	    },{
-	        "name": "other1",
-	        "cniVersion": "0.2.0",
-	        "type": "other-plugin"
-	    }]
-	}`),
-		}
-		// Netns is given garbage value
-		fmt.Println("args.Netns: ", args.Netns)
-
-		// Touch the default network file.
-		configPath := "/tmp/foo.multus.conf"
-		os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
-
-		fExec := &fakeExec{}
-		expectedResult1 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.2/24"),
-			},
-		}
-		expectedConf1 := `{
-	    "name": "weave1",
-	    "cniVersion": "0.2.0",
-	    "type": "weave-net"
-	}`
-		fExec.addPlugin020(nil, "eth0", expectedConf1, expectedResult1, nil)
-
-		expectedResult2 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.5/24"),
-			},
-		}
-		expectedConf2 := `{
-	    "name": "other1",
-	    "cniVersion": "0.2.0",
-	    "type": "other-plugin"
-	}`
-		fExec.addPlugin020(nil, "net1", expectedConf2, expectedResult2, nil)
-
-		os.Setenv("CNI_COMMAND", "ADD")
-		os.Setenv("CNI_IFNAME", "eth0")
-		result, err := CmdAdd(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.addIndex).To(Equal(len(fExec.plugins)))
-		r := result.(*types020.Result)
-		// plugin 1 is the masterplugin
-		Expect(reflect.DeepEqual(r, expectedResult1)).To(BeTrue())
-
-		os.Setenv("CNI_COMMAND", "DEL")
-		os.Setenv("CNI_IFNAME", "eth0")
-		err = CmdDel(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
-
-		// Cleanup default network file.
-		if _, errStat := os.Stat(configPath); errStat == nil {
-			errRemove := os.Remove(configPath)
-			Expect(errRemove).NotTo(HaveOccurred())
-		}
-	})
-
 	It("returns the previous result using CmdCheck", func() {
 		args := &skel.CmdArgs{
 			ContainerID: "123456789",
@@ -781,239 +632,6 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 		// Check is not supported until v 0.4.0
 		err = CmdCheck(args, fExec, nil)
 		Expect(err).To(HaveOccurred())
-
-		os.Setenv("CNI_COMMAND", "DEL")
-		os.Setenv("CNI_IFNAME", "eth0")
-		err = CmdDel(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
-
-		// Cleanup default network file.
-		if _, errStat := os.Stat(configPath); errStat == nil {
-			errRemove := os.Remove(configPath)
-			Expect(errRemove).NotTo(HaveOccurred())
-		}
-	})
-
-	It("executes delegates given faulty namespace", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "123456789",
-			Netns:       "fsdadfad",
-			IfName:      "eth0",
-			StdinData: []byte(`{
-	    "name": "node-cni-network",
-	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
-	    "defaultnetworkwaitseconds": 3,
-	    "delegates": [{
-	        "name": "weave1",
-	        "cniVersion": "0.2.0",
-	        "type": "weave-net"
-	    },{
-	        "name": "other1",
-	        "cniVersion": "0.2.0",
-	        "type": "other-plugin"
-	    }]
-	}`),
-		}
-		// Netns is given garbage value
-
-		// Touch the default network file.
-		configPath := "/tmp/foo.multus.conf"
-		os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
-
-		fExec := &fakeExec{}
-		expectedResult1 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.2/24"),
-			},
-		}
-		expectedConf1 := `{
-	    "name": "weave1",
-	    "cniVersion": "0.2.0",
-	    "type": "weave-net"
-	}`
-		fExec.addPlugin020(nil, "eth0", expectedConf1, expectedResult1, nil)
-
-		expectedResult2 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.5/24"),
-			},
-		}
-		expectedConf2 := `{
-	    "name": "other1",
-	    "cniVersion": "0.2.0",
-	    "type": "other-plugin"
-	}`
-		fExec.addPlugin020(nil, "net1", expectedConf2, expectedResult2, nil)
-
-		os.Setenv("CNI_COMMAND", "ADD")
-		os.Setenv("CNI_IFNAME", "eth0")
-		result, err := CmdAdd(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.addIndex).To(Equal(len(fExec.plugins)))
-		r := result.(*types020.Result)
-		// plugin 1 is the masterplugin
-		Expect(reflect.DeepEqual(r, expectedResult1)).To(BeTrue())
-
-		os.Setenv("CNI_COMMAND", "DEL")
-		os.Setenv("CNI_IFNAME", "eth0")
-		err = CmdDel(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
-
-		// Cleanup default network file.
-		if _, errStat := os.Stat(configPath); errStat == nil {
-			errRemove := os.Remove(configPath)
-			Expect(errRemove).NotTo(HaveOccurred())
-		}
-	})
-
-	It("returns the previous result using CmdCheck", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "123456789",
-			Netns:       testNS.Path(),
-			IfName:      "eth0",
-			StdinData: []byte(`{
-	    "name": "node-cni-network",
-	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
-	    "defaultnetworkwaitseconds": 3,
-	    "delegates": [{
-	        "name": "weave1",
-	        "cniVersion": "0.2.0",
-	        "type": "weave-net"
-	    },{
-	        "name": "other1",
-	        "cniVersion": "0.2.0",
-	        "type": "other-plugin"
-	    }]
-	}`),
-		}
-
-		logging.SetLogLevel("verbose")
-
-		// Touch the default network file.
-		configPath := "/tmp/foo.multus.conf"
-		os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
-
-		fExec := &fakeExec{}
-		expectedResult1 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.2/24"),
-			},
-		}
-		expectedConf1 := `{
-	    "name": "weave1",
-	    "cniVersion": "0.2.0",
-	    "type": "weave-net"
-	}`
-		fExec.addPlugin020(nil, "eth0", expectedConf1, expectedResult1, nil)
-
-		expectedResult2 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.5/24"),
-			},
-		}
-		expectedConf2 := `{
-	    "name": "other1",
-	    "cniVersion": "0.2.0",
-	    "type": "other-plugin"
-	}`
-		fExec.addPlugin020(nil, "net1", expectedConf2, expectedResult2, nil)
-
-		os.Setenv("CNI_COMMAND", "ADD")
-		os.Setenv("CNI_IFNAME", "eth0")
-		result, err := CmdAdd(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.addIndex).To(Equal(len(fExec.plugins)))
-		r := result.(*types020.Result)
-		// plugin 1 is the masterplugin
-		Expect(reflect.DeepEqual(r, expectedResult1)).To(BeTrue())
-
-		// Check is not supported until v 0.4.0
-		err = CmdCheck(args, fExec, nil)
-		Expect(err).To(HaveOccurred())
-
-		os.Setenv("CNI_COMMAND", "DEL")
-		os.Setenv("CNI_IFNAME", "eth0")
-		err = CmdDel(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
-
-		// Cleanup default network file.
-		if _, errStat := os.Stat(configPath); errStat == nil {
-			errRemove := os.Remove(configPath)
-			Expect(errRemove).NotTo(HaveOccurred())
-		}
-	})
-
-	It("executes delegates given faulty namespace", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "123456789",
-			Netns:       "fsdadfad",
-			IfName:      "eth0",
-			StdinData: []byte(`{
-	    "name": "node-cni-network",
-	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
-	    "defaultnetworkwaitseconds": 3,
-	    "delegates": [{
-	        "name": "weave1",
-	        "cniVersion": "0.2.0",
-	        "type": "weave-net"
-	    },{
-	        "name": "other1",
-	        "cniVersion": "0.2.0",
-	        "type": "other-plugin"
-	    }]
-	}`),
-		}
-		// Netns is given garbage value
-
-		// Touch the default network file.
-		configPath := "/tmp/foo.multus.conf"
-		os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
-
-		fExec := &fakeExec{}
-		expectedResult1 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.2/24"),
-			},
-		}
-		expectedConf1 := `{
-	    "name": "weave1",
-	    "cniVersion": "0.2.0",
-	    "type": "weave-net"
-	}`
-		fExec.addPlugin020(nil, "eth0", expectedConf1, expectedResult1, nil)
-
-		expectedResult2 := &types020.Result{
-			CNIVersion: "0.2.0",
-			IP4: &types020.IPConfig{
-				IP: *testhelpers.EnsureCIDR("1.1.1.5/24"),
-			},
-		}
-		expectedConf2 := `{
-	    "name": "other1",
-	    "cniVersion": "0.2.0",
-	    "type": "other-plugin"
-	}`
-		fExec.addPlugin020(nil, "net1", expectedConf2, expectedResult2, nil)
-
-		os.Setenv("CNI_COMMAND", "ADD")
-		os.Setenv("CNI_IFNAME", "eth0")
-		result, err := CmdAdd(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.addIndex).To(Equal(len(fExec.plugins)))
-		r := result.(*types020.Result)
-		// plugin 1 is the masterplugin
-		Expect(reflect.DeepEqual(r, expectedResult1)).To(BeTrue())
 
 		os.Setenv("CNI_COMMAND", "DEL")
 		os.Setenv("CNI_IFNAME", "eth0")
@@ -2410,83 +2028,6 @@ var _ = Describe("multus operations cniVersion 0.4.0 config", func() {
 		os.Setenv("CNI_COMMAND", "CHECK")
 		err = CmdCheck(args, fExec, nil)
 		Expect(err).NotTo(HaveOccurred())
-
-		os.Setenv("CNI_COMMAND", "DEL")
-		os.Setenv("CNI_IFNAME", "eth0")
-		err = CmdDel(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.delIndex).To(Equal(len(fExec.plugins)))
-
-		// Cleanup default network file.
-		if _, errStat := os.Stat(configPath); errStat == nil {
-			errRemove := os.Remove(configPath)
-			Expect(errRemove).NotTo(HaveOccurred())
-		}
-	})
-
-	It("executes delegates given faulty namespace", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "123456789",
-			Netns:       "fsdadfad",
-			IfName:      "eth0",
-			StdinData: []byte(`{
-	    "name": "node-cni-network",
-	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
-	    "defaultnetworkwaitseconds": 3,
-	    "delegates": [{
-	        "name": "weave1",
-	        "cniVersion": "0.4.0",
-	        "type": "weave-net"
-	    },{
-	        "name": "other1",
-	        "cniVersion": "0.4.0",
-	        "type": "other-plugin"
-	    }]
-	}`),
-		}
-		// Netns is given garbage value
-
-		// Touch the default network file.
-		configPath := "/tmp/foo.multus.conf"
-		os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
-
-		fExec := &fakeExec{}
-		expectedResult1 := &current.Result{
-			CNIVersion: "0.4.0",
-			IPs: []*current.IPConfig{{
-				Address: *testhelpers.EnsureCIDR("1.1.1.2/24"),
-			},
-			},
-		}
-		expectedConf1 := `{
-	    "name": "weave1",
-	    "cniVersion": "0.4.0",
-	    "type": "weave-net"
-	}`
-		fExec.addPlugin(nil, "eth0", expectedConf1, expectedResult1, nil)
-
-		expectedResult2 := &current.Result{
-			CNIVersion: "0.4.0",
-			IPs: []*current.IPConfig{{
-				Address: *testhelpers.EnsureCIDR("1.1.1.5/24"),
-			},
-			},
-		}
-		expectedConf2 := `{
-	    "name": "other1",
-	    "cniVersion": "0.4.0",
-	    "type": "other-plugin"
-	}`
-		fExec.addPlugin(nil, "net1", expectedConf2, expectedResult2, nil)
-
-		os.Setenv("CNI_COMMAND", "ADD")
-		os.Setenv("CNI_IFNAME", "eth0")
-		result, err := CmdAdd(args, fExec, nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(fExec.addIndex).To(Equal(len(fExec.plugins)))
-		// plugin 1 is the masterplugin
-		Expect(reflect.DeepEqual(result, expectedResult1)).To(BeTrue())
 
 		os.Setenv("CNI_COMMAND", "DEL")
 		os.Setenv("CNI_IFNAME", "eth0")

--- a/pkg/netutils/netutils.go
+++ b/pkg/netutils/netutils.go
@@ -23,15 +23,14 @@ import (
 	"path/filepath"
 
 	"github.com/containernetworking/cni/libcni"
-	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/logging"
 )
 
 // DeleteDefaultGW removes the default gateway from marked interfaces.
-func DeleteDefaultGW(args *skel.CmdArgs, ifName string) error {
-	netns, err := ns.GetNS(args.Netns)
+func DeleteDefaultGW(netnsPath string, ifName string) error {
+	netns, err := ns.GetNS(netnsPath)
 	if err != nil {
 		return logging.Errorf("DeleteDefaultGW: Error getting namespace %v", err)
 	}
@@ -52,9 +51,9 @@ func DeleteDefaultGW(args *skel.CmdArgs, ifName string) error {
 }
 
 // SetDefaultGW adds a default gateway on a specific interface
-func SetDefaultGW(args *skel.CmdArgs, ifName string, gateways []net.IP) error {
+func SetDefaultGW(netnsPath string, ifName string, gateways []net.IP) error {
 	// This ensures we're acting within the net namespace for the pod.
-	netns, err := ns.GetNS(args.Netns)
+	netns, err := ns.GetNS(netnsPath)
 	if err != nil {
 		return logging.Errorf("SetDefaultGW: Error getting namespace %v", err)
 	}

--- a/pkg/netutils/netutils_test.go
+++ b/pkg/netutils/netutils_test.go
@@ -198,7 +198,7 @@ var _ = Describe("netutil netlink function testing", func() {
 			Expect(originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				Expect(DeleteDefaultGW(args, IFNAME)).Should(Succeed())
+				Expect(DeleteDefaultGW(args.Netns, IFNAME)).Should(Succeed())
 				return nil
 			})).Should(Succeed())
 		})
@@ -232,7 +232,7 @@ var _ = Describe("netutil netlink function testing", func() {
 			Expect(originalNS.Do(func(ns.NetNS) error {
 				defer GinkgoRecover()
 
-				Expect(SetDefaultGW(args, IFNAME, []net.IP{net.ParseIP("10.0.0.1")})).Should(Succeed())
+				Expect(SetDefaultGW(args.Netns, IFNAME, []net.IP{net.ParseIP("10.0.0.1")})).Should(Succeed())
 				return nil
 			})).Should(Succeed())
 		})

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -427,27 +427,6 @@ func LoadDaemonNetConf(configPath string) (*ControllerNetConf, error) {
 		daemonNetConf.BinDir = defaultBinDir
 	}
 
-	if len(daemonNetConf.SystemNamespaces) == 0 {
-		daemonNetConf.SystemNamespaces = []string{"kube-system"}
-	}
-
-	if daemonNetConf.MultusNamespace == "" {
-		daemonNetConf.MultusNamespace = defaultMultusNamespace
-	}
-
-	// setup namespace isolation
-	if daemonNetConf.RawNonIsolatedNamespaces == "" {
-		daemonNetConf.NonIsolatedNamespaces = []string{defaultNonIsolatedNamespace}
-	} else {
-		// Parse the comma separated list
-		nonisolated := strings.Split(daemonNetConf.RawNonIsolatedNamespaces, ",")
-		// Cleanup the whitespace
-		for i, nonv := range nonisolated {
-			nonisolated[i] = strings.TrimSpace(nonv)
-		}
-		daemonNetConf.NonIsolatedNamespaces = nonisolated
-	}
-
 	if daemonNetConf.MultusSocketDir == "" {
 		daemonNetConf.MultusSocketDir = defaultMultusRunDir
 	}

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -184,41 +184,24 @@ func mergeCNIRuntimeConfig(runtimeConfig *RuntimeConfig, delegate *DelegateNetCo
 // CreateCNIRuntimeConf create CNI RuntimeConf for a delegate. If delegate configuration
 // exists, merge data with the runtime config.
 func CreateCNIRuntimeConf(args *skel.CmdArgs, k8sArgs *K8sArgs, ifName string, rc *RuntimeConfig, delegate *DelegateNetConf) (*libcni.RuntimeConf, string) {
-	logging.Debugf("LoadCNIRuntimeConf: %v, %v, %s, %v %v", args, k8sArgs, ifName, rc, delegate)
-	var cniDeviceInfoFile string
-	var delegateRc *RuntimeConfig
+	podName := string(k8sArgs.K8S_POD_NAME)
+	podNamespace := string(k8sArgs.K8S_POD_NAMESPACE)
+	podUID := string(k8sArgs.K8S_POD_UID)
+	sandboxID := string(k8sArgs.K8S_POD_INFRA_CONTAINER_ID)
+	return NewCNIRuntimeConf(args.ContainerID, sandboxID, podName, podNamespace, podUID, args.Netns, ifName, rc, delegate)
+}
 
-	if delegate != nil {
-		delegateRc = mergeCNIRuntimeConfig(rc, delegate)
-		if delegateRc.DeviceID != "" {
-			if delegateRc.CNIDeviceInfoFile != "" {
-				logging.Debugf("Warning: Existing value of CNIDeviceInfoFile will be overwritten %s", delegateRc.CNIDeviceInfoFile)
-			}
-			autoDeviceInfo := fmt.Sprintf("%s-%s_%s", delegate.Name, args.ContainerID, ifName)
-			delegateRc.CNIDeviceInfoFile = nadutils.GetCNIDeviceInfoPath(autoDeviceInfo)
-			cniDeviceInfoFile = delegateRc.CNIDeviceInfoFile
-			logging.Debugf("Adding auto-generated CNIDeviceInfoFile: %s", delegateRc.CNIDeviceInfoFile)
-		}
-	} else {
-		delegateRc = rc
-	}
+// NewCNIRuntimeConf creates the CNI `RuntimeConf` for the given ADD / DEL request.
+func NewCNIRuntimeConf(containerID, sandboxID, podName, podNamespace, podUID, netNs, ifName string, rc *RuntimeConfig, delegate *DelegateNetConf) (*libcni.RuntimeConf, string) {
+	logging.Debugf("LoadCNIRuntimeConf: %s, %v %v", ifName, rc, delegate)
 
+	delegateRc := DelegateRuntimeConfig(containerID, delegate, rc, ifName)
 	// In part, adapted from K8s pkg/kubelet/dockershim/network/cni/cni.go#buildCNIRuntimeConf
-	rt := &libcni.RuntimeConf{
-		ContainerID: args.ContainerID,
-		NetNS:       args.Netns,
-		IfName:      ifName,
-		// NOTE: Verbose logging depends on this order, so please keep Args order.
-		Args: [][2]string{
-			{"IgnoreUnknown", string("true")},
-			{"K8S_POD_NAMESPACE", string(k8sArgs.K8S_POD_NAMESPACE)},
-			{"K8S_POD_NAME", string(k8sArgs.K8S_POD_NAME)},
-			{"K8S_POD_INFRA_CONTAINER_ID", string(k8sArgs.K8S_POD_INFRA_CONTAINER_ID)},
-			{"K8S_POD_UID", string(k8sArgs.K8S_POD_UID)},
-		},
-	}
+	rt := CreateRuntimeConf(netNs, podNamespace, podName, containerID, sandboxID, podUID, ifName)
 
+	var cniDeviceInfoFile string
 	if delegateRc != nil {
+		cniDeviceInfoFile = delegateRc.CNIDeviceInfoFile
 		capabilityArgs := map[string]interface{}{}
 		if len(delegateRc.PortMaps) != 0 {
 			capabilityArgs["portMappings"] = delegateRc.PortMaps
@@ -244,6 +227,43 @@ func CreateCNIRuntimeConf(args *skel.CmdArgs, k8sArgs *K8sArgs, ifName string, r
 		rt.CapabilityArgs = capabilityArgs
 	}
 	return rt, cniDeviceInfoFile
+}
+
+// CreateRuntimeConf creates the CNI `RuntimeConf` for the given ADD / DEL request.
+func CreateRuntimeConf(netNs, podNamespace, podName, containerID, sandboxID, podUID, ifName string) *libcni.RuntimeConf {
+	return &libcni.RuntimeConf{
+		ContainerID: containerID,
+		NetNS:       netNs,
+		IfName:      ifName,
+		// NOTE: Verbose logging depends on this order, so please keep Args order.
+		Args: [][2]string{
+			{"IgnoreUnknown", "true"},
+			{"K8S_POD_NAMESPACE", podNamespace},
+			{"K8S_POD_NAME", podName},
+			{"K8S_POD_INFRA_CONTAINER_ID", sandboxID},
+			{"K8S_POD_UID", podUID},
+		},
+	}
+}
+
+// DelegateRuntimeConfig creates the CNI `RuntimeConf` for the given ADD / DEL request.
+func DelegateRuntimeConfig(containerID string, delegate *DelegateNetConf, rc *RuntimeConfig, ifName string) *RuntimeConfig {
+	var delegateRc *RuntimeConfig
+
+	if delegate != nil {
+		delegateRc = mergeCNIRuntimeConfig(rc, delegate)
+		if delegateRc.DeviceID != "" {
+			if delegateRc.CNIDeviceInfoFile != "" {
+				logging.Debugf("Warning: Existing value of CNIDeviceInfoFile will be overwritten %s", delegateRc.CNIDeviceInfoFile)
+			}
+			autoDeviceInfo := fmt.Sprintf("%s-%s_%s", delegate.Name, containerID, ifName)
+			delegateRc.CNIDeviceInfoFile = nadutils.GetCNIDeviceInfoPath(autoDeviceInfo)
+			logging.Debugf("Adding auto-generated CNIDeviceInfoFile: %s", delegateRc.CNIDeviceInfoFile)
+		}
+	} else {
+		delegateRc = rc
+	}
+	return delegateRc
 }
 
 // GetGatewayFromResult retrieves gateway IP addresses from CNI result

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -172,3 +172,40 @@ type ResourceClient interface {
 	// GetPodResourceMap returns an instance of a map of Pod ResourceInfo given a (Pod name, namespace) tuple
 	GetPodResourceMap(*v1.Pod) (map[string]*ResourceInfo, error)
 }
+
+// ShimNetConf for the SHIM cni config file written in json
+type ShimNetConf struct {
+	types.NetConf
+
+	MultusSocketDir string `json:"socketDir"`
+	LogFile         string `json:"logFile,omitempty"`
+	LogLevel        string `json:"logLevel,omitempty"`
+	LogToStderr     bool   `json:"logToStderr,omitempty"`
+}
+
+// ControllerNetConf for the controller cni configuration
+type ControllerNetConf struct {
+	ConfDir string `json:"confDir"`
+	CNIDir  string `json:"cniDir"`
+	BinDir  string `json:"binDir"`
+
+	ClusterNetwork  string   `json:"clusterNetwork"`
+	DefaultNetworks []string `json:"defaultNetworks"`
+	LogFile         string   `json:"logFile"`
+	LogLevel        string   `json:"logLevel"`
+	LogToStderr     bool     `json:"logToStderr,omitempty"`
+
+	// Option to isolate the usage of CR's to the namespace in which a pod resides.
+	NamespaceIsolation       bool     `json:"namespaceIsolation"`
+	RawNonIsolatedNamespaces string   `json:"globalNamespaces"`
+	NonIsolatedNamespaces    []string `json:"-"`
+
+	// Option to set system namespaces (to avoid to add defaultNetworks)
+	SystemNamespaces []string `json:"systemNamespaces"`
+	// Option to set the namespace that multus-cni uses (clusterNetwork/defaultNetworks)
+	MultusNamespace string `json:"multusNamespace"`
+
+	// Option to point to the path of the unix domain socket through which the
+	// multus client / server communicate.
+	MultusSocketDir string `json:"socketDir"`
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -185,25 +185,12 @@ type ShimNetConf struct {
 
 // ControllerNetConf for the controller cni configuration
 type ControllerNetConf struct {
-	ConfDir string `json:"confDir"`
-	CNIDir  string `json:"cniDir"`
-	BinDir  string `json:"binDir"`
-
-	ClusterNetwork  string   `json:"clusterNetwork"`
-	DefaultNetworks []string `json:"defaultNetworks"`
-	LogFile         string   `json:"logFile"`
-	LogLevel        string   `json:"logLevel"`
-	LogToStderr     bool     `json:"logToStderr,omitempty"`
-
-	// Option to isolate the usage of CR's to the namespace in which a pod resides.
-	NamespaceIsolation       bool     `json:"namespaceIsolation"`
-	RawNonIsolatedNamespaces string   `json:"globalNamespaces"`
-	NonIsolatedNamespaces    []string `json:"-"`
-
-	// Option to set system namespaces (to avoid to add defaultNetworks)
-	SystemNamespaces []string `json:"systemNamespaces"`
-	// Option to set the namespace that multus-cni uses (clusterNetwork/defaultNetworks)
-	MultusNamespace string `json:"multusNamespace"`
+	ConfDir     string `json:"confDir"`
+	CNIDir      string `json:"cniDir"`
+	BinDir      string `json:"binDir"`
+	LogFile     string `json:"logFile"`
+	LogLevel    string `json:"logLevel"`
+	LogToStderr bool   `json:"logToStderr,omitempty"`
 
 	// Option to point to the path of the unix domain socket through which the
 	// multus client / server communicate.

--- a/vendor/github.com/gorilla/mux/AUTHORS
+++ b/vendor/github.com/gorilla/mux/AUTHORS
@@ -1,0 +1,8 @@
+# This is the official list of gorilla/mux authors for copyright purposes.
+#
+# Please keep the list sorted.
+
+Google LLC (https://opensource.google.com/)
+Kamil Kisielk <kamil@kamilkisiel.net>
+Matt Silverlock <matt@eatsleeprepeat.net>
+Rodrigo Moraes (https://github.com/moraes)

--- a/vendor/github.com/gorilla/mux/LICENSE
+++ b/vendor/github.com/gorilla/mux/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+	 * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+	 * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+	 * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/gorilla/mux/README.md
+++ b/vendor/github.com/gorilla/mux/README.md
@@ -1,0 +1,805 @@
+# gorilla/mux
+
+[![GoDoc](https://godoc.org/github.com/gorilla/mux?status.svg)](https://godoc.org/github.com/gorilla/mux)
+[![CircleCI](https://circleci.com/gh/gorilla/mux.svg?style=svg)](https://circleci.com/gh/gorilla/mux)
+[![Sourcegraph](https://sourcegraph.com/github.com/gorilla/mux/-/badge.svg)](https://sourcegraph.com/github.com/gorilla/mux?badge)
+
+![Gorilla Logo](https://cloud-cdn.questionable.services/gorilla-icon-64.png)
+
+https://www.gorillatoolkit.org/pkg/mux
+
+Package `gorilla/mux` implements a request router and dispatcher for matching incoming requests to
+their respective handler.
+
+The name mux stands for "HTTP request multiplexer". Like the standard `http.ServeMux`, `mux.Router` matches incoming requests against a list of registered routes and calls a handler for the route that matches the URL or other conditions. The main features are:
+
+* It implements the `http.Handler` interface so it is compatible with the standard `http.ServeMux`.
+* Requests can be matched based on URL host, path, path prefix, schemes, header and query values, HTTP methods or using custom matchers.
+* URL hosts, paths and query values can have variables with an optional regular expression.
+* Registered URLs can be built, or "reversed", which helps maintaining references to resources.
+* Routes can be used as subrouters: nested routes are only tested if the parent route matches. This is useful to define groups of routes that share common conditions like a host, a path prefix or other repeated attributes. As a bonus, this optimizes request matching.
+
+---
+
+* [Install](#install)
+* [Examples](#examples)
+* [Matching Routes](#matching-routes)
+* [Static Files](#static-files)
+* [Serving Single Page Applications](#serving-single-page-applications) (e.g. React, Vue, Ember.js, etc.)
+* [Registered URLs](#registered-urls)
+* [Walking Routes](#walking-routes)
+* [Graceful Shutdown](#graceful-shutdown)
+* [Middleware](#middleware)
+* [Handling CORS Requests](#handling-cors-requests)
+* [Testing Handlers](#testing-handlers)
+* [Full Example](#full-example)
+
+---
+
+## Install
+
+With a [correctly configured](https://golang.org/doc/install#testing) Go toolchain:
+
+```sh
+go get -u github.com/gorilla/mux
+```
+
+## Examples
+
+Let's start registering a couple of URL paths and handlers:
+
+```go
+func main() {
+    r := mux.NewRouter()
+    r.HandleFunc("/", HomeHandler)
+    r.HandleFunc("/products", ProductsHandler)
+    r.HandleFunc("/articles", ArticlesHandler)
+    http.Handle("/", r)
+}
+```
+
+Here we register three routes mapping URL paths to handlers. This is equivalent to how `http.HandleFunc()` works: if an incoming request URL matches one of the paths, the corresponding handler is called passing (`http.ResponseWriter`, `*http.Request`) as parameters.
+
+Paths can have variables. They are defined using the format `{name}` or `{name:pattern}`. If a regular expression pattern is not defined, the matched variable will be anything until the next slash. For example:
+
+```go
+r := mux.NewRouter()
+r.HandleFunc("/products/{key}", ProductHandler)
+r.HandleFunc("/articles/{category}/", ArticlesCategoryHandler)
+r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler)
+```
+
+The names are used to create a map of route variables which can be retrieved calling `mux.Vars()`:
+
+```go
+func ArticlesCategoryHandler(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+    w.WriteHeader(http.StatusOK)
+    fmt.Fprintf(w, "Category: %v\n", vars["category"])
+}
+```
+
+And this is all you need to know about the basic usage. More advanced options are explained below.
+
+### Matching Routes
+
+Routes can also be restricted to a domain or subdomain. Just define a host pattern to be matched. They can also have variables:
+
+```go
+r := mux.NewRouter()
+// Only matches if domain is "www.example.com".
+r.Host("www.example.com")
+// Matches a dynamic subdomain.
+r.Host("{subdomain:[a-z]+}.example.com")
+```
+
+There are several other matchers that can be added. To match path prefixes:
+
+```go
+r.PathPrefix("/products/")
+```
+
+...or HTTP methods:
+
+```go
+r.Methods("GET", "POST")
+```
+
+...or URL schemes:
+
+```go
+r.Schemes("https")
+```
+
+...or header values:
+
+```go
+r.Headers("X-Requested-With", "XMLHttpRequest")
+```
+
+...or query values:
+
+```go
+r.Queries("key", "value")
+```
+
+...or to use a custom matcher function:
+
+```go
+r.MatcherFunc(func(r *http.Request, rm *RouteMatch) bool {
+    return r.ProtoMajor == 0
+})
+```
+
+...and finally, it is possible to combine several matchers in a single route:
+
+```go
+r.HandleFunc("/products", ProductsHandler).
+  Host("www.example.com").
+  Methods("GET").
+  Schemes("http")
+```
+
+Routes are tested in the order they were added to the router. If two routes match, the first one wins:
+
+```go
+r := mux.NewRouter()
+r.HandleFunc("/specific", specificHandler)
+r.PathPrefix("/").Handler(catchAllHandler)
+```
+
+Setting the same matching conditions again and again can be boring, so we have a way to group several routes that share the same requirements. We call it "subrouting".
+
+For example, let's say we have several URLs that should only match when the host is `www.example.com`. Create a route for that host and get a "subrouter" from it:
+
+```go
+r := mux.NewRouter()
+s := r.Host("www.example.com").Subrouter()
+```
+
+Then register routes in the subrouter:
+
+```go
+s.HandleFunc("/products/", ProductsHandler)
+s.HandleFunc("/products/{key}", ProductHandler)
+s.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler)
+```
+
+The three URL paths we registered above will only be tested if the domain is `www.example.com`, because the subrouter is tested first. This is not only convenient, but also optimizes request matching. You can create subrouters combining any attribute matchers accepted by a route.
+
+Subrouters can be used to create domain or path "namespaces": you define subrouters in a central place and then parts of the app can register its paths relatively to a given subrouter.
+
+There's one more thing about subroutes. When a subrouter has a path prefix, the inner routes use it as base for their paths:
+
+```go
+r := mux.NewRouter()
+s := r.PathPrefix("/products").Subrouter()
+// "/products/"
+s.HandleFunc("/", ProductsHandler)
+// "/products/{key}/"
+s.HandleFunc("/{key}/", ProductHandler)
+// "/products/{key}/details"
+s.HandleFunc("/{key}/details", ProductDetailsHandler)
+```
+
+
+### Static Files
+
+Note that the path provided to `PathPrefix()` represents a "wildcard": calling
+`PathPrefix("/static/").Handler(...)` means that the handler will be passed any
+request that matches "/static/\*". This makes it easy to serve static files with mux:
+
+```go
+func main() {
+    var dir string
+
+    flag.StringVar(&dir, "dir", ".", "the directory to serve files from. Defaults to the current dir")
+    flag.Parse()
+    r := mux.NewRouter()
+
+    // This will serve files under http://localhost:8000/static/<filename>
+    r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(dir))))
+
+    srv := &http.Server{
+        Handler:      r,
+        Addr:         "127.0.0.1:8000",
+        // Good practice: enforce timeouts for servers you create!
+        WriteTimeout: 15 * time.Second,
+        ReadTimeout:  15 * time.Second,
+    }
+
+    log.Fatal(srv.ListenAndServe())
+}
+```
+
+### Serving Single Page Applications
+
+Most of the time it makes sense to serve your SPA on a separate web server from your API,
+but sometimes it's desirable to serve them both from one place. It's possible to write a simple
+handler for serving your SPA (for use with React Router's [BrowserRouter](https://reacttraining.com/react-router/web/api/BrowserRouter) for example), and leverage
+mux's powerful routing for your API endpoints.
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// spaHandler implements the http.Handler interface, so we can use it
+// to respond to HTTP requests. The path to the static directory and
+// path to the index file within that static directory are used to
+// serve the SPA in the given static directory.
+type spaHandler struct {
+	staticPath string
+	indexPath  string
+}
+
+// ServeHTTP inspects the URL path to locate a file within the static dir
+// on the SPA handler. If a file is found, it will be served. If not, the
+// file located at the index path on the SPA handler will be served. This
+// is suitable behavior for serving an SPA (single page application).
+func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    // get the absolute path to prevent directory traversal
+	path, err := filepath.Abs(r.URL.Path)
+	if err != nil {
+        // if we failed to get the absolute path respond with a 400 bad request
+        // and stop
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+    // prepend the path with the path to the static directory
+	path = filepath.Join(h.staticPath, path)
+
+    // check whether a file exists at the given path
+	_, err = os.Stat(path)
+	if os.IsNotExist(err) {
+		// file does not exist, serve index.html
+		http.ServeFile(w, r, filepath.Join(h.staticPath, h.indexPath))
+		return
+	} else if err != nil {
+        // if we got an error (that wasn't that the file doesn't exist) stating the
+        // file, return a 500 internal server error and stop
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+    // otherwise, use http.FileServer to serve the static dir
+	http.FileServer(http.Dir(h.staticPath)).ServeHTTP(w, r)
+}
+
+func main() {
+	router := mux.NewRouter()
+
+	router.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
+		// an example API handler
+		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	})
+
+	spa := spaHandler{staticPath: "build", indexPath: "index.html"}
+	router.PathPrefix("/").Handler(spa)
+
+	srv := &http.Server{
+		Handler: router,
+		Addr:    "127.0.0.1:8000",
+		// Good practice: enforce timeouts for servers you create!
+		WriteTimeout: 15 * time.Second,
+		ReadTimeout:  15 * time.Second,
+	}
+
+	log.Fatal(srv.ListenAndServe())
+}
+```
+
+### Registered URLs
+
+Now let's see how to build registered URLs.
+
+Routes can be named. All routes that define a name can have their URLs built, or "reversed". We define a name calling `Name()` on a route. For example:
+
+```go
+r := mux.NewRouter()
+r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler).
+  Name("article")
+```
+
+To build a URL, get the route and call the `URL()` method, passing a sequence of key/value pairs for the route variables. For the previous route, we would do:
+
+```go
+url, err := r.Get("article").URL("category", "technology", "id", "42")
+```
+
+...and the result will be a `url.URL` with the following path:
+
+```
+"/articles/technology/42"
+```
+
+This also works for host and query value variables:
+
+```go
+r := mux.NewRouter()
+r.Host("{subdomain}.example.com").
+  Path("/articles/{category}/{id:[0-9]+}").
+  Queries("filter", "{filter}").
+  HandlerFunc(ArticleHandler).
+  Name("article")
+
+// url.String() will be "http://news.example.com/articles/technology/42?filter=gorilla"
+url, err := r.Get("article").URL("subdomain", "news",
+                                 "category", "technology",
+                                 "id", "42",
+                                 "filter", "gorilla")
+```
+
+All variables defined in the route are required, and their values must conform to the corresponding patterns. These requirements guarantee that a generated URL will always match a registered route -- the only exception is for explicitly defined "build-only" routes which never match.
+
+Regex support also exists for matching Headers within a route. For example, we could do:
+
+```go
+r.HeadersRegexp("Content-Type", "application/(text|json)")
+```
+
+...and the route will match both requests with a Content-Type of `application/json` as well as `application/text`
+
+There's also a way to build only the URL host or path for a route: use the methods `URLHost()` or `URLPath()` instead. For the previous route, we would do:
+
+```go
+// "http://news.example.com/"
+host, err := r.Get("article").URLHost("subdomain", "news")
+
+// "/articles/technology/42"
+path, err := r.Get("article").URLPath("category", "technology", "id", "42")
+```
+
+And if you use subrouters, host and path defined separately can be built as well:
+
+```go
+r := mux.NewRouter()
+s := r.Host("{subdomain}.example.com").Subrouter()
+s.Path("/articles/{category}/{id:[0-9]+}").
+  HandlerFunc(ArticleHandler).
+  Name("article")
+
+// "http://news.example.com/articles/technology/42"
+url, err := r.Get("article").URL("subdomain", "news",
+                                 "category", "technology",
+                                 "id", "42")
+```
+
+### Walking Routes
+
+The `Walk` function on `mux.Router` can be used to visit all of the routes that are registered on a router. For example,
+the following prints all of the registered routes:
+
+```go
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	return
+}
+
+func main() {
+	r := mux.NewRouter()
+	r.HandleFunc("/", handler)
+	r.HandleFunc("/products", handler).Methods("POST")
+	r.HandleFunc("/articles", handler).Methods("GET")
+	r.HandleFunc("/articles/{id}", handler).Methods("GET", "PUT")
+	r.HandleFunc("/authors", handler).Queries("surname", "{surname}")
+	err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		pathTemplate, err := route.GetPathTemplate()
+		if err == nil {
+			fmt.Println("ROUTE:", pathTemplate)
+		}
+		pathRegexp, err := route.GetPathRegexp()
+		if err == nil {
+			fmt.Println("Path regexp:", pathRegexp)
+		}
+		queriesTemplates, err := route.GetQueriesTemplates()
+		if err == nil {
+			fmt.Println("Queries templates:", strings.Join(queriesTemplates, ","))
+		}
+		queriesRegexps, err := route.GetQueriesRegexp()
+		if err == nil {
+			fmt.Println("Queries regexps:", strings.Join(queriesRegexps, ","))
+		}
+		methods, err := route.GetMethods()
+		if err == nil {
+			fmt.Println("Methods:", strings.Join(methods, ","))
+		}
+		fmt.Println()
+		return nil
+	})
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	http.Handle("/", r)
+}
+```
+
+### Graceful Shutdown
+
+Go 1.8 introduced the ability to [gracefully shutdown](https://golang.org/doc/go1.8#http_shutdown) a `*http.Server`. Here's how to do that alongside `mux`:
+
+```go
+package main
+
+import (
+    "context"
+    "flag"
+    "log"
+    "net/http"
+    "os"
+    "os/signal"
+    "time"
+
+    "github.com/gorilla/mux"
+)
+
+func main() {
+    var wait time.Duration
+    flag.DurationVar(&wait, "graceful-timeout", time.Second * 15, "the duration for which the server gracefully wait for existing connections to finish - e.g. 15s or 1m")
+    flag.Parse()
+
+    r := mux.NewRouter()
+    // Add your routes as needed
+
+    srv := &http.Server{
+        Addr:         "0.0.0.0:8080",
+        // Good practice to set timeouts to avoid Slowloris attacks.
+        WriteTimeout: time.Second * 15,
+        ReadTimeout:  time.Second * 15,
+        IdleTimeout:  time.Second * 60,
+        Handler: r, // Pass our instance of gorilla/mux in.
+    }
+
+    // Run our server in a goroutine so that it doesn't block.
+    go func() {
+        if err := srv.ListenAndServe(); err != nil {
+            log.Println(err)
+        }
+    }()
+
+    c := make(chan os.Signal, 1)
+    // We'll accept graceful shutdowns when quit via SIGINT (Ctrl+C)
+    // SIGKILL, SIGQUIT or SIGTERM (Ctrl+/) will not be caught.
+    signal.Notify(c, os.Interrupt)
+
+    // Block until we receive our signal.
+    <-c
+
+    // Create a deadline to wait for.
+    ctx, cancel := context.WithTimeout(context.Background(), wait)
+    defer cancel()
+    // Doesn't block if no connections, but will otherwise wait
+    // until the timeout deadline.
+    srv.Shutdown(ctx)
+    // Optionally, you could run srv.Shutdown in a goroutine and block on
+    // <-ctx.Done() if your application should wait for other services
+    // to finalize based on context cancellation.
+    log.Println("shutting down")
+    os.Exit(0)
+}
+```
+
+### Middleware
+
+Mux supports the addition of middlewares to a [Router](https://godoc.org/github.com/gorilla/mux#Router), which are executed in the order they are added if a match is found, including its subrouters.
+Middlewares are (typically) small pieces of code which take one request, do something with it, and pass it down to another middleware or the final handler. Some common use cases for middleware are request logging, header manipulation, or `ResponseWriter` hijacking.
+
+Mux middlewares are defined using the de facto standard type:
+
+```go
+type MiddlewareFunc func(http.Handler) http.Handler
+```
+
+Typically, the returned handler is a closure which does something with the http.ResponseWriter and http.Request passed to it, and then calls the handler passed as parameter to the MiddlewareFunc. This takes advantage of closures being able access variables from the context where they are created, while retaining the signature enforced by the receivers.
+
+A very basic middleware which logs the URI of the request being handled could be written as:
+
+```go
+func loggingMiddleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        // Do stuff here
+        log.Println(r.RequestURI)
+        // Call the next handler, which can be another middleware in the chain, or the final handler.
+        next.ServeHTTP(w, r)
+    })
+}
+```
+
+Middlewares can be added to a router using `Router.Use()`:
+
+```go
+r := mux.NewRouter()
+r.HandleFunc("/", handler)
+r.Use(loggingMiddleware)
+```
+
+A more complex authentication middleware, which maps session token to users, could be written as:
+
+```go
+// Define our struct
+type authenticationMiddleware struct {
+	tokenUsers map[string]string
+}
+
+// Initialize it somewhere
+func (amw *authenticationMiddleware) Populate() {
+	amw.tokenUsers["00000000"] = "user0"
+	amw.tokenUsers["aaaaaaaa"] = "userA"
+	amw.tokenUsers["05f717e5"] = "randomUser"
+	amw.tokenUsers["deadbeef"] = "user0"
+}
+
+// Middleware function, which will be called for each request
+func (amw *authenticationMiddleware) Middleware(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        token := r.Header.Get("X-Session-Token")
+
+        if user, found := amw.tokenUsers[token]; found {
+        	// We found the token in our map
+        	log.Printf("Authenticated user %s\n", user)
+        	// Pass down the request to the next middleware (or final handler)
+        	next.ServeHTTP(w, r)
+        } else {
+        	// Write an error and stop the handler chain
+        	http.Error(w, "Forbidden", http.StatusForbidden)
+        }
+    })
+}
+```
+
+```go
+r := mux.NewRouter()
+r.HandleFunc("/", handler)
+
+amw := authenticationMiddleware{}
+amw.Populate()
+
+r.Use(amw.Middleware)
+```
+
+Note: The handler chain will be stopped if your middleware doesn't call `next.ServeHTTP()` with the corresponding parameters. This can be used to abort a request if the middleware writer wants to. Middlewares _should_ write to `ResponseWriter` if they _are_ going to terminate the request, and they _should not_ write to `ResponseWriter` if they _are not_ going to terminate it.
+
+### Handling CORS Requests
+
+[CORSMethodMiddleware](https://godoc.org/github.com/gorilla/mux#CORSMethodMiddleware) intends to make it easier to strictly set the `Access-Control-Allow-Methods` response header.
+
+* You will still need to use your own CORS handler to set the other CORS headers such as `Access-Control-Allow-Origin`
+* The middleware will set the `Access-Control-Allow-Methods` header to all the method matchers (e.g. `r.Methods(http.MethodGet, http.MethodPut, http.MethodOptions)` -> `Access-Control-Allow-Methods: GET,PUT,OPTIONS`) on a route
+* If you do not specify any methods, then:
+> _Important_: there must be an `OPTIONS` method matcher for the middleware to set the headers.
+
+Here is an example of using `CORSMethodMiddleware` along with a custom `OPTIONS` handler to set all the required CORS headers:
+
+```go
+package main
+
+import (
+	"net/http"
+	"github.com/gorilla/mux"
+)
+
+func main() {
+    r := mux.NewRouter()
+
+    // IMPORTANT: you must specify an OPTIONS method matcher for the middleware to set CORS headers
+    r.HandleFunc("/foo", fooHandler).Methods(http.MethodGet, http.MethodPut, http.MethodPatch, http.MethodOptions)
+    r.Use(mux.CORSMethodMiddleware(r))
+    
+    http.ListenAndServe(":8080", r)
+}
+
+func fooHandler(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Access-Control-Allow-Origin", "*")
+    if r.Method == http.MethodOptions {
+        return
+    }
+
+    w.Write([]byte("foo"))
+}
+```
+
+And an request to `/foo` using something like:
+
+```bash
+curl localhost:8080/foo -v
+```
+
+Would look like:
+
+```bash
+*   Trying ::1...
+* TCP_NODELAY set
+* Connected to localhost (::1) port 8080 (#0)
+> GET /foo HTTP/1.1
+> Host: localhost:8080
+> User-Agent: curl/7.59.0
+> Accept: */*
+> 
+< HTTP/1.1 200 OK
+< Access-Control-Allow-Methods: GET,PUT,PATCH,OPTIONS
+< Access-Control-Allow-Origin: *
+< Date: Fri, 28 Jun 2019 20:13:30 GMT
+< Content-Length: 3
+< Content-Type: text/plain; charset=utf-8
+< 
+* Connection #0 to host localhost left intact
+foo
+```
+
+### Testing Handlers
+
+Testing handlers in a Go web application is straightforward, and _mux_ doesn't complicate this any further. Given two files: `endpoints.go` and `endpoints_test.go`, here's how we'd test an application using _mux_.
+
+First, our simple HTTP handler:
+
+```go
+// endpoints.go
+package main
+
+func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
+    // A very simple health check.
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+
+    // In the future we could report back on the status of our DB, or our cache
+    // (e.g. Redis) by performing a simple PING, and include them in the response.
+    io.WriteString(w, `{"alive": true}`)
+}
+
+func main() {
+    r := mux.NewRouter()
+    r.HandleFunc("/health", HealthCheckHandler)
+
+    log.Fatal(http.ListenAndServe("localhost:8080", r))
+}
+```
+
+Our test code:
+
+```go
+// endpoints_test.go
+package main
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+)
+
+func TestHealthCheckHandler(t *testing.T) {
+    // Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+    // pass 'nil' as the third parameter.
+    req, err := http.NewRequest("GET", "/health", nil)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    // We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response.
+    rr := httptest.NewRecorder()
+    handler := http.HandlerFunc(HealthCheckHandler)
+
+    // Our handlers satisfy http.Handler, so we can call their ServeHTTP method
+    // directly and pass in our Request and ResponseRecorder.
+    handler.ServeHTTP(rr, req)
+
+    // Check the status code is what we expect.
+    if status := rr.Code; status != http.StatusOK {
+        t.Errorf("handler returned wrong status code: got %v want %v",
+            status, http.StatusOK)
+    }
+
+    // Check the response body is what we expect.
+    expected := `{"alive": true}`
+    if rr.Body.String() != expected {
+        t.Errorf("handler returned unexpected body: got %v want %v",
+            rr.Body.String(), expected)
+    }
+}
+```
+
+In the case that our routes have [variables](#examples), we can pass those in the request. We could write
+[table-driven tests](https://dave.cheney.net/2013/06/09/writing-table-driven-tests-in-go) to test multiple
+possible route variables as needed.
+
+```go
+// endpoints.go
+func main() {
+    r := mux.NewRouter()
+    // A route with a route variable:
+    r.HandleFunc("/metrics/{type}", MetricsHandler)
+
+    log.Fatal(http.ListenAndServe("localhost:8080", r))
+}
+```
+
+Our test file, with a table-driven test of `routeVariables`:
+
+```go
+// endpoints_test.go
+func TestMetricsHandler(t *testing.T) {
+    tt := []struct{
+        routeVariable string
+        shouldPass bool
+    }{
+        {"goroutines", true},
+        {"heap", true},
+        {"counters", true},
+        {"queries", true},
+        {"adhadaeqm3k", false},
+    }
+
+    for _, tc := range tt {
+        path := fmt.Sprintf("/metrics/%s", tc.routeVariable)
+        req, err := http.NewRequest("GET", path, nil)
+        if err != nil {
+            t.Fatal(err)
+        }
+
+        rr := httptest.NewRecorder()
+	
+	// Need to create a router that we can pass the request through so that the vars will be added to the context
+	router := mux.NewRouter()
+        router.HandleFunc("/metrics/{type}", MetricsHandler)
+        router.ServeHTTP(rr, req)
+
+        // In this case, our MetricsHandler returns a non-200 response
+        // for a route variable it doesn't know about.
+        if rr.Code == http.StatusOK && !tc.shouldPass {
+            t.Errorf("handler should have failed on routeVariable %s: got %v want %v",
+                tc.routeVariable, rr.Code, http.StatusOK)
+        }
+    }
+}
+```
+
+## Full Example
+
+Here's a complete, runnable example of a small `mux` based server:
+
+```go
+package main
+
+import (
+    "net/http"
+    "log"
+    "github.com/gorilla/mux"
+)
+
+func YourHandler(w http.ResponseWriter, r *http.Request) {
+    w.Write([]byte("Gorilla!\n"))
+}
+
+func main() {
+    r := mux.NewRouter()
+    // Routes consist of a path and a handler function.
+    r.HandleFunc("/", YourHandler)
+
+    // Bind to a port and pass our router in
+    log.Fatal(http.ListenAndServe(":8000", r))
+}
+```
+
+## License
+
+BSD licensed. See the LICENSE file for details.

--- a/vendor/github.com/gorilla/mux/doc.go
+++ b/vendor/github.com/gorilla/mux/doc.go
@@ -1,0 +1,306 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package mux implements a request router and dispatcher.
+
+The name mux stands for "HTTP request multiplexer". Like the standard
+http.ServeMux, mux.Router matches incoming requests against a list of
+registered routes and calls a handler for the route that matches the URL
+or other conditions. The main features are:
+
+	* Requests can be matched based on URL host, path, path prefix, schemes,
+	  header and query values, HTTP methods or using custom matchers.
+	* URL hosts, paths and query values can have variables with an optional
+	  regular expression.
+	* Registered URLs can be built, or "reversed", which helps maintaining
+	  references to resources.
+	* Routes can be used as subrouters: nested routes are only tested if the
+	  parent route matches. This is useful to define groups of routes that
+	  share common conditions like a host, a path prefix or other repeated
+	  attributes. As a bonus, this optimizes request matching.
+	* It implements the http.Handler interface so it is compatible with the
+	  standard http.ServeMux.
+
+Let's start registering a couple of URL paths and handlers:
+
+	func main() {
+		r := mux.NewRouter()
+		r.HandleFunc("/", HomeHandler)
+		r.HandleFunc("/products", ProductsHandler)
+		r.HandleFunc("/articles", ArticlesHandler)
+		http.Handle("/", r)
+	}
+
+Here we register three routes mapping URL paths to handlers. This is
+equivalent to how http.HandleFunc() works: if an incoming request URL matches
+one of the paths, the corresponding handler is called passing
+(http.ResponseWriter, *http.Request) as parameters.
+
+Paths can have variables. They are defined using the format {name} or
+{name:pattern}. If a regular expression pattern is not defined, the matched
+variable will be anything until the next slash. For example:
+
+	r := mux.NewRouter()
+	r.HandleFunc("/products/{key}", ProductHandler)
+	r.HandleFunc("/articles/{category}/", ArticlesCategoryHandler)
+	r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler)
+
+Groups can be used inside patterns, as long as they are non-capturing (?:re). For example:
+
+	r.HandleFunc("/articles/{category}/{sort:(?:asc|desc|new)}", ArticlesCategoryHandler)
+
+The names are used to create a map of route variables which can be retrieved
+calling mux.Vars():
+
+	vars := mux.Vars(request)
+	category := vars["category"]
+
+Note that if any capturing groups are present, mux will panic() during parsing. To prevent
+this, convert any capturing groups to non-capturing, e.g. change "/{sort:(asc|desc)}" to
+"/{sort:(?:asc|desc)}". This is a change from prior versions which behaved unpredictably
+when capturing groups were present.
+
+And this is all you need to know about the basic usage. More advanced options
+are explained below.
+
+Routes can also be restricted to a domain or subdomain. Just define a host
+pattern to be matched. They can also have variables:
+
+	r := mux.NewRouter()
+	// Only matches if domain is "www.example.com".
+	r.Host("www.example.com")
+	// Matches a dynamic subdomain.
+	r.Host("{subdomain:[a-z]+}.domain.com")
+
+There are several other matchers that can be added. To match path prefixes:
+
+	r.PathPrefix("/products/")
+
+...or HTTP methods:
+
+	r.Methods("GET", "POST")
+
+...or URL schemes:
+
+	r.Schemes("https")
+
+...or header values:
+
+	r.Headers("X-Requested-With", "XMLHttpRequest")
+
+...or query values:
+
+	r.Queries("key", "value")
+
+...or to use a custom matcher function:
+
+	r.MatcherFunc(func(r *http.Request, rm *RouteMatch) bool {
+		return r.ProtoMajor == 0
+	})
+
+...and finally, it is possible to combine several matchers in a single route:
+
+	r.HandleFunc("/products", ProductsHandler).
+	  Host("www.example.com").
+	  Methods("GET").
+	  Schemes("http")
+
+Setting the same matching conditions again and again can be boring, so we have
+a way to group several routes that share the same requirements.
+We call it "subrouting".
+
+For example, let's say we have several URLs that should only match when the
+host is "www.example.com". Create a route for that host and get a "subrouter"
+from it:
+
+	r := mux.NewRouter()
+	s := r.Host("www.example.com").Subrouter()
+
+Then register routes in the subrouter:
+
+	s.HandleFunc("/products/", ProductsHandler)
+	s.HandleFunc("/products/{key}", ProductHandler)
+	s.HandleFunc("/articles/{category}/{id:[0-9]+}"), ArticleHandler)
+
+The three URL paths we registered above will only be tested if the domain is
+"www.example.com", because the subrouter is tested first. This is not
+only convenient, but also optimizes request matching. You can create
+subrouters combining any attribute matchers accepted by a route.
+
+Subrouters can be used to create domain or path "namespaces": you define
+subrouters in a central place and then parts of the app can register its
+paths relatively to a given subrouter.
+
+There's one more thing about subroutes. When a subrouter has a path prefix,
+the inner routes use it as base for their paths:
+
+	r := mux.NewRouter()
+	s := r.PathPrefix("/products").Subrouter()
+	// "/products/"
+	s.HandleFunc("/", ProductsHandler)
+	// "/products/{key}/"
+	s.HandleFunc("/{key}/", ProductHandler)
+	// "/products/{key}/details"
+	s.HandleFunc("/{key}/details", ProductDetailsHandler)
+
+Note that the path provided to PathPrefix() represents a "wildcard": calling
+PathPrefix("/static/").Handler(...) means that the handler will be passed any
+request that matches "/static/*". This makes it easy to serve static files with mux:
+
+	func main() {
+		var dir string
+
+		flag.StringVar(&dir, "dir", ".", "the directory to serve files from. Defaults to the current dir")
+		flag.Parse()
+		r := mux.NewRouter()
+
+		// This will serve files under http://localhost:8000/static/<filename>
+		r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir(dir))))
+
+		srv := &http.Server{
+			Handler:      r,
+			Addr:         "127.0.0.1:8000",
+			// Good practice: enforce timeouts for servers you create!
+			WriteTimeout: 15 * time.Second,
+			ReadTimeout:  15 * time.Second,
+		}
+
+		log.Fatal(srv.ListenAndServe())
+	}
+
+Now let's see how to build registered URLs.
+
+Routes can be named. All routes that define a name can have their URLs built,
+or "reversed". We define a name calling Name() on a route. For example:
+
+	r := mux.NewRouter()
+	r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler).
+	  Name("article")
+
+To build a URL, get the route and call the URL() method, passing a sequence of
+key/value pairs for the route variables. For the previous route, we would do:
+
+	url, err := r.Get("article").URL("category", "technology", "id", "42")
+
+...and the result will be a url.URL with the following path:
+
+	"/articles/technology/42"
+
+This also works for host and query value variables:
+
+	r := mux.NewRouter()
+	r.Host("{subdomain}.domain.com").
+	  Path("/articles/{category}/{id:[0-9]+}").
+	  Queries("filter", "{filter}").
+	  HandlerFunc(ArticleHandler).
+	  Name("article")
+
+	// url.String() will be "http://news.domain.com/articles/technology/42?filter=gorilla"
+	url, err := r.Get("article").URL("subdomain", "news",
+	                                 "category", "technology",
+	                                 "id", "42",
+	                                 "filter", "gorilla")
+
+All variables defined in the route are required, and their values must
+conform to the corresponding patterns. These requirements guarantee that a
+generated URL will always match a registered route -- the only exception is
+for explicitly defined "build-only" routes which never match.
+
+Regex support also exists for matching Headers within a route. For example, we could do:
+
+	r.HeadersRegexp("Content-Type", "application/(text|json)")
+
+...and the route will match both requests with a Content-Type of `application/json` as well as
+`application/text`
+
+There's also a way to build only the URL host or path for a route:
+use the methods URLHost() or URLPath() instead. For the previous route,
+we would do:
+
+	// "http://news.domain.com/"
+	host, err := r.Get("article").URLHost("subdomain", "news")
+
+	// "/articles/technology/42"
+	path, err := r.Get("article").URLPath("category", "technology", "id", "42")
+
+And if you use subrouters, host and path defined separately can be built
+as well:
+
+	r := mux.NewRouter()
+	s := r.Host("{subdomain}.domain.com").Subrouter()
+	s.Path("/articles/{category}/{id:[0-9]+}").
+	  HandlerFunc(ArticleHandler).
+	  Name("article")
+
+	// "http://news.domain.com/articles/technology/42"
+	url, err := r.Get("article").URL("subdomain", "news",
+	                                 "category", "technology",
+	                                 "id", "42")
+
+Mux supports the addition of middlewares to a Router, which are executed in the order they are added if a match is found, including its subrouters. Middlewares are (typically) small pieces of code which take one request, do something with it, and pass it down to another middleware or the final handler. Some common use cases for middleware are request logging, header manipulation, or ResponseWriter hijacking.
+
+	type MiddlewareFunc func(http.Handler) http.Handler
+
+Typically, the returned handler is a closure which does something with the http.ResponseWriter and http.Request passed to it, and then calls the handler passed as parameter to the MiddlewareFunc (closures can access variables from the context where they are created).
+
+A very basic middleware which logs the URI of the request being handled could be written as:
+
+	func simpleMw(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Do stuff here
+			log.Println(r.RequestURI)
+			// Call the next handler, which can be another middleware in the chain, or the final handler.
+			next.ServeHTTP(w, r)
+		})
+	}
+
+Middlewares can be added to a router using `Router.Use()`:
+
+	r := mux.NewRouter()
+	r.HandleFunc("/", handler)
+	r.Use(simpleMw)
+
+A more complex authentication middleware, which maps session token to users, could be written as:
+
+	// Define our struct
+	type authenticationMiddleware struct {
+		tokenUsers map[string]string
+	}
+
+	// Initialize it somewhere
+	func (amw *authenticationMiddleware) Populate() {
+		amw.tokenUsers["00000000"] = "user0"
+		amw.tokenUsers["aaaaaaaa"] = "userA"
+		amw.tokenUsers["05f717e5"] = "randomUser"
+		amw.tokenUsers["deadbeef"] = "user0"
+	}
+
+	// Middleware function, which will be called for each request
+	func (amw *authenticationMiddleware) Middleware(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := r.Header.Get("X-Session-Token")
+
+			if user, found := amw.tokenUsers[token]; found {
+				// We found the token in our map
+				log.Printf("Authenticated user %s\n", user)
+				next.ServeHTTP(w, r)
+			} else {
+				http.Error(w, "Forbidden", http.StatusForbidden)
+			}
+		})
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/", handler)
+
+	amw := authenticationMiddleware{tokenUsers: make(map[string]string)}
+	amw.Populate()
+
+	r.Use(amw.Middleware)
+
+Note: The handler chain will be stopped if your middleware doesn't call `next.ServeHTTP()` with the corresponding parameters. This can be used to abort a request if the middleware writer wants to.
+
+*/
+package mux

--- a/vendor/github.com/gorilla/mux/go.mod
+++ b/vendor/github.com/gorilla/mux/go.mod
@@ -1,0 +1,3 @@
+module github.com/gorilla/mux
+
+go 1.12

--- a/vendor/github.com/gorilla/mux/middleware.go
+++ b/vendor/github.com/gorilla/mux/middleware.go
@@ -1,0 +1,74 @@
+package mux
+
+import (
+	"net/http"
+	"strings"
+)
+
+// MiddlewareFunc is a function which receives an http.Handler and returns another http.Handler.
+// Typically, the returned handler is a closure which does something with the http.ResponseWriter and http.Request passed
+// to it, and then calls the handler passed as parameter to the MiddlewareFunc.
+type MiddlewareFunc func(http.Handler) http.Handler
+
+// middleware interface is anything which implements a MiddlewareFunc named Middleware.
+type middleware interface {
+	Middleware(handler http.Handler) http.Handler
+}
+
+// Middleware allows MiddlewareFunc to implement the middleware interface.
+func (mw MiddlewareFunc) Middleware(handler http.Handler) http.Handler {
+	return mw(handler)
+}
+
+// Use appends a MiddlewareFunc to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Router.
+func (r *Router) Use(mwf ...MiddlewareFunc) {
+	for _, fn := range mwf {
+		r.middlewares = append(r.middlewares, fn)
+	}
+}
+
+// useInterface appends a middleware to the chain. Middleware can be used to intercept or otherwise modify requests and/or responses, and are executed in the order that they are applied to the Router.
+func (r *Router) useInterface(mw middleware) {
+	r.middlewares = append(r.middlewares, mw)
+}
+
+// CORSMethodMiddleware automatically sets the Access-Control-Allow-Methods response header
+// on requests for routes that have an OPTIONS method matcher to all the method matchers on
+// the route. Routes that do not explicitly handle OPTIONS requests will not be processed
+// by the middleware. See examples for usage.
+func CORSMethodMiddleware(r *Router) MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			allMethods, err := getAllMethodsForRoute(r, req)
+			if err == nil {
+				for _, v := range allMethods {
+					if v == http.MethodOptions {
+						w.Header().Set("Access-Control-Allow-Methods", strings.Join(allMethods, ","))
+					}
+				}
+			}
+
+			next.ServeHTTP(w, req)
+		})
+	}
+}
+
+// getAllMethodsForRoute returns all the methods from method matchers matching a given
+// request.
+func getAllMethodsForRoute(r *Router, req *http.Request) ([]string, error) {
+	var allMethods []string
+
+	for _, route := range r.routes {
+		var match RouteMatch
+		if route.Match(req, &match) || match.MatchErr == ErrMethodMismatch {
+			methods, err := route.GetMethods()
+			if err != nil {
+				return nil, err
+			}
+
+			allMethods = append(allMethods, methods...)
+		}
+	}
+
+	return allMethods, nil
+}

--- a/vendor/github.com/gorilla/mux/mux.go
+++ b/vendor/github.com/gorilla/mux/mux.go
@@ -1,0 +1,606 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+	"regexp"
+)
+
+var (
+	// ErrMethodMismatch is returned when the method in the request does not match
+	// the method defined against the route.
+	ErrMethodMismatch = errors.New("method is not allowed")
+	// ErrNotFound is returned when no route match is found.
+	ErrNotFound = errors.New("no matching route was found")
+)
+
+// NewRouter returns a new router instance.
+func NewRouter() *Router {
+	return &Router{namedRoutes: make(map[string]*Route)}
+}
+
+// Router registers routes to be matched and dispatches a handler.
+//
+// It implements the http.Handler interface, so it can be registered to serve
+// requests:
+//
+//     var router = mux.NewRouter()
+//
+//     func main() {
+//         http.Handle("/", router)
+//     }
+//
+// Or, for Google App Engine, register it in a init() function:
+//
+//     func init() {
+//         http.Handle("/", router)
+//     }
+//
+// This will send all incoming requests to the router.
+type Router struct {
+	// Configurable Handler to be used when no route matches.
+	NotFoundHandler http.Handler
+
+	// Configurable Handler to be used when the request method does not match the route.
+	MethodNotAllowedHandler http.Handler
+
+	// Routes to be matched, in order.
+	routes []*Route
+
+	// Routes by name for URL building.
+	namedRoutes map[string]*Route
+
+	// If true, do not clear the request context after handling the request.
+	//
+	// Deprecated: No effect, since the context is stored on the request itself.
+	KeepContext bool
+
+	// Slice of middlewares to be called after a match is found
+	middlewares []middleware
+
+	// configuration shared with `Route`
+	routeConf
+}
+
+// common route configuration shared between `Router` and `Route`
+type routeConf struct {
+	// If true, "/path/foo%2Fbar/to" will match the path "/path/{var}/to"
+	useEncodedPath bool
+
+	// If true, when the path pattern is "/path/", accessing "/path" will
+	// redirect to the former and vice versa.
+	strictSlash bool
+
+	// If true, when the path pattern is "/path//to", accessing "/path//to"
+	// will not redirect
+	skipClean bool
+
+	// Manager for the variables from host and path.
+	regexp routeRegexpGroup
+
+	// List of matchers.
+	matchers []matcher
+
+	// The scheme used when building URLs.
+	buildScheme string
+
+	buildVarsFunc BuildVarsFunc
+}
+
+// returns an effective deep copy of `routeConf`
+func copyRouteConf(r routeConf) routeConf {
+	c := r
+
+	if r.regexp.path != nil {
+		c.regexp.path = copyRouteRegexp(r.regexp.path)
+	}
+
+	if r.regexp.host != nil {
+		c.regexp.host = copyRouteRegexp(r.regexp.host)
+	}
+
+	c.regexp.queries = make([]*routeRegexp, 0, len(r.regexp.queries))
+	for _, q := range r.regexp.queries {
+		c.regexp.queries = append(c.regexp.queries, copyRouteRegexp(q))
+	}
+
+	c.matchers = make([]matcher, len(r.matchers))
+	copy(c.matchers, r.matchers)
+
+	return c
+}
+
+func copyRouteRegexp(r *routeRegexp) *routeRegexp {
+	c := *r
+	return &c
+}
+
+// Match attempts to match the given request against the router's registered routes.
+//
+// If the request matches a route of this router or one of its subrouters the Route,
+// Handler, and Vars fields of the the match argument are filled and this function
+// returns true.
+//
+// If the request does not match any of this router's or its subrouters' routes
+// then this function returns false. If available, a reason for the match failure
+// will be filled in the match argument's MatchErr field. If the match failure type
+// (eg: not found) has a registered handler, the handler is assigned to the Handler
+// field of the match argument.
+func (r *Router) Match(req *http.Request, match *RouteMatch) bool {
+	for _, route := range r.routes {
+		if route.Match(req, match) {
+			// Build middleware chain if no error was found
+			if match.MatchErr == nil {
+				for i := len(r.middlewares) - 1; i >= 0; i-- {
+					match.Handler = r.middlewares[i].Middleware(match.Handler)
+				}
+			}
+			return true
+		}
+	}
+
+	if match.MatchErr == ErrMethodMismatch {
+		if r.MethodNotAllowedHandler != nil {
+			match.Handler = r.MethodNotAllowedHandler
+			return true
+		}
+
+		return false
+	}
+
+	// Closest match for a router (includes sub-routers)
+	if r.NotFoundHandler != nil {
+		match.Handler = r.NotFoundHandler
+		match.MatchErr = ErrNotFound
+		return true
+	}
+
+	match.MatchErr = ErrNotFound
+	return false
+}
+
+// ServeHTTP dispatches the handler registered in the matched route.
+//
+// When there is a match, the route variables can be retrieved calling
+// mux.Vars(request).
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if !r.skipClean {
+		path := req.URL.Path
+		if r.useEncodedPath {
+			path = req.URL.EscapedPath()
+		}
+		// Clean path to canonical form and redirect.
+		if p := cleanPath(path); p != path {
+
+			// Added 3 lines (Philip Schlump) - It was dropping the query string and #whatever from query.
+			// This matches with fix in go 1.2 r.c. 4 for same problem.  Go Issue:
+			// http://code.google.com/p/go/issues/detail?id=5252
+			url := *req.URL
+			url.Path = p
+			p = url.String()
+
+			w.Header().Set("Location", p)
+			w.WriteHeader(http.StatusMovedPermanently)
+			return
+		}
+	}
+	var match RouteMatch
+	var handler http.Handler
+	if r.Match(req, &match) {
+		handler = match.Handler
+		req = requestWithVars(req, match.Vars)
+		req = requestWithRoute(req, match.Route)
+	}
+
+	if handler == nil && match.MatchErr == ErrMethodMismatch {
+		handler = methodNotAllowedHandler()
+	}
+
+	if handler == nil {
+		handler = http.NotFoundHandler()
+	}
+
+	handler.ServeHTTP(w, req)
+}
+
+// Get returns a route registered with the given name.
+func (r *Router) Get(name string) *Route {
+	return r.namedRoutes[name]
+}
+
+// GetRoute returns a route registered with the given name. This method
+// was renamed to Get() and remains here for backwards compatibility.
+func (r *Router) GetRoute(name string) *Route {
+	return r.namedRoutes[name]
+}
+
+// StrictSlash defines the trailing slash behavior for new routes. The initial
+// value is false.
+//
+// When true, if the route path is "/path/", accessing "/path" will perform a redirect
+// to the former and vice versa. In other words, your application will always
+// see the path as specified in the route.
+//
+// When false, if the route path is "/path", accessing "/path/" will not match
+// this route and vice versa.
+//
+// The re-direct is a HTTP 301 (Moved Permanently). Note that when this is set for
+// routes with a non-idempotent method (e.g. POST, PUT), the subsequent re-directed
+// request will be made as a GET by most clients. Use middleware or client settings
+// to modify this behaviour as needed.
+//
+// Special case: when a route sets a path prefix using the PathPrefix() method,
+// strict slash is ignored for that route because the redirect behavior can't
+// be determined from a prefix alone. However, any subrouters created from that
+// route inherit the original StrictSlash setting.
+func (r *Router) StrictSlash(value bool) *Router {
+	r.strictSlash = value
+	return r
+}
+
+// SkipClean defines the path cleaning behaviour for new routes. The initial
+// value is false. Users should be careful about which routes are not cleaned
+//
+// When true, if the route path is "/path//to", it will remain with the double
+// slash. This is helpful if you have a route like: /fetch/http://xkcd.com/534/
+//
+// When false, the path will be cleaned, so /fetch/http://xkcd.com/534/ will
+// become /fetch/http/xkcd.com/534
+func (r *Router) SkipClean(value bool) *Router {
+	r.skipClean = value
+	return r
+}
+
+// UseEncodedPath tells the router to match the encoded original path
+// to the routes.
+// For eg. "/path/foo%2Fbar/to" will match the path "/path/{var}/to".
+//
+// If not called, the router will match the unencoded path to the routes.
+// For eg. "/path/foo%2Fbar/to" will match the path "/path/foo/bar/to"
+func (r *Router) UseEncodedPath() *Router {
+	r.useEncodedPath = true
+	return r
+}
+
+// ----------------------------------------------------------------------------
+// Route factories
+// ----------------------------------------------------------------------------
+
+// NewRoute registers an empty route.
+func (r *Router) NewRoute() *Route {
+	// initialize a route with a copy of the parent router's configuration
+	route := &Route{routeConf: copyRouteConf(r.routeConf), namedRoutes: r.namedRoutes}
+	r.routes = append(r.routes, route)
+	return route
+}
+
+// Name registers a new route with a name.
+// See Route.Name().
+func (r *Router) Name(name string) *Route {
+	return r.NewRoute().Name(name)
+}
+
+// Handle registers a new route with a matcher for the URL path.
+// See Route.Path() and Route.Handler().
+func (r *Router) Handle(path string, handler http.Handler) *Route {
+	return r.NewRoute().Path(path).Handler(handler)
+}
+
+// HandleFunc registers a new route with a matcher for the URL path.
+// See Route.Path() and Route.HandlerFunc().
+func (r *Router) HandleFunc(path string, f func(http.ResponseWriter,
+	*http.Request)) *Route {
+	return r.NewRoute().Path(path).HandlerFunc(f)
+}
+
+// Headers registers a new route with a matcher for request header values.
+// See Route.Headers().
+func (r *Router) Headers(pairs ...string) *Route {
+	return r.NewRoute().Headers(pairs...)
+}
+
+// Host registers a new route with a matcher for the URL host.
+// See Route.Host().
+func (r *Router) Host(tpl string) *Route {
+	return r.NewRoute().Host(tpl)
+}
+
+// MatcherFunc registers a new route with a custom matcher function.
+// See Route.MatcherFunc().
+func (r *Router) MatcherFunc(f MatcherFunc) *Route {
+	return r.NewRoute().MatcherFunc(f)
+}
+
+// Methods registers a new route with a matcher for HTTP methods.
+// See Route.Methods().
+func (r *Router) Methods(methods ...string) *Route {
+	return r.NewRoute().Methods(methods...)
+}
+
+// Path registers a new route with a matcher for the URL path.
+// See Route.Path().
+func (r *Router) Path(tpl string) *Route {
+	return r.NewRoute().Path(tpl)
+}
+
+// PathPrefix registers a new route with a matcher for the URL path prefix.
+// See Route.PathPrefix().
+func (r *Router) PathPrefix(tpl string) *Route {
+	return r.NewRoute().PathPrefix(tpl)
+}
+
+// Queries registers a new route with a matcher for URL query values.
+// See Route.Queries().
+func (r *Router) Queries(pairs ...string) *Route {
+	return r.NewRoute().Queries(pairs...)
+}
+
+// Schemes registers a new route with a matcher for URL schemes.
+// See Route.Schemes().
+func (r *Router) Schemes(schemes ...string) *Route {
+	return r.NewRoute().Schemes(schemes...)
+}
+
+// BuildVarsFunc registers a new route with a custom function for modifying
+// route variables before building a URL.
+func (r *Router) BuildVarsFunc(f BuildVarsFunc) *Route {
+	return r.NewRoute().BuildVarsFunc(f)
+}
+
+// Walk walks the router and all its sub-routers, calling walkFn for each route
+// in the tree. The routes are walked in the order they were added. Sub-routers
+// are explored depth-first.
+func (r *Router) Walk(walkFn WalkFunc) error {
+	return r.walk(walkFn, []*Route{})
+}
+
+// SkipRouter is used as a return value from WalkFuncs to indicate that the
+// router that walk is about to descend down to should be skipped.
+var SkipRouter = errors.New("skip this router")
+
+// WalkFunc is the type of the function called for each route visited by Walk.
+// At every invocation, it is given the current route, and the current router,
+// and a list of ancestor routes that lead to the current route.
+type WalkFunc func(route *Route, router *Router, ancestors []*Route) error
+
+func (r *Router) walk(walkFn WalkFunc, ancestors []*Route) error {
+	for _, t := range r.routes {
+		err := walkFn(t, r, ancestors)
+		if err == SkipRouter {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		for _, sr := range t.matchers {
+			if h, ok := sr.(*Router); ok {
+				ancestors = append(ancestors, t)
+				err := h.walk(walkFn, ancestors)
+				if err != nil {
+					return err
+				}
+				ancestors = ancestors[:len(ancestors)-1]
+			}
+		}
+		if h, ok := t.handler.(*Router); ok {
+			ancestors = append(ancestors, t)
+			err := h.walk(walkFn, ancestors)
+			if err != nil {
+				return err
+			}
+			ancestors = ancestors[:len(ancestors)-1]
+		}
+	}
+	return nil
+}
+
+// ----------------------------------------------------------------------------
+// Context
+// ----------------------------------------------------------------------------
+
+// RouteMatch stores information about a matched route.
+type RouteMatch struct {
+	Route   *Route
+	Handler http.Handler
+	Vars    map[string]string
+
+	// MatchErr is set to appropriate matching error
+	// It is set to ErrMethodMismatch if there is a mismatch in
+	// the request method and route method
+	MatchErr error
+}
+
+type contextKey int
+
+const (
+	varsKey contextKey = iota
+	routeKey
+)
+
+// Vars returns the route variables for the current request, if any.
+func Vars(r *http.Request) map[string]string {
+	if rv := r.Context().Value(varsKey); rv != nil {
+		return rv.(map[string]string)
+	}
+	return nil
+}
+
+// CurrentRoute returns the matched route for the current request, if any.
+// This only works when called inside the handler of the matched route
+// because the matched route is stored in the request context which is cleared
+// after the handler returns.
+func CurrentRoute(r *http.Request) *Route {
+	if rv := r.Context().Value(routeKey); rv != nil {
+		return rv.(*Route)
+	}
+	return nil
+}
+
+func requestWithVars(r *http.Request, vars map[string]string) *http.Request {
+	ctx := context.WithValue(r.Context(), varsKey, vars)
+	return r.WithContext(ctx)
+}
+
+func requestWithRoute(r *http.Request, route *Route) *http.Request {
+	ctx := context.WithValue(r.Context(), routeKey, route)
+	return r.WithContext(ctx)
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+// cleanPath returns the canonical path for p, eliminating . and .. elements.
+// Borrowed from the net/http package.
+func cleanPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	np := path.Clean(p)
+	// path.Clean removes trailing slash except for root;
+	// put the trailing slash back if necessary.
+	if p[len(p)-1] == '/' && np != "/" {
+		np += "/"
+	}
+
+	return np
+}
+
+// uniqueVars returns an error if two slices contain duplicated strings.
+func uniqueVars(s1, s2 []string) error {
+	for _, v1 := range s1 {
+		for _, v2 := range s2 {
+			if v1 == v2 {
+				return fmt.Errorf("mux: duplicated route variable %q", v2)
+			}
+		}
+	}
+	return nil
+}
+
+// checkPairs returns the count of strings passed in, and an error if
+// the count is not an even number.
+func checkPairs(pairs ...string) (int, error) {
+	length := len(pairs)
+	if length%2 != 0 {
+		return length, fmt.Errorf(
+			"mux: number of parameters must be multiple of 2, got %v", pairs)
+	}
+	return length, nil
+}
+
+// mapFromPairsToString converts variadic string parameters to a
+// string to string map.
+func mapFromPairsToString(pairs ...string) (map[string]string, error) {
+	length, err := checkPairs(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]string, length/2)
+	for i := 0; i < length; i += 2 {
+		m[pairs[i]] = pairs[i+1]
+	}
+	return m, nil
+}
+
+// mapFromPairsToRegex converts variadic string parameters to a
+// string to regex map.
+func mapFromPairsToRegex(pairs ...string) (map[string]*regexp.Regexp, error) {
+	length, err := checkPairs(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]*regexp.Regexp, length/2)
+	for i := 0; i < length; i += 2 {
+		regex, err := regexp.Compile(pairs[i+1])
+		if err != nil {
+			return nil, err
+		}
+		m[pairs[i]] = regex
+	}
+	return m, nil
+}
+
+// matchInArray returns true if the given string value is in the array.
+func matchInArray(arr []string, value string) bool {
+	for _, v := range arr {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+// matchMapWithString returns true if the given key/value pairs exist in a given map.
+func matchMapWithString(toCheck map[string]string, toMatch map[string][]string, canonicalKey bool) bool {
+	for k, v := range toCheck {
+		// Check if key exists.
+		if canonicalKey {
+			k = http.CanonicalHeaderKey(k)
+		}
+		if values := toMatch[k]; values == nil {
+			return false
+		} else if v != "" {
+			// If value was defined as an empty string we only check that the
+			// key exists. Otherwise we also check for equality.
+			valueExists := false
+			for _, value := range values {
+				if v == value {
+					valueExists = true
+					break
+				}
+			}
+			if !valueExists {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// matchMapWithRegex returns true if the given key/value pairs exist in a given map compiled against
+// the given regex
+func matchMapWithRegex(toCheck map[string]*regexp.Regexp, toMatch map[string][]string, canonicalKey bool) bool {
+	for k, v := range toCheck {
+		// Check if key exists.
+		if canonicalKey {
+			k = http.CanonicalHeaderKey(k)
+		}
+		if values := toMatch[k]; values == nil {
+			return false
+		} else if v != nil {
+			// If value was defined as an empty string we only check that the
+			// key exists. Otherwise we also check for equality.
+			valueExists := false
+			for _, value := range values {
+				if v.MatchString(value) {
+					valueExists = true
+					break
+				}
+			}
+			if !valueExists {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// methodNotAllowed replies to the request with an HTTP status code 405.
+func methodNotAllowed(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusMethodNotAllowed)
+}
+
+// methodNotAllowedHandler returns a simple request handler
+// that replies to each request with a status code 405.
+func methodNotAllowedHandler() http.Handler { return http.HandlerFunc(methodNotAllowed) }

--- a/vendor/github.com/gorilla/mux/regexp.go
+++ b/vendor/github.com/gorilla/mux/regexp.go
@@ -1,0 +1,388 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mux
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type routeRegexpOptions struct {
+	strictSlash    bool
+	useEncodedPath bool
+}
+
+type regexpType int
+
+const (
+	regexpTypePath   regexpType = 0
+	regexpTypeHost   regexpType = 1
+	regexpTypePrefix regexpType = 2
+	regexpTypeQuery  regexpType = 3
+)
+
+// newRouteRegexp parses a route template and returns a routeRegexp,
+// used to match a host, a path or a query string.
+//
+// It will extract named variables, assemble a regexp to be matched, create
+// a "reverse" template to build URLs and compile regexps to validate variable
+// values used in URL building.
+//
+// Previously we accepted only Python-like identifiers for variable
+// names ([a-zA-Z_][a-zA-Z0-9_]*), but currently the only restriction is that
+// name and pattern can't be empty, and names can't contain a colon.
+func newRouteRegexp(tpl string, typ regexpType, options routeRegexpOptions) (*routeRegexp, error) {
+	// Check if it is well-formed.
+	idxs, errBraces := braceIndices(tpl)
+	if errBraces != nil {
+		return nil, errBraces
+	}
+	// Backup the original.
+	template := tpl
+	// Now let's parse it.
+	defaultPattern := "[^/]+"
+	if typ == regexpTypeQuery {
+		defaultPattern = ".*"
+	} else if typ == regexpTypeHost {
+		defaultPattern = "[^.]+"
+	}
+	// Only match strict slash if not matching
+	if typ != regexpTypePath {
+		options.strictSlash = false
+	}
+	// Set a flag for strictSlash.
+	endSlash := false
+	if options.strictSlash && strings.HasSuffix(tpl, "/") {
+		tpl = tpl[:len(tpl)-1]
+		endSlash = true
+	}
+	varsN := make([]string, len(idxs)/2)
+	varsR := make([]*regexp.Regexp, len(idxs)/2)
+	pattern := bytes.NewBufferString("")
+	pattern.WriteByte('^')
+	reverse := bytes.NewBufferString("")
+	var end int
+	var err error
+	for i := 0; i < len(idxs); i += 2 {
+		// Set all values we are interested in.
+		raw := tpl[end:idxs[i]]
+		end = idxs[i+1]
+		parts := strings.SplitN(tpl[idxs[i]+1:end-1], ":", 2)
+		name := parts[0]
+		patt := defaultPattern
+		if len(parts) == 2 {
+			patt = parts[1]
+		}
+		// Name or pattern can't be empty.
+		if name == "" || patt == "" {
+			return nil, fmt.Errorf("mux: missing name or pattern in %q",
+				tpl[idxs[i]:end])
+		}
+		// Build the regexp pattern.
+		fmt.Fprintf(pattern, "%s(?P<%s>%s)", regexp.QuoteMeta(raw), varGroupName(i/2), patt)
+
+		// Build the reverse template.
+		fmt.Fprintf(reverse, "%s%%s", raw)
+
+		// Append variable name and compiled pattern.
+		varsN[i/2] = name
+		varsR[i/2], err = regexp.Compile(fmt.Sprintf("^%s$", patt))
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Add the remaining.
+	raw := tpl[end:]
+	pattern.WriteString(regexp.QuoteMeta(raw))
+	if options.strictSlash {
+		pattern.WriteString("[/]?")
+	}
+	if typ == regexpTypeQuery {
+		// Add the default pattern if the query value is empty
+		if queryVal := strings.SplitN(template, "=", 2)[1]; queryVal == "" {
+			pattern.WriteString(defaultPattern)
+		}
+	}
+	if typ != regexpTypePrefix {
+		pattern.WriteByte('$')
+	}
+
+	var wildcardHostPort bool
+	if typ == regexpTypeHost {
+		if !strings.Contains(pattern.String(), ":") {
+			wildcardHostPort = true
+		}
+	}
+	reverse.WriteString(raw)
+	if endSlash {
+		reverse.WriteByte('/')
+	}
+	// Compile full regexp.
+	reg, errCompile := regexp.Compile(pattern.String())
+	if errCompile != nil {
+		return nil, errCompile
+	}
+
+	// Check for capturing groups which used to work in older versions
+	if reg.NumSubexp() != len(idxs)/2 {
+		panic(fmt.Sprintf("route %s contains capture groups in its regexp. ", template) +
+			"Only non-capturing groups are accepted: e.g. (?:pattern) instead of (pattern)")
+	}
+
+	// Done!
+	return &routeRegexp{
+		template:         template,
+		regexpType:       typ,
+		options:          options,
+		regexp:           reg,
+		reverse:          reverse.String(),
+		varsN:            varsN,
+		varsR:            varsR,
+		wildcardHostPort: wildcardHostPort,
+	}, nil
+}
+
+// routeRegexp stores a regexp to match a host or path and information to
+// collect and validate route variables.
+type routeRegexp struct {
+	// The unmodified template.
+	template string
+	// The type of match
+	regexpType regexpType
+	// Options for matching
+	options routeRegexpOptions
+	// Expanded regexp.
+	regexp *regexp.Regexp
+	// Reverse template.
+	reverse string
+	// Variable names.
+	varsN []string
+	// Variable regexps (validators).
+	varsR []*regexp.Regexp
+	// Wildcard host-port (no strict port match in hostname)
+	wildcardHostPort bool
+}
+
+// Match matches the regexp against the URL host or path.
+func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
+	if r.regexpType == regexpTypeHost {
+		host := getHost(req)
+		if r.wildcardHostPort {
+			// Don't be strict on the port match
+			if i := strings.Index(host, ":"); i != -1 {
+				host = host[:i]
+			}
+		}
+		return r.regexp.MatchString(host)
+	}
+
+	if r.regexpType == regexpTypeQuery {
+		return r.matchQueryString(req)
+	}
+	path := req.URL.Path
+	if r.options.useEncodedPath {
+		path = req.URL.EscapedPath()
+	}
+	return r.regexp.MatchString(path)
+}
+
+// url builds a URL part using the given values.
+func (r *routeRegexp) url(values map[string]string) (string, error) {
+	urlValues := make([]interface{}, len(r.varsN), len(r.varsN))
+	for k, v := range r.varsN {
+		value, ok := values[v]
+		if !ok {
+			return "", fmt.Errorf("mux: missing route variable %q", v)
+		}
+		if r.regexpType == regexpTypeQuery {
+			value = url.QueryEscape(value)
+		}
+		urlValues[k] = value
+	}
+	rv := fmt.Sprintf(r.reverse, urlValues...)
+	if !r.regexp.MatchString(rv) {
+		// The URL is checked against the full regexp, instead of checking
+		// individual variables. This is faster but to provide a good error
+		// message, we check individual regexps if the URL doesn't match.
+		for k, v := range r.varsN {
+			if !r.varsR[k].MatchString(values[v]) {
+				return "", fmt.Errorf(
+					"mux: variable %q doesn't match, expected %q", values[v],
+					r.varsR[k].String())
+			}
+		}
+	}
+	return rv, nil
+}
+
+// getURLQuery returns a single query parameter from a request URL.
+// For a URL with foo=bar&baz=ding, we return only the relevant key
+// value pair for the routeRegexp.
+func (r *routeRegexp) getURLQuery(req *http.Request) string {
+	if r.regexpType != regexpTypeQuery {
+		return ""
+	}
+	templateKey := strings.SplitN(r.template, "=", 2)[0]
+	val, ok := findFirstQueryKey(req.URL.RawQuery, templateKey)
+	if ok {
+		return templateKey + "=" + val
+	}
+	return ""
+}
+
+// findFirstQueryKey returns the same result as (*url.URL).Query()[key][0].
+// If key was not found, empty string and false is returned.
+func findFirstQueryKey(rawQuery, key string) (value string, ok bool) {
+	query := []byte(rawQuery)
+	for len(query) > 0 {
+		foundKey := query
+		if i := bytes.IndexAny(foundKey, "&;"); i >= 0 {
+			foundKey, query = foundKey[:i], foundKey[i+1:]
+		} else {
+			query = query[:0]
+		}
+		if len(foundKey) == 0 {
+			continue
+		}
+		var value []byte
+		if i := bytes.IndexByte(foundKey, '='); i >= 0 {
+			foundKey, value = foundKey[:i], foundKey[i+1:]
+		}
+		if len(foundKey) < len(key) {
+			// Cannot possibly be key.
+			continue
+		}
+		keyString, err := url.QueryUnescape(string(foundKey))
+		if err != nil {
+			continue
+		}
+		if keyString != key {
+			continue
+		}
+		valueString, err := url.QueryUnescape(string(value))
+		if err != nil {
+			continue
+		}
+		return valueString, true
+	}
+	return "", false
+}
+
+func (r *routeRegexp) matchQueryString(req *http.Request) bool {
+	return r.regexp.MatchString(r.getURLQuery(req))
+}
+
+// braceIndices returns the first level curly brace indices from a string.
+// It returns an error in case of unbalanced braces.
+func braceIndices(s string) ([]int, error) {
+	var level, idx int
+	var idxs []int
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			if level++; level == 1 {
+				idx = i
+			}
+		case '}':
+			if level--; level == 0 {
+				idxs = append(idxs, idx, i+1)
+			} else if level < 0 {
+				return nil, fmt.Errorf("mux: unbalanced braces in %q", s)
+			}
+		}
+	}
+	if level != 0 {
+		return nil, fmt.Errorf("mux: unbalanced braces in %q", s)
+	}
+	return idxs, nil
+}
+
+// varGroupName builds a capturing group name for the indexed variable.
+func varGroupName(idx int) string {
+	return "v" + strconv.Itoa(idx)
+}
+
+// ----------------------------------------------------------------------------
+// routeRegexpGroup
+// ----------------------------------------------------------------------------
+
+// routeRegexpGroup groups the route matchers that carry variables.
+type routeRegexpGroup struct {
+	host    *routeRegexp
+	path    *routeRegexp
+	queries []*routeRegexp
+}
+
+// setMatch extracts the variables from the URL once a route matches.
+func (v routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) {
+	// Store host variables.
+	if v.host != nil {
+		host := getHost(req)
+		if v.host.wildcardHostPort {
+			// Don't be strict on the port match
+			if i := strings.Index(host, ":"); i != -1 {
+				host = host[:i]
+			}
+		}
+		matches := v.host.regexp.FindStringSubmatchIndex(host)
+		if len(matches) > 0 {
+			extractVars(host, matches, v.host.varsN, m.Vars)
+		}
+	}
+	path := req.URL.Path
+	if r.useEncodedPath {
+		path = req.URL.EscapedPath()
+	}
+	// Store path variables.
+	if v.path != nil {
+		matches := v.path.regexp.FindStringSubmatchIndex(path)
+		if len(matches) > 0 {
+			extractVars(path, matches, v.path.varsN, m.Vars)
+			// Check if we should redirect.
+			if v.path.options.strictSlash {
+				p1 := strings.HasSuffix(path, "/")
+				p2 := strings.HasSuffix(v.path.template, "/")
+				if p1 != p2 {
+					u, _ := url.Parse(req.URL.String())
+					if p1 {
+						u.Path = u.Path[:len(u.Path)-1]
+					} else {
+						u.Path += "/"
+					}
+					m.Handler = http.RedirectHandler(u.String(), http.StatusMovedPermanently)
+				}
+			}
+		}
+	}
+	// Store query string variables.
+	for _, q := range v.queries {
+		queryURL := q.getURLQuery(req)
+		matches := q.regexp.FindStringSubmatchIndex(queryURL)
+		if len(matches) > 0 {
+			extractVars(queryURL, matches, q.varsN, m.Vars)
+		}
+	}
+}
+
+// getHost tries its best to return the request host.
+// According to section 14.23 of RFC 2616 the Host header
+// can include the port number if the default value of 80 is not used.
+func getHost(r *http.Request) string {
+	if r.URL.IsAbs() {
+		return r.URL.Host
+	}
+	return r.Host
+}
+
+func extractVars(input string, matches []int, names []string, output map[string]string) {
+	for i, name := range names {
+		output[name] = input[matches[2*i+2]:matches[2*i+3]]
+	}
+}

--- a/vendor/github.com/gorilla/mux/route.go
+++ b/vendor/github.com/gorilla/mux/route.go
@@ -1,0 +1,736 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mux
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// Route stores information to match a request and build URLs.
+type Route struct {
+	// Request handler for the route.
+	handler http.Handler
+	// If true, this route never matches: it is only used to build URLs.
+	buildOnly bool
+	// The name used to build URLs.
+	name string
+	// Error resulted from building a route.
+	err error
+
+	// "global" reference to all named routes
+	namedRoutes map[string]*Route
+
+	// config possibly passed in from `Router`
+	routeConf
+}
+
+// SkipClean reports whether path cleaning is enabled for this route via
+// Router.SkipClean.
+func (r *Route) SkipClean() bool {
+	return r.skipClean
+}
+
+// Match matches the route against the request.
+func (r *Route) Match(req *http.Request, match *RouteMatch) bool {
+	if r.buildOnly || r.err != nil {
+		return false
+	}
+
+	var matchErr error
+
+	// Match everything.
+	for _, m := range r.matchers {
+		if matched := m.Match(req, match); !matched {
+			if _, ok := m.(methodMatcher); ok {
+				matchErr = ErrMethodMismatch
+				continue
+			}
+
+			// Ignore ErrNotFound errors. These errors arise from match call
+			// to Subrouters.
+			//
+			// This prevents subsequent matching subrouters from failing to
+			// run middleware. If not ignored, the middleware would see a
+			// non-nil MatchErr and be skipped, even when there was a
+			// matching route.
+			if match.MatchErr == ErrNotFound {
+				match.MatchErr = nil
+			}
+
+			matchErr = nil
+			return false
+		}
+	}
+
+	if matchErr != nil {
+		match.MatchErr = matchErr
+		return false
+	}
+
+	if match.MatchErr == ErrMethodMismatch && r.handler != nil {
+		// We found a route which matches request method, clear MatchErr
+		match.MatchErr = nil
+		// Then override the mis-matched handler
+		match.Handler = r.handler
+	}
+
+	// Yay, we have a match. Let's collect some info about it.
+	if match.Route == nil {
+		match.Route = r
+	}
+	if match.Handler == nil {
+		match.Handler = r.handler
+	}
+	if match.Vars == nil {
+		match.Vars = make(map[string]string)
+	}
+
+	// Set variables.
+	r.regexp.setMatch(req, match, r)
+	return true
+}
+
+// ----------------------------------------------------------------------------
+// Route attributes
+// ----------------------------------------------------------------------------
+
+// GetError returns an error resulted from building the route, if any.
+func (r *Route) GetError() error {
+	return r.err
+}
+
+// BuildOnly sets the route to never match: it is only used to build URLs.
+func (r *Route) BuildOnly() *Route {
+	r.buildOnly = true
+	return r
+}
+
+// Handler --------------------------------------------------------------------
+
+// Handler sets a handler for the route.
+func (r *Route) Handler(handler http.Handler) *Route {
+	if r.err == nil {
+		r.handler = handler
+	}
+	return r
+}
+
+// HandlerFunc sets a handler function for the route.
+func (r *Route) HandlerFunc(f func(http.ResponseWriter, *http.Request)) *Route {
+	return r.Handler(http.HandlerFunc(f))
+}
+
+// GetHandler returns the handler for the route, if any.
+func (r *Route) GetHandler() http.Handler {
+	return r.handler
+}
+
+// Name -----------------------------------------------------------------------
+
+// Name sets the name for the route, used to build URLs.
+// It is an error to call Name more than once on a route.
+func (r *Route) Name(name string) *Route {
+	if r.name != "" {
+		r.err = fmt.Errorf("mux: route already has name %q, can't set %q",
+			r.name, name)
+	}
+	if r.err == nil {
+		r.name = name
+		r.namedRoutes[name] = r
+	}
+	return r
+}
+
+// GetName returns the name for the route, if any.
+func (r *Route) GetName() string {
+	return r.name
+}
+
+// ----------------------------------------------------------------------------
+// Matchers
+// ----------------------------------------------------------------------------
+
+// matcher types try to match a request.
+type matcher interface {
+	Match(*http.Request, *RouteMatch) bool
+}
+
+// addMatcher adds a matcher to the route.
+func (r *Route) addMatcher(m matcher) *Route {
+	if r.err == nil {
+		r.matchers = append(r.matchers, m)
+	}
+	return r
+}
+
+// addRegexpMatcher adds a host or path matcher and builder to a route.
+func (r *Route) addRegexpMatcher(tpl string, typ regexpType) error {
+	if r.err != nil {
+		return r.err
+	}
+	if typ == regexpTypePath || typ == regexpTypePrefix {
+		if len(tpl) > 0 && tpl[0] != '/' {
+			return fmt.Errorf("mux: path must start with a slash, got %q", tpl)
+		}
+		if r.regexp.path != nil {
+			tpl = strings.TrimRight(r.regexp.path.template, "/") + tpl
+		}
+	}
+	rr, err := newRouteRegexp(tpl, typ, routeRegexpOptions{
+		strictSlash:    r.strictSlash,
+		useEncodedPath: r.useEncodedPath,
+	})
+	if err != nil {
+		return err
+	}
+	for _, q := range r.regexp.queries {
+		if err = uniqueVars(rr.varsN, q.varsN); err != nil {
+			return err
+		}
+	}
+	if typ == regexpTypeHost {
+		if r.regexp.path != nil {
+			if err = uniqueVars(rr.varsN, r.regexp.path.varsN); err != nil {
+				return err
+			}
+		}
+		r.regexp.host = rr
+	} else {
+		if r.regexp.host != nil {
+			if err = uniqueVars(rr.varsN, r.regexp.host.varsN); err != nil {
+				return err
+			}
+		}
+		if typ == regexpTypeQuery {
+			r.regexp.queries = append(r.regexp.queries, rr)
+		} else {
+			r.regexp.path = rr
+		}
+	}
+	r.addMatcher(rr)
+	return nil
+}
+
+// Headers --------------------------------------------------------------------
+
+// headerMatcher matches the request against header values.
+type headerMatcher map[string]string
+
+func (m headerMatcher) Match(r *http.Request, match *RouteMatch) bool {
+	return matchMapWithString(m, r.Header, true)
+}
+
+// Headers adds a matcher for request header values.
+// It accepts a sequence of key/value pairs to be matched. For example:
+//
+//     r := mux.NewRouter()
+//     r.Headers("Content-Type", "application/json",
+//               "X-Requested-With", "XMLHttpRequest")
+//
+// The above route will only match if both request header values match.
+// If the value is an empty string, it will match any value if the key is set.
+func (r *Route) Headers(pairs ...string) *Route {
+	if r.err == nil {
+		var headers map[string]string
+		headers, r.err = mapFromPairsToString(pairs...)
+		return r.addMatcher(headerMatcher(headers))
+	}
+	return r
+}
+
+// headerRegexMatcher matches the request against the route given a regex for the header
+type headerRegexMatcher map[string]*regexp.Regexp
+
+func (m headerRegexMatcher) Match(r *http.Request, match *RouteMatch) bool {
+	return matchMapWithRegex(m, r.Header, true)
+}
+
+// HeadersRegexp accepts a sequence of key/value pairs, where the value has regex
+// support. For example:
+//
+//     r := mux.NewRouter()
+//     r.HeadersRegexp("Content-Type", "application/(text|json)",
+//               "X-Requested-With", "XMLHttpRequest")
+//
+// The above route will only match if both the request header matches both regular expressions.
+// If the value is an empty string, it will match any value if the key is set.
+// Use the start and end of string anchors (^ and $) to match an exact value.
+func (r *Route) HeadersRegexp(pairs ...string) *Route {
+	if r.err == nil {
+		var headers map[string]*regexp.Regexp
+		headers, r.err = mapFromPairsToRegex(pairs...)
+		return r.addMatcher(headerRegexMatcher(headers))
+	}
+	return r
+}
+
+// Host -----------------------------------------------------------------------
+
+// Host adds a matcher for the URL host.
+// It accepts a template with zero or more URL variables enclosed by {}.
+// Variables can define an optional regexp pattern to be matched:
+//
+// - {name} matches anything until the next dot.
+//
+// - {name:pattern} matches the given regexp pattern.
+//
+// For example:
+//
+//     r := mux.NewRouter()
+//     r.Host("www.example.com")
+//     r.Host("{subdomain}.domain.com")
+//     r.Host("{subdomain:[a-z]+}.domain.com")
+//
+// Variable names must be unique in a given route. They can be retrieved
+// calling mux.Vars(request).
+func (r *Route) Host(tpl string) *Route {
+	r.err = r.addRegexpMatcher(tpl, regexpTypeHost)
+	return r
+}
+
+// MatcherFunc ----------------------------------------------------------------
+
+// MatcherFunc is the function signature used by custom matchers.
+type MatcherFunc func(*http.Request, *RouteMatch) bool
+
+// Match returns the match for a given request.
+func (m MatcherFunc) Match(r *http.Request, match *RouteMatch) bool {
+	return m(r, match)
+}
+
+// MatcherFunc adds a custom function to be used as request matcher.
+func (r *Route) MatcherFunc(f MatcherFunc) *Route {
+	return r.addMatcher(f)
+}
+
+// Methods --------------------------------------------------------------------
+
+// methodMatcher matches the request against HTTP methods.
+type methodMatcher []string
+
+func (m methodMatcher) Match(r *http.Request, match *RouteMatch) bool {
+	return matchInArray(m, r.Method)
+}
+
+// Methods adds a matcher for HTTP methods.
+// It accepts a sequence of one or more methods to be matched, e.g.:
+// "GET", "POST", "PUT".
+func (r *Route) Methods(methods ...string) *Route {
+	for k, v := range methods {
+		methods[k] = strings.ToUpper(v)
+	}
+	return r.addMatcher(methodMatcher(methods))
+}
+
+// Path -----------------------------------------------------------------------
+
+// Path adds a matcher for the URL path.
+// It accepts a template with zero or more URL variables enclosed by {}. The
+// template must start with a "/".
+// Variables can define an optional regexp pattern to be matched:
+//
+// - {name} matches anything until the next slash.
+//
+// - {name:pattern} matches the given regexp pattern.
+//
+// For example:
+//
+//     r := mux.NewRouter()
+//     r.Path("/products/").Handler(ProductsHandler)
+//     r.Path("/products/{key}").Handler(ProductsHandler)
+//     r.Path("/articles/{category}/{id:[0-9]+}").
+//       Handler(ArticleHandler)
+//
+// Variable names must be unique in a given route. They can be retrieved
+// calling mux.Vars(request).
+func (r *Route) Path(tpl string) *Route {
+	r.err = r.addRegexpMatcher(tpl, regexpTypePath)
+	return r
+}
+
+// PathPrefix -----------------------------------------------------------------
+
+// PathPrefix adds a matcher for the URL path prefix. This matches if the given
+// template is a prefix of the full URL path. See Route.Path() for details on
+// the tpl argument.
+//
+// Note that it does not treat slashes specially ("/foobar/" will be matched by
+// the prefix "/foo") so you may want to use a trailing slash here.
+//
+// Also note that the setting of Router.StrictSlash() has no effect on routes
+// with a PathPrefix matcher.
+func (r *Route) PathPrefix(tpl string) *Route {
+	r.err = r.addRegexpMatcher(tpl, regexpTypePrefix)
+	return r
+}
+
+// Query ----------------------------------------------------------------------
+
+// Queries adds a matcher for URL query values.
+// It accepts a sequence of key/value pairs. Values may define variables.
+// For example:
+//
+//     r := mux.NewRouter()
+//     r.Queries("foo", "bar", "id", "{id:[0-9]+}")
+//
+// The above route will only match if the URL contains the defined queries
+// values, e.g.: ?foo=bar&id=42.
+//
+// If the value is an empty string, it will match any value if the key is set.
+//
+// Variables can define an optional regexp pattern to be matched:
+//
+// - {name} matches anything until the next slash.
+//
+// - {name:pattern} matches the given regexp pattern.
+func (r *Route) Queries(pairs ...string) *Route {
+	length := len(pairs)
+	if length%2 != 0 {
+		r.err = fmt.Errorf(
+			"mux: number of parameters must be multiple of 2, got %v", pairs)
+		return nil
+	}
+	for i := 0; i < length; i += 2 {
+		if r.err = r.addRegexpMatcher(pairs[i]+"="+pairs[i+1], regexpTypeQuery); r.err != nil {
+			return r
+		}
+	}
+
+	return r
+}
+
+// Schemes --------------------------------------------------------------------
+
+// schemeMatcher matches the request against URL schemes.
+type schemeMatcher []string
+
+func (m schemeMatcher) Match(r *http.Request, match *RouteMatch) bool {
+	scheme := r.URL.Scheme
+	// https://golang.org/pkg/net/http/#Request
+	// "For [most] server requests, fields other than Path and RawQuery will be
+	// empty."
+	// Since we're an http muxer, the scheme is either going to be http or https
+	// though, so we can just set it based on the tls termination state.
+	if scheme == "" {
+		if r.TLS == nil {
+			scheme = "http"
+		} else {
+			scheme = "https"
+		}
+	}
+	return matchInArray(m, scheme)
+}
+
+// Schemes adds a matcher for URL schemes.
+// It accepts a sequence of schemes to be matched, e.g.: "http", "https".
+// If the request's URL has a scheme set, it will be matched against.
+// Generally, the URL scheme will only be set if a previous handler set it,
+// such as the ProxyHeaders handler from gorilla/handlers.
+// If unset, the scheme will be determined based on the request's TLS
+// termination state.
+// The first argument to Schemes will be used when constructing a route URL.
+func (r *Route) Schemes(schemes ...string) *Route {
+	for k, v := range schemes {
+		schemes[k] = strings.ToLower(v)
+	}
+	if len(schemes) > 0 {
+		r.buildScheme = schemes[0]
+	}
+	return r.addMatcher(schemeMatcher(schemes))
+}
+
+// BuildVarsFunc --------------------------------------------------------------
+
+// BuildVarsFunc is the function signature used by custom build variable
+// functions (which can modify route variables before a route's URL is built).
+type BuildVarsFunc func(map[string]string) map[string]string
+
+// BuildVarsFunc adds a custom function to be used to modify build variables
+// before a route's URL is built.
+func (r *Route) BuildVarsFunc(f BuildVarsFunc) *Route {
+	if r.buildVarsFunc != nil {
+		// compose the old and new functions
+		old := r.buildVarsFunc
+		r.buildVarsFunc = func(m map[string]string) map[string]string {
+			return f(old(m))
+		}
+	} else {
+		r.buildVarsFunc = f
+	}
+	return r
+}
+
+// Subrouter ------------------------------------------------------------------
+
+// Subrouter creates a subrouter for the route.
+//
+// It will test the inner routes only if the parent route matched. For example:
+//
+//     r := mux.NewRouter()
+//     s := r.Host("www.example.com").Subrouter()
+//     s.HandleFunc("/products/", ProductsHandler)
+//     s.HandleFunc("/products/{key}", ProductHandler)
+//     s.HandleFunc("/articles/{category}/{id:[0-9]+}"), ArticleHandler)
+//
+// Here, the routes registered in the subrouter won't be tested if the host
+// doesn't match.
+func (r *Route) Subrouter() *Router {
+	// initialize a subrouter with a copy of the parent route's configuration
+	router := &Router{routeConf: copyRouteConf(r.routeConf), namedRoutes: r.namedRoutes}
+	r.addMatcher(router)
+	return router
+}
+
+// ----------------------------------------------------------------------------
+// URL building
+// ----------------------------------------------------------------------------
+
+// URL builds a URL for the route.
+//
+// It accepts a sequence of key/value pairs for the route variables. For
+// example, given this route:
+//
+//     r := mux.NewRouter()
+//     r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler).
+//       Name("article")
+//
+// ...a URL for it can be built using:
+//
+//     url, err := r.Get("article").URL("category", "technology", "id", "42")
+//
+// ...which will return an url.URL with the following path:
+//
+//     "/articles/technology/42"
+//
+// This also works for host variables:
+//
+//     r := mux.NewRouter()
+//     r.HandleFunc("/articles/{category}/{id:[0-9]+}", ArticleHandler).
+//       Host("{subdomain}.domain.com").
+//       Name("article")
+//
+//     // url.String() will be "http://news.domain.com/articles/technology/42"
+//     url, err := r.Get("article").URL("subdomain", "news",
+//                                      "category", "technology",
+//                                      "id", "42")
+//
+// The scheme of the resulting url will be the first argument that was passed to Schemes:
+//
+//     // url.String() will be "https://example.com"
+//     r := mux.NewRouter()
+//     url, err := r.Host("example.com")
+//                  .Schemes("https", "http").URL()
+//
+// All variables defined in the route are required, and their values must
+// conform to the corresponding patterns.
+func (r *Route) URL(pairs ...string) (*url.URL, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	values, err := r.prepareVars(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	var scheme, host, path string
+	queries := make([]string, 0, len(r.regexp.queries))
+	if r.regexp.host != nil {
+		if host, err = r.regexp.host.url(values); err != nil {
+			return nil, err
+		}
+		scheme = "http"
+		if r.buildScheme != "" {
+			scheme = r.buildScheme
+		}
+	}
+	if r.regexp.path != nil {
+		if path, err = r.regexp.path.url(values); err != nil {
+			return nil, err
+		}
+	}
+	for _, q := range r.regexp.queries {
+		var query string
+		if query, err = q.url(values); err != nil {
+			return nil, err
+		}
+		queries = append(queries, query)
+	}
+	return &url.URL{
+		Scheme:   scheme,
+		Host:     host,
+		Path:     path,
+		RawQuery: strings.Join(queries, "&"),
+	}, nil
+}
+
+// URLHost builds the host part of the URL for a route. See Route.URL().
+//
+// The route must have a host defined.
+func (r *Route) URLHost(pairs ...string) (*url.URL, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.regexp.host == nil {
+		return nil, errors.New("mux: route doesn't have a host")
+	}
+	values, err := r.prepareVars(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	host, err := r.regexp.host.url(values)
+	if err != nil {
+		return nil, err
+	}
+	u := &url.URL{
+		Scheme: "http",
+		Host:   host,
+	}
+	if r.buildScheme != "" {
+		u.Scheme = r.buildScheme
+	}
+	return u, nil
+}
+
+// URLPath builds the path part of the URL for a route. See Route.URL().
+//
+// The route must have a path defined.
+func (r *Route) URLPath(pairs ...string) (*url.URL, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.regexp.path == nil {
+		return nil, errors.New("mux: route doesn't have a path")
+	}
+	values, err := r.prepareVars(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	path, err := r.regexp.path.url(values)
+	if err != nil {
+		return nil, err
+	}
+	return &url.URL{
+		Path: path,
+	}, nil
+}
+
+// GetPathTemplate returns the template used to build the
+// route match.
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An error will be returned if the route does not define a path.
+func (r *Route) GetPathTemplate() (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	if r.regexp.path == nil {
+		return "", errors.New("mux: route doesn't have a path")
+	}
+	return r.regexp.path.template, nil
+}
+
+// GetPathRegexp returns the expanded regular expression used to match route path.
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An error will be returned if the route does not define a path.
+func (r *Route) GetPathRegexp() (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	if r.regexp.path == nil {
+		return "", errors.New("mux: route does not have a path")
+	}
+	return r.regexp.path.regexp.String(), nil
+}
+
+// GetQueriesRegexp returns the expanded regular expressions used to match the
+// route queries.
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An error will be returned if the route does not have queries.
+func (r *Route) GetQueriesRegexp() ([]string, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.regexp.queries == nil {
+		return nil, errors.New("mux: route doesn't have queries")
+	}
+	queries := make([]string, 0, len(r.regexp.queries))
+	for _, query := range r.regexp.queries {
+		queries = append(queries, query.regexp.String())
+	}
+	return queries, nil
+}
+
+// GetQueriesTemplates returns the templates used to build the
+// query matching.
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An error will be returned if the route does not define queries.
+func (r *Route) GetQueriesTemplates() ([]string, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.regexp.queries == nil {
+		return nil, errors.New("mux: route doesn't have queries")
+	}
+	queries := make([]string, 0, len(r.regexp.queries))
+	for _, query := range r.regexp.queries {
+		queries = append(queries, query.template)
+	}
+	return queries, nil
+}
+
+// GetMethods returns the methods the route matches against
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An error will be returned if route does not have methods.
+func (r *Route) GetMethods() ([]string, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	for _, m := range r.matchers {
+		if methods, ok := m.(methodMatcher); ok {
+			return []string(methods), nil
+		}
+	}
+	return nil, errors.New("mux: route doesn't have methods")
+}
+
+// GetHostTemplate returns the template used to build the
+// route match.
+// This is useful for building simple REST API documentation and for instrumentation
+// against third-party services.
+// An error will be returned if the route does not define a host.
+func (r *Route) GetHostTemplate() (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	if r.regexp.host == nil {
+		return "", errors.New("mux: route doesn't have a host")
+	}
+	return r.regexp.host.template, nil
+}
+
+// prepareVars converts the route variable pairs into a map. If the route has a
+// BuildVarsFunc, it is invoked.
+func (r *Route) prepareVars(pairs ...string) (map[string]string, error) {
+	m, err := mapFromPairsToString(pairs...)
+	if err != nil {
+		return nil, err
+	}
+	return r.buildVars(m), nil
+}
+
+func (r *Route) buildVars(m map[string]string) map[string]string {
+	if r.buildVarsFunc != nil {
+		m = r.buildVarsFunc(m)
+	}
+	return m
+}

--- a/vendor/github.com/gorilla/mux/test_helpers.go
+++ b/vendor/github.com/gorilla/mux/test_helpers.go
@@ -1,0 +1,19 @@
+// Copyright 2012 The Gorilla Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mux
+
+import "net/http"
+
+// SetURLVars sets the URL variables for the given request, to be accessed via
+// mux.Vars for testing route behaviour. Arguments are not modified, a shallow
+// copy is returned.
+//
+// This API should only be used for testing purposes; it provides a way to
+// inject variables into the request context. Alternatively, URL variables
+// can be set by making a route that captures the required variables,
+// starting a server and sending the request to that server.
+func SetURLVars(r *http.Request, val map[string]string) *http.Request {
+	return requestWithVars(r, val)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -49,6 +49,9 @@ github.com/google/gofuzz
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/openapiv2
+# github.com/gorilla/mux v1.8.0
+## explicit
+github.com/gorilla/mux
 # github.com/imdario/mergo v0.3.5
 github.com/imdario/mergo
 # github.com/json-iterator/go v1.1.10
@@ -153,6 +156,7 @@ golang.org/x/net/trace
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
 # golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
+## explicit
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix
 golang.org/x/sys/windows


### PR DESCRIPTION
This PR's scope is to refactor multus as a thick plugin.

This is a first required step to add / remove network interfaces to / from running PODs.

Follow-up PRs will build upon this, and implement the multus controller that will add / remove network interfaces to / from running pods.

**Info for reviewers**: 
~~This PR is still in draft mode because:~~
- ~~some legacy unit tests are failing. Ongoing investigation.~~
- ~~it misses unit tests for the added code~~
- the way the delegate CNIs are spawned **may** change in the future: mounting vs switching mount namespaces (accessing `/proc/<pid>/root/...` can also be an option - also requires sharing host's PID ns).
