### PR TITLE
enable bandwidth by default

### DIFF
--- a/deployments/multus-daemonset-crio.yml
+++ b/deployments/multus-daemonset-crio.yml
@@ -121,7 +121,8 @@ data:
       "name": "multus-cni-network",
       "type": "multus",
       "capabilities": {
-        "portMappings": true
+        "portMappings": true,
+        "bandwidth": true
       },
       "delegates": [
         {

--- a/deployments/multus-daemonset-gke-1.16.yml
+++ b/deployments/multus-daemonset-gke-1.16.yml
@@ -94,7 +94,8 @@ data:
       "name": "multus-cni-network",
       "type": "multus",
       "capabilities": {
-        "portMappings": true
+        "portMappings": true,
+        "bandwidth": true
       },
       "delegates": [
         {

--- a/deployments/multus-daemonset.yml
+++ b/deployments/multus-daemonset.yml
@@ -121,7 +121,8 @@ data:
       "name": "multus-cni-network",
       "type": "multus",
       "capabilities": {
-        "portMappings": true
+        "portMappings": true,
+        "bandwidth": true
       },
       "delegates": [
         {

--- a/e2e/templates/multus-daemonset.yml.j2
+++ b/e2e/templates/multus-daemonset.yml.j2
@@ -86,7 +86,8 @@ data:
       "name": "multus-cni-network",
       "type": "multus",
       "capabilities": {
-        "portMappings": true
+        "portMappings": true,
+        "bandwidth": true
       },
       "delegates": [
         {


### PR DESCRIPTION
enable bandwidth by default

It's would be better if it enables bandwidth in multus-cni config by default, How do you think?

Refer to: https://github.com/k8snetworkplumbingwg/multus-cni/issues/949