### PR TITLE
Fix missing device-info in networks-status annotation for chained plugins

### DIFF
--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -80,6 +80,8 @@ func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID st
 			if err != nil {
 				return nil, logging.Errorf("LoadDelegateNetConf: failed to add deviceID in NetConfList bytes: %v", err)
 			}
+			delegateConf.ResourceName = resourceName
+			delegateConf.DeviceID = deviceID
 		}
 		if net != nil && net.CNIArgs != nil {
 			bytes, err = addCNIArgsInConfList(bytes, net.CNIArgs)


### PR DESCRIPTION
When chained plugins are used, the networks-status annotations is missing the device-info section.
This PR aims to fix this.