### PR TITLE
improve multus log output

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -93,7 +93,7 @@ func consumeScratchNetConf(containerID, dataDir string) ([]byte, string, error) 
 }
 
 func getIfname(delegate *types.DelegateNetConf, argif string, idx int) string {
-	logging.Debugf("getIfname: %v, %s, %d", delegate, argif, idx)
+	logging.Debugf("getIfname: %v, %s, %d", *delegate, argif, idx)
 	if delegate.IfnameRequest != "" {
 		return delegate.IfnameRequest
 	}
@@ -289,7 +289,7 @@ func conflistDel(rt *libcni.RuntimeConf, rawnetconflist []byte, multusNetconf *t
 
 // DelegateAdd ...
 func DelegateAdd(exec invoke.Exec, kubeClient *k8s.ClientInfo, pod *v1.Pod, delegate *types.DelegateNetConf, rt *libcni.RuntimeConf, multusNetconf *types.NetConf) (cnitypes.Result, error) {
-	logging.Debugf("DelegateAdd: %v, %v, %v", exec, delegate, rt)
+	logging.Debugf("DelegateAdd: %v, %v, %v", exec, *delegate, *rt)
 
 	if err := validateIfName(rt.NetNS, rt.IfName); err != nil {
 		return nil, logging.Errorf("DelegateAdd: cannot set %q interface name to %q: %v", delegate.Conf.Type, rt.IfName, err)

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -163,7 +163,7 @@ func LoadDelegateNetConf(bytes []byte, netElement *NetworkSelectionElement, devi
 
 // mergeCNIRuntimeConfig creates CNI runtimeconfig from delegate
 func mergeCNIRuntimeConfig(runtimeConfig *RuntimeConfig, delegate *DelegateNetConf) *RuntimeConfig {
-	logging.Debugf("mergeCNIRuntimeConfig: %v %v", runtimeConfig, delegate)
+	logging.Debugf("mergeCNIRuntimeConfig: %v %v", *runtimeConfig, *delegate)
 	var mergedRuntimeConfig RuntimeConfig
 
 	if runtimeConfig == nil {


### PR DESCRIPTION
I noticed that there are lots of binary output in multus CNI log. And since some structs do not implement the golang String interface, so let's just print the struct object directly rather than pointer.

Signed-off-by: Icarus9913 <icaruswu66@qq.com>