### PR TITLE
crio: mount /run rslave

### DIFF
--- a/deployments/multus-daemonset-crio.yml
+++ b/deployments/multus-daemonset-crio.yml
@@ -193,6 +193,7 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run
+          mountPropagation: HostToContainer
         - name: cni
           mountPath: /host/etc/cni/net.d
         - name: cnibin


### PR DESCRIPTION
to prevent "unknown FS magic on "/var/run/netns/*": 1021994" errors

Signed-off-by: Peter Hunt <pehunt@redhat.com>