### PR TITLE
delegate plugin delete success, delete cache file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,8 @@ Following is the example of multus config file, in `/etc/cni/net.d/`.
     }, {
         "type": "macvlan",
         ... (snip)
-    }]
+    }],
+    allowTryDeleteOnErr: false
 }
 ```
 
@@ -62,6 +63,7 @@ User should chose following parameters combination (`clusterNetwork`+`defaultNet
 * `systemNamespaces` ([]string, optional): list of namespaces for Kubernetes system (namespaces listed here will not have `defaultNetworks` added)
 * `multusNamespace` (string, optional): namespace for `clusterNetwork`/`defaultNetworks`
 * `delegates` ([]map,required): number of delegate details in the Multus
+* `retryDeleteOnError` (bool, optional): Enable or disable delegate DEL message to next when some missing error. Defaults to false.
 
 ### Network selection flow of clusterNetwork/defaultNetworks
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -61,6 +61,9 @@ type NetConf struct {
 	SystemNamespaces []string `json:"systemNamespaces"`
 	// Option to set the namespace that multus-cni uses (clusterNetwork/defaultNetworks)
 	MultusNamespace string `json:"multusNamespace"`
+
+	// Retry delegate DEL message to next when some error
+	RetryDeleteOnError bool `json:"retryDeleteOnError"`
 }
 
 // RuntimeConfig specifies CNI RuntimeConfig


### PR DESCRIPTION
this case should try max to cleanup

sandBox container stop times, but delegated plugin failed (CNI server maybe in starting .... ) , but cache file has been deleted
container gc manager clean up forever even though POD has been fully deleted from ETCD
POD not find && cache file not find; never clean up, we should try max ...


Add an option allowTryDeleteOnErr in multus conf,   allow to try delegate message on such error  scene 