### PR TITLE
config, logging: correct the logging parameters

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,7 +110,7 @@ Optionally, you may have Multus log to a file on the filesystem. This file will 
 For example in your CNI configuration, you may set:
 
 ```
-    "LogFile": "/var/log/multus.log",
+    "logFile": "/var/log/multus.log",
 ```
 
 #### Logging Level
@@ -127,7 +127,7 @@ The available logging level values, in decreasing order of verbosity are:
 You may configure the logging level by using the `LogLevel` option in your CNI configuration. For example:
 
 ```
-    "LogLevel": "debug",
+    "logLevel": "debug",
 ```
 
 #### Logging Options


### PR DESCRIPTION
The logging parameters were listed using uppercase, which is wrong. 

According to multus configuration, they should be in camelCase:
- [logFile]( https://github.com/k8snetworkplumbingwg/multus-cni/blob/779170a48ea767fe367f58ca472a8c403c203c6f/pkg/types/types.go#L45)
- [logLevel](https://github.com/k8snetworkplumbingwg/multus-cni/blob/779170a48ea767fe367f58ca472a8c403c203c6f/pkg/types/types.go#L46)
