### PR TITLE
Use *[]net.IP for 'default-route' network selection element.

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -644,7 +644,7 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 			// https://docs.google.com/document/d/1Ny03h6IDVy_e_vmElOqR7UdTPAG_RNydhVE1Kx54kFQ (4.1.2.1.9)
 			// the list can be empty; if it is, we'll assume the CNI's config for the default gateway holds,
 			// else we'll update the defaultgateway to the one specified.
-			if delegate.GatewayRequest != nil && delegate.GatewayRequest[0] != nil {
+			if delegate.GatewayRequest != nil && len(*delegate.GatewayRequest) != 0 {
 				deleteV4gateway = true
 				adddefaultgateway = true
 				logging.Debugf("Detected gateway override on interface %v to %v", ifName, delegate.GatewayRequest)
@@ -660,7 +660,7 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 			// https://docs.google.com/document/d/1Ny03h6IDVy_e_vmElOqR7UdTPAG_RNydhVE1Kx54kFQ (4.1.2.1.9)
 			// the list can be empty; if it is, we'll assume the CNI's config for the default gateway holds,
 			// else we'll update the defaultgateway to the one specified.
-			if delegate.GatewayRequest != nil && delegate.GatewayRequest[0] != nil {
+			if delegate.GatewayRequest != nil && len(*delegate.GatewayRequest) != 0 {
 				deleteV6gateway = true
 				adddefaultgateway = true
 				logging.Debugf("Detected gateway override on interface %v to %v", ifName, delegate.GatewayRequest)
@@ -681,11 +681,11 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 
 		// Here we'll set the default gateway which specified in `default-route` network selection
 		if adddefaultgateway {
-			err = netutils.SetDefaultGW(args, ifName, delegate.GatewayRequest)
+			err = netutils.SetDefaultGW(args, ifName, *delegate.GatewayRequest)
 			if err != nil {
 				return nil, cmdErr(k8sArgs, "error setting default gateway: %v", err)
 			}
-			err = netutils.AddDefaultGWCache(n.CNIDir, rt, netName, ifName, delegate.GatewayRequest)
+			err = netutils.AddDefaultGWCache(n.CNIDir, rt, netName, ifName, *delegate.GatewayRequest)
 			if err != nil {
 				return nil, cmdErr(k8sArgs, "error setting default gateway in cache: %v", err)
 			}

--- a/pkg/multus/multus_test.go
+++ b/pkg/multus/multus_test.go
@@ -68,7 +68,7 @@ type fakeExec struct {
 	delIndex        int
 	chkIndex        int
 	expectedDelSkip int
-	plugins map[string]*fakePlugin
+	plugins         map[string]*fakePlugin
 }
 
 func newFakeExec() *fakeExec {

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -60,9 +60,9 @@ func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error 
 }
 
 // LoadDelegateNetConf converts raw CNI JSON into a DelegateNetConf structure
-func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID string, resourceName string) (*DelegateNetConf, error) {
+func LoadDelegateNetConf(bytes []byte, netElement *NetworkSelectionElement, deviceID string, resourceName string) (*DelegateNetConf, error) {
 	var err error
-	logging.Debugf("LoadDelegateNetConf: %s, %v, %s", string(bytes), net, deviceID)
+	logging.Debugf("LoadDelegateNetConf: %s, %v, %s", string(bytes), netElement, deviceID)
 
 	delegateConf := &DelegateNetConf{}
 	if err := json.Unmarshal(bytes, &delegateConf.Conf); err != nil {
@@ -81,8 +81,8 @@ func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID st
 				return nil, logging.Errorf("LoadDelegateNetConf: failed to add deviceID in NetConfList bytes: %v", err)
 			}
 		}
-		if net != nil && net.CNIArgs != nil {
-			bytes, err = addCNIArgsInConfList(bytes, net.CNIArgs)
+		if netElement != nil && netElement.CNIArgs != nil {
+			bytes, err = addCNIArgsInConfList(bytes, netElement.CNIArgs)
 			if err != nil {
 				return nil, logging.Errorf("LoadDelegateNetConf(): failed to add cni-args in NetConfList bytes: %v", err)
 			}
@@ -97,45 +97,51 @@ func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID st
 			delegateConf.ResourceName = resourceName
 			delegateConf.DeviceID = deviceID
 		}
-		if net != nil && net.CNIArgs != nil {
-			bytes, err = addCNIArgsInConfig(bytes, net.CNIArgs)
+		if netElement != nil && netElement.CNIArgs != nil {
+			bytes, err = addCNIArgsInConfig(bytes, netElement.CNIArgs)
 			if err != nil {
 				return nil, logging.Errorf("LoadDelegateNetConf(): failed to add cni-args in NetConfList bytes: %v", err)
 			}
 		}
 	}
 
-	if net != nil {
-		if net.Name != "" {
+	if netElement != nil {
+		if netElement.Name != "" {
 			// Overwrite CNI config name with net-attach-def name
-			delegateConf.Name = fmt.Sprintf("%s/%s", net.Namespace, net.Name)
+			delegateConf.Name = fmt.Sprintf("%s/%s", netElement.Namespace, netElement.Name)
 		}
-		if net.InterfaceRequest != "" {
-			delegateConf.IfnameRequest = net.InterfaceRequest
+		if netElement.InterfaceRequest != "" {
+			delegateConf.IfnameRequest = netElement.InterfaceRequest
 		}
-		if net.MacRequest != "" {
-			delegateConf.MacRequest = net.MacRequest
+		if netElement.MacRequest != "" {
+			delegateConf.MacRequest = netElement.MacRequest
 		}
-		if net.IPRequest != nil {
-			delegateConf.IPRequest = net.IPRequest
+		if netElement.IPRequest != nil {
+			delegateConf.IPRequest = netElement.IPRequest
 		}
-		if net.BandwidthRequest != nil {
-			delegateConf.BandwidthRequest = net.BandwidthRequest
+		if netElement.BandwidthRequest != nil {
+			delegateConf.BandwidthRequest = netElement.BandwidthRequest
 		}
-		if net.PortMappingsRequest != nil {
-			delegateConf.PortMappingsRequest = net.PortMappingsRequest
+		if netElement.PortMappingsRequest != nil {
+			delegateConf.PortMappingsRequest = netElement.PortMappingsRequest
 		}
-		if net.GatewayRequest != nil {
-			delegateConf.GatewayRequest = append(delegateConf.GatewayRequest, net.GatewayRequest...)
+		if netElement.GatewayRequest != nil {
+			var list []net.IP
+			if delegateConf.GatewayRequest != nil {
+				list = append(*delegateConf.GatewayRequest, *netElement.GatewayRequest...)
+			} else {
+				list = *netElement.GatewayRequest
+			}
+			delegateConf.GatewayRequest = &list
 		}
-		if net.InfinibandGUIDRequest != "" {
-			delegateConf.InfinibandGUIDRequest = net.InfinibandGUIDRequest
+		if netElement.InfinibandGUIDRequest != "" {
+			delegateConf.InfinibandGUIDRequest = netElement.InfinibandGUIDRequest
 		}
-		if net.DeviceID != "" {
+		if netElement.DeviceID != "" {
 			if deviceID != "" {
 				logging.Debugf("Warning: Both RuntimeConfig and ResourceMap provide deviceID. Ignoring RuntimeConfig")
 			} else {
-				delegateConf.DeviceID = net.DeviceID
+				delegateConf.DeviceID = netElement.DeviceID
 			}
 		}
 	}
@@ -545,11 +551,13 @@ func CheckGatewayConfig(delegates []*DelegateNetConf) error {
 
 	// Check the gateway
 	for _, delegate := range delegates {
-		for _, gw := range delegate.GatewayRequest {
-			if gw.To4() != nil {
-				v4Gateways++
-			} else {
-				v6Gateways++
+		if delegate.GatewayRequest != nil {
+			for _, gw := range *delegate.GatewayRequest {
+				if gw.To4() != nil {
+					v4Gateways++
+				} else {
+					v6Gateways++
+				}
 			}
 		}
 	}
@@ -565,7 +573,7 @@ func CheckGatewayConfig(delegates []*DelegateNetConf) error {
 			delegates[i].IsFilterV4Gateway = true
 			delegates[i].IsFilterV6Gateway = true
 		} else {
-			for _, gw := range delegate.GatewayRequest {
+			for _, gw := range *delegate.GatewayRequest {
 				if gw.To4() != nil {
 					delegates[i].IsFilterV6Gateway = true
 				} else {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -99,7 +99,7 @@ type DelegateNetConf struct {
 	IPRequest             []string        `json:"ipRequest,omitempty"`
 	PortMappingsRequest   []*PortMapEntry `json:"-"`
 	BandwidthRequest      *BandwidthEntry `json:"-"`
-	GatewayRequest        []net.IP        `json:"default-route,omitempty"`
+	GatewayRequest        *[]net.IP       `json:"default-route,omitempty"`
 	IsFilterV4Gateway     bool
 	IsFilterV6Gateway     bool
 	// MasterPlugin is only used internal housekeeping
@@ -150,7 +150,7 @@ type NetworkSelectionElement struct {
 	// CNIArgs contains additional CNI arguments for the network interface
 	CNIArgs *map[string]interface{} `json:"cni-args"`
 	// GatewayRequest contains default route IP address for the pod
-	GatewayRequest []net.IP `json:"default-route,omitempty"`
+	GatewayRequest *[]net.IP `json:"default-route,omitempty"`
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes


### PR DESCRIPTION
Allows for empty default route for IPv6, e.g. to select the default-route for a given interface but to pass an empty list.