### PR TITLE
Fix sr-iov support

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -168,6 +168,10 @@ spec:
               mountPath: /host/run
             - name: host-var-lib-cni-multus
               mountPath: /var/lib/cni/multus
+            - name: host-var-lib-kubelet
+              mountPath: /var/lib/kubelet
+            - name: host-run-k8s-cni-cncf-io
+              mountPath: /run/k8s.cni.cncf.io
             - name: host-run-netns
               mountPath: /run/netns
               mountPropagation: HostToContainer
@@ -217,6 +221,12 @@ spec:
         - name: host-var-lib-cni-multus
           hostPath:
             path: /var/lib/cni/multus
+        - name: host-var-lib-kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        - name: host-run-k8s-cni-cncf-io
+          hostPath:
+            path: /run/k8s.cni.cncf.io
         - name: host-run-netns
           hostPath:
             path: /run/netns/

--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -33,7 +33,7 @@ type PodDevicesEntry struct {
 	PodUID        string
 	ContainerName string
 	ResourceName  string
-	DeviceIDs     []string
+	DeviceIDs     map[int64][]string
 	AllocResp     []byte
 }
 
@@ -97,12 +97,14 @@ func (cp *checkpoint) GetPodResourceMap(pod *v1.Pod) (map[string]*types.Resource
 	for _, pod := range cp.podEntires {
 		if pod.PodUID == podID {
 			entry, ok := resourceMap[pod.ResourceName]
-			if ok {
-				// already exists; append to it
-				entry.DeviceIDs = append(entry.DeviceIDs, pod.DeviceIDs...)
-			} else {
+			if !ok {
 				// new entry
-				resourceMap[pod.ResourceName] = &types.ResourceInfo{DeviceIDs: pod.DeviceIDs}
+				entry = &types.ResourceInfo{}
+				resourceMap[pod.ResourceName] = entry
+			}
+			for _, v := range pod.DeviceIDs {
+				// already exists; append to it
+				entry.DeviceIDs = append(entry.DeviceIDs, v...)
 			}
 		}
 	}

--- a/pkg/checkpoint/checkpoint_test.go
+++ b/pkg/checkpoint/checkpoint_test.go
@@ -45,10 +45,11 @@ var _ = BeforeSuite(func() {
 				"PodUID": "970a395d-bb3b-11e8-89df-408d5c537d23",
 				"ContainerName": "appcntr1",
 				"ResourceName": "intel.com/sriov_net_A",
-				"DeviceIDs": [
-				"0000:03:02.3",
-				"0000:03:02.0"
-				],
+				"DeviceIDs": {"-1": [
+					"0000:03:02.3",
+					"0000:03:02.0"
+					]
+				},
 				"AllocResp": "CikKC3NyaW92X25ldF9BEhogMDAwMDowMzowMi4zIDAwMDA6MDM6MDIuMA=="
 			}
 			],
@@ -143,10 +144,10 @@ var _ = Describe("Kubelet checkpoint data read operations", func() {
 						"PodUID": "970a395d-bb3b-11e8-89df-408d5c537d23",
 						"ContainerName": "appcntr1",
 						"ResourceName": "intel.com/sriov_net_A",
-						"DeviceIDs": [
+						"DeviceIDs": { "-1": [
 						"0000:03:02.3",
 						"0000:03:02.0"
-						],
+						] },
 						"AllocResp": "CikKC3NyaW92X25ldF9BEhogMDAwMDowMzowMi4zIDAwMDA6MDM6MDIuMA=="
 					}
 					],

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -708,7 +708,7 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		}
 
 		// create the network status, only in case Multus as kubeconfig
-		if n.Kubeconfig != "" && kc != nil {
+		if kubeClient != nil && kc != nil {
 			if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAME), n.SystemNamespaces) {
 				delegateNetStatus, err := nadutils.CreateNetworkStatus(tmpResult, delegate.Name, delegate.MasterPlugin, devinfo)
 				if err != nil {
@@ -724,7 +724,7 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 	}
 
 	// set the network status annotation in apiserver, only in case Multus as kubeconfig
-	if n.Kubeconfig != "" && kc != nil {
+	if kubeClient != nil && kc != nil {
 		if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAME), n.SystemNamespaces) {
 			err = k8s.SetNetworkStatus(kubeClient, k8sArgs, netStatus, n)
 			if err != nil {
@@ -876,7 +876,7 @@ func CmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) er
 	}
 
 	// unset the network status annotation in apiserver, only in case Multus as kubeconfig
-	if in.Kubeconfig != "" {
+	if kubeClient != nil {
 		if netnsfound {
 			if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAMESPACE), in.SystemNamespaces) {
 				err := k8s.SetNetworkStatus(kubeClient, k8sArgs, nil, in)


### PR DESCRIPTION
Fix thick plugin daemonset to add volume mapping required for
sr-iov and fix code to update network status.
In addition, fix checkpoint structures to support K8s without
kubelet pod resources API.

fix https://github.com/k8snetworkplumbingwg/multus-cni/issues/665 and https://github.com/k8snetworkplumbingwg/multus-cni/issues/778