### PR TITLE
write output file for generated kubeconfig

### DIFF
--- a/cmd/config-generation/kubeconfig.go
+++ b/cmd/config-generation/kubeconfig.go
@@ -124,7 +124,7 @@ contexts:
 current-context: multus-context
 `
 	kubeconfig := fmt.Sprintf(kubeConfigTemplate, protocol, k8sServiceIP, k8sServicePort, tlsConfig, serviceAccountToken)
-	logInfo("Generated KubeConfig: \n%s", kubeconfig)
+	logInfo("Generated KubeConfig saved to %s: \n%s", outputPath, kubeconfig)
 	return ioutil.WriteFile(outputPath, []byte(kubeconfig), userRWPermission)
 }
 


### PR DESCRIPTION
This change will make debugging easier in cases when non-default
location is used and user forgot to mount new directory.