### PR TITLE
runtime config: read CNI args from cni lib

### DIFF
--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -73,14 +73,18 @@ func GetAPIEndpoint(endpoint string) string {
 }
 
 // CreateDelegateRequest creates Request for delegate API request
-func CreateDelegateRequest(cniCommand, cniContainerID, cniNetNS, cniIFName, podNamespace, podName, podUID string, cniConfig []byte) *Request {
+func CreateDelegateRequest(cniCommand, cniContainerID, cniNetNS, cniIFName, podNamespace, podName, podUID string, extraCNIArgs string, cniConfig []byte) *Request {
+	cniArgs := fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s;K8S_POD_UID=%s", podNamespace, podName, podUID)
+	if extraCNIArgs != "" {
+		cniArgs += fmt.Sprintf(";%s", extraCNIArgs)
+	}
 	return &Request{
 		Env: map[string]string{
 			"CNI_COMMAND":     strings.ToUpper(cniCommand),
 			"CNI_CONTAINERID": cniContainerID,
 			"CNI_NETNS":       cniNetNS,
 			"CNI_IFNAME":      cniIFName,
-			"CNI_ARGS":        fmt.Sprintf("K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s;K8S_POD_UID=%s", podNamespace, podName, podUID),
+			"CNI_ARGS":        cniArgs,
 		},
 		Config: cniConfig,
 	}

--- a/pkg/types/conf_test.go
+++ b/pkg/types/conf_test.go
@@ -640,11 +640,12 @@ var _ = Describe("config operations", func() {
 		Expect(rt.CapabilityArgs["portMappings"]).To(Equal(rc.PortMaps))
 	})
 
-	It("creates a valid CNI runtime config with K8s args passed via CNI_ARGS environment variable", func() {
+	It("creates a valid CNI runtime config with K8s args passed via CNI_ARGS", func() {
 		args := &skel.CmdArgs{
 			ContainerID: "123456789",
 			Netns:       testNS.Path(),
 			IfName:      "eth0",
+			Args:        "K8S_POD_NAME=dummy;K8S_POD_NAMESPACE=namespacedummy;K8S_POD_INFRA_CONTAINER_ID=123456789;K8S_POD_UID=aaaaa;BLAHBLAH=foo=bar",
 			StdinData: []byte(`{
     "name": "node-cni-network",
     "type": "multus",
@@ -662,7 +663,6 @@ var _ = Describe("config operations", func() {
 }`),
 		}
 
-		os.Setenv("CNI_ARGS", "K8S_POD_NAME=dummy;K8S_POD_NAMESPACE=namespacedummy;K8S_POD_INFRA_CONTAINER_ID=123456789;K8S_POD_UID=aaaaa;BLAHBLAH=foo=bar")
 		k8sArgs := &K8sArgs{}
 		rt, _ := CreateCNIRuntimeConf(args, k8sArgs, "", &RuntimeConfig{}, nil)
 		fmt.Println("rt.ContainerID: ", rt.ContainerID)


### PR DESCRIPTION
Read the CNI arguments from the CNI lib API, instead of relying on the environment variable.

This enables the `Delegate` endpoint to retrieve the runtime configuration via CNI args, which was not possible when using environment variables.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>