### PR TITLE
delegate plugin delete success, delete cache file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,8 @@ Following is the example of multus config file, in `/etc/cni/net.d/`.
     }, {
         "type": "macvlan",
         ... (snip)
-    }]
+    }],
+    allowTryDeleteOnErr: false
 }
 ```
 
@@ -62,6 +63,7 @@ User should chose following parameters combination (`clusterNetwork`+`defaultNet
 * `systemNamespaces` ([]string, optional): list of namespaces for Kubernetes system (namespaces listed here will not have `defaultNetworks` added)
 * `multusNamespace` (string, optional): namespace for `clusterNetwork`/`defaultNetworks`
 * `delegates` ([]map,required): number of delegate details in the Multus
+* `allowTryDeleteOnErr` (bool, optional): Enable or disable delegate DEL message to next when some missing error. Defaults to false.
 
 ### Network selection flow of clusterNetwork/defaultNetworks
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -41,7 +41,10 @@ type NetConf struct {
 	// These parameters are exclusive in one config file:
 	//  - Delegates (directly add delegate CNI config into multus CNI config)
 	//  - ClusterNetwork+DefaultNetworks  (add CNI config through CRD, directory or file)
-	Delegates       []*DelegateNetConf  `json:"-"`
+	Delegates []*DelegateNetConf `json:"-"`
+	// Allow delegate DEL message to next when some missing error
+	AllowTryDeleteOnErr bool `json:"allowTryDeleteOnErr"`
+
 	ClusterNetwork  string              `json:"clusterNetwork"`
 	DefaultNetworks []string            `json:"defaultNetworks"`
 	Kubeconfig      string              `json:"kubeconfig"`


### PR DESCRIPTION
this case should try max to cleanup 

1.  sandBox container stop times, but delegated plugin failed (CNI server maybe in starting .... ) , but cache file has been deleted
2.  container gc manager clean up forever even though POD has been fully deleted from ETCD

POD not find && cache file not find;  never clean up, we should try max ...