### PR TITLE
Fix release 3.x thick image tag to isolate from 4.0

### DIFF
--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -47,7 +47,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:thick-amd64
+            ghcr.io/${{ github.repository }}:stable-thick-amd64
             ${{ steps.docker_meta.outputs.tags }}-thick-amd64
           file: images/Dockerfile.thick
 

--- a/deployments/multus-daemonset-thick-plugin.yml
+++ b/deployments/multus-daemonset-thick-plugin.yml
@@ -122,7 +122,7 @@ spec:
       serviceAccountName: multus
       containers:
         - name: kube-multus
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:thick
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.2-thick-amd64
           command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
           args:
             - "-cni-version=0.3.1"
@@ -146,7 +146,7 @@ spec:
               mountPath: /host/opt/cni/bin
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:thick
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.2-thick-amd64
           command:
             - "cp"
             - "/usr/src/multus-cni/bin/multus"
@@ -162,7 +162,7 @@ spec:
               mountPath: /host/opt/cni/bin
               mountPropagation: Bidirectional
         - name: generate-kubeconfig
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:thick
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.2-thick-amd64
           command:
             - "/usr/src/multus-cni/bin/generate-kubeconfig"
           args:


### PR DESCRIPTION
Due to #900, image tag, ':thick', which is used in 4.0 and 3.x, gets user confused because thick image is not compatible between 4.0 and 3.x. This fix provides strict version name in deployment yaml to specify install image tag.

Note: This requires to release v3.9.2 release, after the PR merge.