### PR TITLE
multus, e2e tests: allow event sending to k8s API

### DIFF
--- a/e2e/multus-daemonset.yml
+++ b/e2e/multus-daemonset.yml
@@ -44,6 +44,15 @@ rules:
     verbs:
       - get
       - update
+  - apiGroups:
+      - ""
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
On the e2e tests you cannot send events since the service account does not have enough permissions.
