### PR TITLE
for miss delete system files in daemon-config

### DIFF
--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -458,7 +458,13 @@ func LoadDaemonNetConf(configPath string) (*ControllerNetConf, []byte, error) {
 		daemonNetConf.BinDir = defaultBinDir
 	}
 
-	if daemonNetConf.MultusSocketDir == "" {
+	if daemonNetConf.MultusSocketDir == "" ||
+		daemonNetConf.MultusSocketDir == "/" ||
+		daemonNetConf.MultusSocketDir == "/run" ||
+		daemonNetConf.MultusSocketDir == "/host" ||
+		daemonNetConf.MultusSocketDir == "/tmp" ||
+		daemonNetConf.MultusSocketDir == "/var/lib" ||
+		daemonNetConf.MultusSocketDir == "/etc" {
 		daemonNetConf.MultusSocketDir = defaultMultusRunDir
 	}
 


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

The daemon-config.json is a location where user can specify , when he modify the contents. and use it do a evil thing , we should prevent it.. like set  "socketDir": "xxxxx" ..
daemon-config.json: |
    {
        "confDir": "/host/etc/cni/net.d",
        "logToStderr": true,
        "logLevel": "debug",
        "logFile": "/tmp/multus.log",
        "binDir": "/host/opt/cni/bin",
        "cniDir": "/var/lib/cni/multus",
        "socketDir": "xxxxx"
    }


According the code 

`
multus-cni/cmd/multus-daemon/main.go
if err := srv.FilesystemPreRequirements(daemonConfig.MultusSocketDir); err != nil {

multus-cni/pkg/server/server.go
func FilesystemPreRequirements(rundir string) error {
	if err := os.RemoveAll(rundir); err != nil && !os.IsNotExist(err) {
`
