### PR TITLE
types: fix usage of strings.Split() for parsing CNI_ARGS

### DIFF
--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -223,24 +223,24 @@ func CreateCNIRuntimeConf(args *skel.CmdArgs, k8sArgs *K8sArgs, ifName string, r
 	cniArgs := os.Getenv("CNI_ARGS")
 	if cniArgs != "" {
 		for _, arg := range strings.Split(cniArgs, ";") {
-			for _, keyval := range strings.Split(arg, "=") {
-				if len(keyval) != 2 {
-					logging.Errorf("CreateCNIRuntimeConf: CNI_ARGS %s %s %d is not recognized as CNI arg, skipped", arg, keyval, len(keyval))
-					continue
-				}
+			// SplitN to handle = within values, like BLAH=foo=bar
+			keyval := strings.SplitN(arg, "=", 2)
+			if len(keyval) != 2 {
+				logging.Errorf("CreateCNIRuntimeConf: CNI_ARGS %s %s %d is not recognized as CNI arg, skipped", arg, keyval, len(keyval))
+				continue
+			}
 
-				envKey := string(keyval[0])
-				envVal := string(keyval[1])
-				isExists := false
-				for _, rtArg := range rt.Args {
-					if rtArg[0] == envKey {
-						isExists = true
-					}
+			envKey := string(keyval[0])
+			envVal := string(keyval[1])
+			isExists := false
+			for _, rtArg := range rt.Args {
+				if rtArg[0] == envKey {
+					isExists = true
 				}
-				if isExists != false {
-					logging.Debugf("CreateCNIRuntimeConf: add new val: %s", arg)
-					rt.Args = append(rt.Args, [2]string{envKey, envVal})
-				}
+			}
+			if isExists != false {
+				logging.Debugf("CreateCNIRuntimeConf: add new val: %s", arg)
+				rt.Args = append(rt.Args, [2]string{envKey, envVal})
 			}
 		}
 	}


### PR DESCRIPTION
strings.Split() returns a slice, in this case with two elements of
the key and value. As such we shouldn't range over the slice when
the code is expecting a 2-element slice of key/value.

Otherwise we get errors for valid CNI_ARGS like:

```
2022-04-22T11:53:54Z [error] CreateCNIRuntimeConf: CNI_ARGS K8S_POD_NAMESPACE=openshift-etcd K8S_POD_NAMESPACE 17 is not recognized as CNI arg, skipped
2022-04-22T11:53:54Z [error] CreateCNIRuntimeConf: CNI_ARGS K8S_POD_NAMESPACE=openshift-etcd openshift-etcd 14 is not recognized as CNI arg, skipped
```

Fixes: d7d2a99ab5b8 ("Replace setenv with runtimeConfig set")

@s1061123 @dougbtv 