### PR TITLE
server: add healthz endpoint

### DIFF
--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -31,6 +31,9 @@ const (
 	// MultusDelegateAPIEndpoint is an endpoint for multus delegate request (for hotplug)
 	MultusDelegateAPIEndpoint = "/delegate"
 	defaultMultusRunDir       = "/run/multus/"
+
+	// MultusHealthAPIEndpoint is an endpoint API clients can query to know if they can communicate w/ multus server
+	MultusHealthAPIEndpoint = "/healthz"
 )
 
 // DoCNI sends a CNI request to the CNI server via JSON + HTTP over a root-owned unix socket,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -216,6 +216,12 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 			}
 		}))).Methods("POST")
 
+	router.HandleFunc(api.MultusHealthAPIEndpoint, promhttp.InstrumentHandlerCounter(s.metrics.requestCounter.MustCurryWith(prometheus.Labels{"handler": api.MultusHealthAPIEndpoint}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+		}))).Methods("GET")
+
 	return s, nil
 }
 


### PR DESCRIPTION
From the node (or any privileged pod having mounted the multus socket) you can now query the multus-cni server liveliness - for instance:
```
root@kind-worker:/# curl -v --unix-socket /run/multus/multus.sock localhost/healthz
*   Trying /run/multus/multus.sock:0...
* Connected to localhost (/host/run/multus/multus.sock) port 80 (#0)
> GET /healthz HTTP/1.1
> Host: localhost
> User-Agent: curl/7.74.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Date: Mon, 14 Nov 2022 17:21:07 GMT
< Content-Length: 0
< Connection: close
<
* Closing connection 0
```

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

Fixes: #970