### PR TITLE
Fix license boilerplate/copyright in go files

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 // This binary works as a server that receives requests from multus-shim
 // CNI plugin and creates network interface for kubernets pods.

--- a/cmd/multus-shim/main.go
+++ b/cmd/multus-shim/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/multus/main.go
+++ b/cmd/multus/main.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2016 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package checkpoint
 

--- a/pkg/checkpoint/checkpoint_test.go
+++ b/pkg/checkpoint/checkpoint_test.go
@@ -1,3 +1,18 @@
+// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package checkpoint
 
 import (

--- a/pkg/checkpoint/doc.go
+++ b/pkg/checkpoint/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,4 +14,5 @@
 
 // Package checkpoint is the package that contains the libraries that manipulates kubelet's
 // checkpoint API
+
 package checkpoint

--- a/pkg/k8sclient/doc.go
+++ b/pkg/k8sclient/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 // Package k8sclient is the package that contains the Kubernetes client libraries.
+
 package k8sclient

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/k8sclient/k8sclient_test.go
+++ b/pkg/k8sclient/k8sclient_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package k8sclient
 

--- a/pkg/kubeletclient/doc.go
+++ b/pkg/kubeletclient/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,4 +14,5 @@
 
 // Package kubeletclient is the package that contains the kubelet's libraries that
 // controls podresource API in kubelet
+
 package kubeletclient

--- a/pkg/kubeletclient/kubeletclient.go
+++ b/pkg/kubeletclient/kubeletclient.go
@@ -1,3 +1,18 @@
+// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kubeletclient
 
 import (

--- a/pkg/kubeletclient/kubeletclient_test.go
+++ b/pkg/kubeletclient/kubeletclient_test.go
@@ -1,3 +1,18 @@
+// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kubeletclient
 
 import (

--- a/pkg/logging/doc.go
+++ b/pkg/logging/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 // Package logging is the package that contains logging library.
+
 package logging

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/multus/doc.go
+++ b/pkg/multus/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,4 +14,5 @@
 
 // Package multus is the package that contains main multus function, which
 // manipulates CNI request for delegate plugins.
+
 package multus

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2016 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/multus/multus_cni020_test.go
+++ b/pkg/multus/multus_cni020_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package multus
 

--- a/pkg/multus/multus_cni040_test.go
+++ b/pkg/multus/multus_cni040_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package multus
 

--- a/pkg/multus/multus_cni100_test.go
+++ b/pkg/multus/multus_cni100_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Kubernetes Network Plumbing Working Group
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package multus
 

--- a/pkg/multus/multus_suite_test.go
+++ b/pkg/multus/multus_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Kubernetes Network Plumbing Working Group
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/netutils/doc.go
+++ b/pkg/netutils/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 // Package netutils is the package that contains network related utilities.
+
 package netutils

--- a/pkg/netutils/netutils.go
+++ b/pkg/netutils/netutils.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2019 Multus Authors
+// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package netutils
 

--- a/pkg/netutils/netutils_test.go
+++ b/pkg/netutils/netutils_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2019 Multus Authors
+// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package netutils
 

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package api
 

--- a/pkg/server/api/doc.go
+++ b/pkg/server/api/doc.go
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 // Package api is the package that contains thick pluigin's server apis.
+
 package api

--- a/pkg/server/api/shim.go
+++ b/pkg/server/api/shim.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package api
 

--- a/pkg/server/api/socket.go
+++ b/pkg/server/api/socket.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package api
 

--- a/pkg/server/config/config_suite_test.go
+++ b/pkg/server/config/config_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package config
 

--- a/pkg/server/config/doc.go
+++ b/pkg/server/config/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,4 +14,5 @@
 
 // Package config is the package that contains the libraries that operates
 // CNI config files
+
 package config

--- a/pkg/server/config/generator.go
+++ b/pkg/server/config/generator.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package config
 

--- a/pkg/server/config/generator_test.go
+++ b/pkg/server/config/generator_test.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package config
 

--- a/pkg/server/config/manager.go
+++ b/pkg/server/config/manager.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package config
 

--- a/pkg/server/config/manager_test.go
+++ b/pkg/server/config/manager_test.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package config
 

--- a/pkg/server/doc.go
+++ b/pkg/server/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 // Package server is the package that contains thick pluigin's server libraries.
+
 package server

--- a/pkg/server/exec_chroot.go
+++ b/pkg/server/exec_chroot.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/server/exec_chroot_test.go
+++ b/pkg/server/exec_chroot_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package server
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package server
 

--- a/pkg/server/server_suite_test.go
+++ b/pkg/server/server_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package server
 

--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package server
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/pkg/testing/doc.go
+++ b/pkg/testing/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 // Package testing is the package that contains unit-test libraries.
+
 package testing

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package testing
 

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package types
 

--- a/pkg/types/conf_test.go
+++ b/pkg/types/conf_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package types
 

--- a/pkg/types/doc.go
+++ b/pkg/types/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Multus Authors
+// Copyright (c) 2022 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 // Package types contains common types in the multus.
+
 package types

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Intel Corporation
+// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2021 Multus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package types
 


### PR DESCRIPTION
This change fix license boilerplate and its copyright. The updated year in copyright is based on the file creation date. If older than 2021, added copyright is transfered to multus authors from Intel corporation as the multus code was officially transfered to Kubernetes Networking Plumbing Working Group on March 11, 2021.

Fix #937 