### PR TITLE
e2e tests: always pull new multus images

### DIFF
--- a/e2e/multus-daemonset.yml
+++ b/e2e/multus-daemonset.yml
@@ -154,6 +154,7 @@ spec:
       containers:
       - name: kube-multus
         image: localhost:5000/multus:e2e
+        imagePullPolicy: Always
         command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
         args:
         - "-multus-conf-file=auto"


### PR DESCRIPTION
Currently, the local workflow is far from optimal, since for every
change on the multus images the developers are required to redeploy
the kind cluster.

A more efficient workflow would be to build a local image, upload it to
the kind cluster, and finally re-deploy (delete & re-provision) the
daemonset, which would be running the new version.

For this flow to be possible, the multus container `imagePullPolicy`
must be set to `Always` - [0] - otherwise, the image is not updated.

To use this flow, execute the following commands:
```bash
$ hack/build-go.sh

$ podman build -t localhost:5000/multus:e2e -f images/Dockerfile.thick .
...

$ podman push localhost:5000/multus:e2e
Getting image source signatures
Copying blob 2007419be463 done  
Copying blob 6f64ff3fc38f done  
Copying blob e7ed17121dee skipped: already exists  
Copying blob 785573c4b945 skipped: already exists  
Copying config e5b8f481b7 done  
Writing manifest to image destination
Storing signatures

$ kubectl delete -f e2e/multus-daemonset.yml && kubectl apply -f e2e/multus-daemonset.yml
```

[0] - https://kubernetes.io/docs/concepts/containers/images/#updating-images

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>