### PR TITLE
remove io/ioutil for advanced golang

### DIFF
--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -17,7 +17,7 @@ package checkpoint
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/logging"
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/types"
@@ -72,7 +72,7 @@ func getCheckpoint(filePath string) (types.ResourceClient, error) {
 func (cp *checkpoint) getPodEntries() error {
 
 	cpd := &checkpointFileData{}
-	rawBytes, err := ioutil.ReadFile(cp.fileName)
+	rawBytes, err := os.ReadFile(cp.fileName)
 	if err != nil {
 		return logging.Errorf("getPodEntries: error reading file %s\n%v\n", checkPointfile, err)
 	}

--- a/pkg/checkpoint/checkpoint_test.go
+++ b/pkg/checkpoint/checkpoint_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"io/ioutil"
 	"testing"
 
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/types"
@@ -40,7 +39,7 @@ type fakeCheckpoint struct {
 }
 
 func (fc *fakeCheckpoint) WriteToFile(inBytes []byte) error {
-	return ioutil.WriteFile(fc.fileName, inBytes, 0600)
+	return os.WriteFile(fc.fileName, inBytes, 0600)
 }
 
 func (fc *fakeCheckpoint) DeleteFile() error {

--- a/pkg/k8sclient/k8sclient_test.go
+++ b/pkg/k8sclient/k8sclient_test.go
@@ -17,7 +17,6 @@ package k8sclient
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,7 +59,7 @@ var _ = Describe("k8sclient operations", func() {
 	const fakePodName string = "testPod"
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "multus_tmp")
+		tmpDir, err = os.MkdirTemp("", "multus_tmp")
 		Expect(err).NotTo(HaveOccurred())
 		genericConf = `{
 			"name":"node-cni-network",
@@ -546,7 +545,7 @@ var _ = Describe("k8sclient operations", func() {
 
 	It("retrieves cluster network from cni config path", func() {
 		net1Name := filepath.Join(tmpDir, "10-net1.conf")
-		ioutil.WriteFile(net1Name, []byte(`{
+		os.WriteFile(net1Name, []byte(`{
 				"name": "net1",
 				"type": "mynet",
 				"cniVersion": "0.3.1"
@@ -765,7 +764,7 @@ var _ = Describe("k8sclient operations", func() {
 	})
 
 	It("uses cached delegates when an error in loading from pod annotation occurs", func() {
-		dir, err := ioutil.TempDir("", "multus-test")
+		dir, err := os.MkdirTemp("", "multus-test")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.RemoveAll(dir) // clean up
 

--- a/pkg/kubeletclient/kubeletclient_test.go
+++ b/pkg/kubeletclient/kubeletclient_test.go
@@ -18,7 +18,6 @@ package kubeletclient
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -102,7 +101,7 @@ func CreateListener(addr string) (net.Listener, error) {
 	}
 
 	// Create the socket on a tempfile and move it to the destination socket to handle improper cleanup
-	file, err := ioutil.TempFile(filepath.Dir(addr), "")
+	file, err := os.CreateTemp(filepath.Dir(addr), "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary file: %v", err)
 	}
@@ -124,7 +123,7 @@ func CreateListener(addr string) (net.Listener, error) {
 }
 
 func setUp() error {
-	tempSocketDir, err := ioutil.TempDir("", "kubelet-resource-client")
+	tempSocketDir, err := os.MkdirTemp("", "kubelet-resource-client")
 	if err != nil {
 		return err
 	}

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -17,7 +17,6 @@ package logging
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -101,7 +100,7 @@ var _ = Describe("logging operations", func() {
 	})
 
 	It("Check log function is worked with stderr", func() {
-		tmpDir, err := ioutil.TempDir("", "multus_tmp")
+		tmpDir, err := os.MkdirTemp("", "multus_tmp")
 		SetLogFile(fmt.Sprintf("%s/log.txt", tmpDir))
 		Debugf("foobar")
 		Verbosef("foobar")

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -77,7 +76,7 @@ func saveScratchNetConf(containerID, dataDir string, netconf []byte) error {
 
 	path := filepath.Join(dataDir, containerID)
 
-	err := ioutil.WriteFile(path, netconf, 0600)
+	err := os.WriteFile(path, netconf, 0600)
 	if err != nil {
 		return logging.Errorf("saveScratchNetConf: failed to write container data in the path(%q): %v", path, err)
 	}
@@ -89,7 +88,7 @@ func consumeScratchNetConf(containerID, dataDir string) ([]byte, string, error) 
 	logging.Debugf("consumeScratchNetConf: %s, %s", containerID, dataDir)
 	path := filepath.Join(dataDir, containerID)
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	return b, path, err
 }
 

--- a/pkg/multus/multus_cni020_test.go
+++ b/pkg/multus/multus_cni020_test.go
@@ -17,7 +17,6 @@ package multus
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 
@@ -51,7 +50,7 @@ var _ = Describe("multus operations", func() {
 	It("delete delegates given good filepath", func() {
 		os.MkdirAll("/opt/cni/bin", 0755)
 		d1 := []byte("blah")
-		ioutil.WriteFile("/opt/cni/bin/123456789", d1, 0644)
+		os.WriteFile("/opt/cni/bin/123456789", d1, 0644)
 
 		err := deleteDelegates("123456789", "/opt/cni/bin")
 		Expect(err).NotTo(HaveOccurred())
@@ -71,7 +70,7 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 		os.Setenv("CNI_NETNS", testNS.Path())
 		os.Setenv("CNI_PATH", "/some/path")
 
-		tmpDir, err = ioutil.TempDir("", "multus_tmp")
+		tmpDir, err = os.MkdirTemp("", "multus_tmp")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Touch the default network file.

--- a/pkg/multus/multus_cni040_test.go
+++ b/pkg/multus/multus_cni040_test.go
@@ -17,7 +17,6 @@ package multus
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 
@@ -49,7 +48,7 @@ var _ = Describe("multus operations cniVersion 0.3.1 config", func() {
 		os.Setenv("CNI_NETNS", testNS.Path())
 		os.Setenv("CNI_PATH", "/some/path")
 
-		tmpDir, err = ioutil.TempDir("", "multus_tmp")
+		tmpDir, err = os.MkdirTemp("", "multus_tmp")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Touch the default network file.
@@ -561,7 +560,7 @@ var _ = Describe("multus operations cniVersion 0.4.0 config", func() {
 		os.Setenv("CNI_NETNS", testNS.Path())
 		os.Setenv("CNI_PATH", "/some/path")
 
-		tmpDir, err = ioutil.TempDir("", "multus_tmp")
+		tmpDir, err = os.MkdirTemp("", "multus_tmp")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Touch the default network file.

--- a/pkg/multus/multus_cni100_test.go
+++ b/pkg/multus/multus_cni100_test.go
@@ -16,7 +16,6 @@ package multus
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 
@@ -47,7 +46,7 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 		os.Setenv("CNI_NETNS", testNS.Path())
 		os.Setenv("CNI_PATH", "/some/path")
 
-		tmpDir, err = ioutil.TempDir("", "multus_tmp")
+		tmpDir, err = os.MkdirTemp("", "multus_tmp")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Touch the default network file.

--- a/pkg/netutils/netutils.go
+++ b/pkg/netutils/netutils.go
@@ -18,8 +18,8 @@ package netutils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 
 	"github.com/containernetworking/cni/libcni"
@@ -95,7 +95,7 @@ func SetDefaultGW(netnsPath string, ifName string, gateways []net.IP) error {
 func DeleteDefaultGWCache(cacheDir string, rt *libcni.RuntimeConf, netName string, ifName string, ipv4, ipv6 bool) error {
 	cacheFile := filepath.Join(cacheDir, "results", fmt.Sprintf("%s-%s-%s", netName, rt.ContainerID, rt.IfName))
 
-	cache, err := ioutil.ReadFile(cacheFile)
+	cache, err := os.ReadFile(cacheFile)
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func DeleteDefaultGWCache(cacheDir string, rt *libcni.RuntimeConf, netName strin
 	}
 
 	logging.Debugf("DeleteDefaultGWCache: update cache to delete GW: %s", string(newCache))
-	return ioutil.WriteFile(cacheFile, newCache, 0600)
+	return os.WriteFile(cacheFile, newCache, 0600)
 }
 
 func deleteDefaultGWCacheBytes(cacheFile []byte, ipv4, ipv6 bool) ([]byte, error) {
@@ -267,7 +267,7 @@ func deleteDefaultGWResult020(result map[string]interface{}, ipv4, ipv6 bool) (m
 func AddDefaultGWCache(cacheDir string, rt *libcni.RuntimeConf, netName string, ifName string, gw []net.IP) error {
 	cacheFile := filepath.Join(cacheDir, "results", fmt.Sprintf("%s-%s-%s", netName, rt.ContainerID, rt.IfName))
 
-	cache, err := ioutil.ReadFile(cacheFile)
+	cache, err := os.ReadFile(cacheFile)
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func AddDefaultGWCache(cacheDir string, rt *libcni.RuntimeConf, netName string, 
 	}
 
 	logging.Debugf("AddDefaultGWCache: update cache to add GW: %s", string(newCache))
-	return ioutil.WriteFile(cacheFile, newCache, 0600)
+	return os.WriteFile(cacheFile, newCache, 0600)
 }
 
 func addDefaultGWCacheBytes(cacheFile []byte, gw []net.IP) ([]byte, error) {

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -54,7 +54,7 @@ func DoCNI(url string, req interface{}, socketPath string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read CNI result: %v", err)
 	}

--- a/pkg/server/config/generator.go
+++ b/pkg/server/config/generator.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -331,7 +331,7 @@ func findMasterPlugin(cniConfigDirPath string, remainingTries int) (string, erro
 		return "", fmt.Errorf("could not find a plugin configuration in %s", cniConfigDirPath)
 	}
 	var cniPluginConfigs []string
-	files, err := ioutil.ReadDir(cniConfigDirPath)
+	files, err := os.ReadDir(cniConfigDirPath)
 	if err != nil {
 		return "", fmt.Errorf("error when listing the CNI plugin configurations: %w", err)
 	}

--- a/pkg/server/config/generator_test.go
+++ b/pkg/server/config/generator_test.go
@@ -17,7 +17,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -64,7 +63,7 @@ var _ = Describe("Configuration Generator", func() {
 	var err error
 
 	BeforeEach(func() {
-		tmpDir, err = ioutil.TempDir("", "multus_tmp")
+		tmpDir, err = os.MkdirTemp("", "multus_tmp")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/server/config/manager.go
+++ b/pkg/server/config/manager.go
@@ -17,7 +17,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/fsnotify/fsnotify"
 
@@ -64,7 +64,7 @@ func NewManagerWithExplicitPrimaryCNIPlugin(config MultusConf, multusAutoconfigD
 
 // overrideCNIVersion overrides cniVersion in cniConfigFile, it should be used only in kind case
 func overrideCNIVersion(cniConfigFile string, multusCNIVersion string) error {
-	masterCNIConfigData, err := ioutil.ReadFile(cniConfigFile)
+	masterCNIConfigData, err := os.ReadFile(cniConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to read cni config %s: %v", cniConfigFile, err)
 	}
@@ -80,7 +80,7 @@ func overrideCNIVersion(cniConfigFile string, multusCNIVersion string) error {
 		return fmt.Errorf("couldn't update cluster network config: %v", err)
 	}
 
-	err = ioutil.WriteFile(cniConfigFile, configBytes, 0644)
+	err = os.WriteFile(cniConfigFile, configBytes, 0644)
 	if err != nil {
 		return fmt.Errorf("couldn't update cluster network config: %v", err)
 	}
@@ -214,7 +214,7 @@ func (m Manager) MonitorPluginConfiguration(shutDown <-chan struct{}, done chan<
 // PersistMultusConfig persists the provided configuration to the disc, with
 // Read / Write permissions. The output file path is `<multus auto config dir>/00-multus.conf`
 func (m Manager) PersistMultusConfig(config string) error {
-	return ioutil.WriteFile(m.multusConfigFilePath, []byte(config), UserRWPermission)
+	return os.WriteFile(m.multusConfigFilePath, []byte(config), UserRWPermission)
 }
 
 func getPrimaryCNIPluginName(multusAutoconfigDir string) (string, error) {
@@ -254,7 +254,7 @@ func shouldRegenerateConfig(event fsnotify.Event) bool {
 }
 
 func primaryCNIData(masterCNIPluginPath string) (interface{}, error) {
-	masterCNIConfigData, err := ioutil.ReadFile(masterCNIPluginPath)
+	masterCNIConfigData, err := os.ReadFile(masterCNIPluginPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read the cluster primary CNI config %s: %w", masterCNIPluginPath, err)
 	}

--- a/pkg/server/config/manager_test.go
+++ b/pkg/server/config/manager_test.go
@@ -17,7 +17,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -45,12 +44,12 @@ var _ = Describe("Configuration Manager", func() {
 
 	BeforeEach(func() {
 		var err error
-		multusConfigDir, err = ioutil.TempDir("", "multus-config")
+		multusConfigDir, err = os.MkdirTemp("", "multus-config")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(os.MkdirAll(multusConfigDir, 0755)).To(Succeed())
 
 		defaultCniConfig = fmt.Sprintf("%s/%s", multusConfigDir, primaryCNIPluginName)
-		Expect(ioutil.WriteFile(defaultCniConfig, []byte(primaryCNIPluginTemplate), UserRWPermission)).To(Succeed())
+		Expect(os.WriteFile(defaultCniConfig, []byte(primaryCNIPluginTemplate), UserRWPermission)).To(Succeed())
 
 		multusConf, _ := NewMultusConfig(
 			primaryCNIName,
@@ -73,7 +72,7 @@ var _ = Describe("Configuration Manager", func() {
 	It("Check overrideCNIVersion is worked", func() {
 		err := overrideCNIVersion(defaultCniConfig, "1.1.1")
 		Expect(err).NotTo(HaveOccurred())
-		raw, err := ioutil.ReadFile(defaultCniConfig)
+		raw, err := os.ReadFile(defaultCniConfig)
 		Expect(err).NotTo(HaveOccurred())
 
 		var jsonConfig map[string]interface{}
@@ -111,11 +110,11 @@ var _ = Describe("Configuration Manager", func() {
 }
 `
 		// update the CNI config to update the master config
-		Expect(ioutil.WriteFile(defaultCniConfig, []byte(updatedCNIConfig), UserRWPermission)).To(Succeed())
+		Expect(os.WriteFile(defaultCniConfig, []byte(updatedCNIConfig), UserRWPermission)).To(Succeed())
 
 		// wait for a while to get fsnotify event
 		time.Sleep(100 * time.Millisecond)
-		file, err := ioutil.ReadFile(configManager.multusConfigFilePath)
+		file, err := os.ReadFile(configManager.multusConfigFilePath)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(file)).To(Equal(config))
 
@@ -156,12 +155,12 @@ var _ = Describe("Configuration Manager with mismatched cniVersion", func() {
 
 	It("test cni version incompatibility", func() {
 		var err error
-		multusConfigDir, err = ioutil.TempDir("", "multus-config")
+		multusConfigDir, err = os.MkdirTemp("", "multus-config")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(os.MkdirAll(multusConfigDir, 0755)).To(Succeed())
 
 		defaultCniConfig = fmt.Sprintf("%s/%s", multusConfigDir, primaryCNIPluginName)
-		Expect(ioutil.WriteFile(defaultCniConfig, []byte(primaryCNIPluginTemplate), UserRWPermission)).To(Succeed())
+		Expect(os.WriteFile(defaultCniConfig, []byte(primaryCNIPluginTemplate), UserRWPermission)).To(Succeed())
 
 		multusConf, _ := NewMultusConfig(
 			primaryCNIName,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -220,7 +220,7 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 
 func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 	var cr api.Request
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +247,7 @@ func (s *Server) handleCNIRequest(r *http.Request) ([]byte, error) {
 
 func (s *Server) handleDelegateRequest(r *http.Request) ([]byte, error) {
 	var cr api.Request
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -17,7 +17,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -68,7 +67,7 @@ var _ = Describe(suiteName, func() {
 
 	BeforeEach(func() {
 		var err error
-		thickPluginRunDir, err = ioutil.TempDir("", thickCNISocketDirPath)
+		thickPluginRunDir, err = os.MkdirTemp("", thickCNISocketDirPath)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -55,7 +54,7 @@ func NewFakeNetAttachDefFile(namespace, name, filePath, fileData string) *netv1.
 			Namespace: namespace,
 		},
 	}
-	err := ioutil.WriteFile(filePath, []byte(fileData), 0600)
+	err := os.WriteFile(filePath, []byte(fileData), 0600)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	return netAttach
 }

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -18,7 +18,6 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -428,7 +427,7 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 
 // LoadDaemonNetConf loads the configuration for the multus daemon
 func LoadDaemonNetConf(configPath string) (*ControllerNetConf, []byte, error) {
-	config, err := ioutil.ReadFile(configPath)
+	config, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read the config file's contents: %w", err)
 	}

--- a/pkg/types/conf_test.go
+++ b/pkg/types/conf_test.go
@@ -18,7 +18,6 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -49,7 +48,7 @@ var _ = Describe("config operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		os.Setenv("CNI_PATH", "/some/path")
 
-		tmpDir, err = ioutil.TempDir("", "multus_tmp")
+		tmpDir, err = os.MkdirTemp("", "multus_tmp")
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

We should clean all io/util package according the url: https://go.dev/doc/go1.16#ioutil
/kind cleanup
