### PR TITLE
The cachefile name should be the delegate configuration name

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -617,14 +617,14 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 			}
 		}
 
-		netName := ""
+		// We collect the delegate netName for the cachefile name as well as following errors
+		netName := delegate.Conf.Name
+		if netName == "" {
+			netName = delegate.ConfList.Name
+		}
 		tmpResult, err = delegateAdd(exec, kubeClient, pod, delegate, rt, n)
 		if err != nil {
 			// If the add failed, tear down all networks we already added
-			netName = delegate.Conf.Name
-			if netName == "" {
-				netName = delegate.ConfList.Name
-			}
 			// Ignore errors; DEL must be idempotent anyway
 			_ = delPlugins(exec, nil, args, k8sArgs, n.Delegates, idx, n.RuntimeConfig, n)
 			return nil, cmdPluginErr(k8sArgs, netName, "error adding container to network %q: %v", netName, err)
@@ -665,10 +665,6 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 				logging.Debugf("Detected gateway override on interface %v to %v", ifName, delegate.GatewayRequest)
 			}
 		}
-
-		// Remove namespace from delegate.Name for Add/Del CNI cache
-		nameSlice := strings.Split(delegate.Name, "/")
-		netName = nameSlice[len(nameSlice)-1]
 
 		// Remove gateway if `default-route` network selection is specified
 		if deleteV4gateway || deleteV6gateway {


### PR DESCRIPTION
It was previously using the net-attach-def name, which doesn't align with the cache file. Causing default-route selection to not succeed.

To reproduce the error, run through the steps in [the specifying a default route docs](https://github.com/k8snetworkplumbingwg/multus-cni/blob/130db696ca739fb3bcb550104ace34f03c00a360/docs/how-to-use.md#specifying-a-default-route-for-a-specific-attachment).

Previous to this fix, it should fail with:

```
error deleting default gateway in cache: open /var/lib/cni/multus/results/macvlan-conf-1b516b1ef0c52920145b3502a71182c92858a542067ea1f134d0dcd27e61f3c4-net1: no such file or directory
```

In this case the string `macvlan-conf` comes from the net-attach-def name, but it should come from the delegate name in order to match the cache filename on disk.