### PR TITLE
Fix wrong location for daemonset in readme

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -15,7 +15,7 @@ $ docker build -t dougbtv/multus -f images/Dockerfile .
 You may wish to deploy Multus as a daemonset, you can do so by starting with the example Daemonset shown here:
 
 ```
-$ kubectl create -f ./images/multus-daemonset.yml
+$ kubectl create -f ./deployments/multus-daemonset.yml
 ```
 
 Note: The likely best practice here is to build your own image given the Dockerfile, and then push it to your preferred registry, and change the `image` fields in the Daemonset YAML to reference that image.


### PR DESCRIPTION
This PR fixes an outdated reference in the docs where
multus-daemonset.yml was expected to be found under the images folder.