### PR TITLE
update e2e tools version for kind and cni-plugins

### DIFF
--- a/e2e/cni-install.yml
+++ b/e2e/cni-install.yml
@@ -7,9 +7,9 @@ metadata:
 data:
   install_cni.sh: |
     cd /tmp
-    wget https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz
+    wget https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-linux-amd64-v1.1.1.tgz
     cd /host/opt/cni/bin
-    tar xvfzp /tmp/cni-plugins-linux-amd64-v0.8.5.tgz
+    tar xvfzp /tmp/cni-plugins-linux-amd64-v1.1.1.tgz
     sleep infinite
 ---
 apiVersion: apps/v1

--- a/e2e/get_tools.sh
+++ b/e2e/get_tools.sh
@@ -5,11 +5,11 @@ if [ ! -d bin ]; then
 	mkdir bin
 fi
 
-curl -Lo ./bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-$(uname)-amd64"
+curl -Lo ./bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-$(uname)-amd64"
 chmod +x ./bin/kind
 curl -Lo ./bin/kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
 chmod +x ./bin/kubectl
-curl -Lo ./bin/koko https://github.com/redhat-nfvpe/koko/releases/download/v0.82/koko_0.82_linux_amd64
+curl -Lo ./bin/koko https://github.com/redhat-nfvpe/koko/releases/download/v0.83/koko_0.83_linux_amd64
 chmod +x ./bin/koko
 curl -Lo ./bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
 chmod +x ./bin/jq


### PR DESCRIPTION
Hi, I noticed that some of the tools are a bit out of date,So I update these tools version:
- cni-plugins: v0.8.5 -> v1.1.1
- kind: v0.8.1 -> v0.12.0
- koko: v0.82 -> v0.83