### PR TITLE
Update network-attachment-definition-client to v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containernetworking/plugins v1.1.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-logr/logr v1.2.3 // indirect
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/onsi/ginkgo/v2 v2.5.1
 	github.com/onsi/gomega v1.24.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0 h1:MjRRgZyTGo90G+UrwlDQjU+uG4Z7By65qvQxGoILT/8=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0 h1:VzM3TYHDgqPkettiP6I6q2jOeQFL4nrJM+UcAc4f6Fs=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0/go.mod h1:nqCI7aelBJU61wiBeeZWJ6oi4bJy5nrjkM6lWIMA4j0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -43,7 +43,7 @@ const (
 	DeviceInfoTypeVHostUser = "vhost-user"
 	DeviceInfoTypeMemif     = "memif"
 	DeviceInfoTypeVDPA      = "vdpa"
-	DeviceInfoVersion       = "1.0.0"
+	DeviceInfoVersion       = "1.1.0"
 )
 
 // DeviceInfo contains the information of the device associated
@@ -58,18 +58,20 @@ type DeviceInfo struct {
 }
 
 type PciDevice struct {
-	PciAddress   string `json:"pci-address,omitempty"`
-	Vhostnet     string `json:"vhost-net,omitempty"`
-	RdmaDevice   string `json:"rdma-device,omitempty"`
-	PfPciAddress string `json:"pf-pci-address,omitempty"`
+	PciAddress        string `json:"pci-address,omitempty"`
+	Vhostnet          string `json:"vhost-net,omitempty"`
+	RdmaDevice        string `json:"rdma-device,omitempty"`
+	PfPciAddress      string `json:"pf-pci-address,omitempty"`
+	RepresentorDevice string `json:"representor-device,omitempty"`
 }
 
 type VdpaDevice struct {
-	ParentDevice string `json:"parent-device,omitempty"`
-	Driver       string `json:"driver,omitempty"`
-	Path         string `json:"path,omitempty"`
-	PciAddress   string `json:"pci-address,omitempty"`
-	PfPciAddress string `json:"pf-pci-address,omitempty"`
+	ParentDevice      string `json:"parent-device,omitempty"`
+	Driver            string `json:"driver,omitempty"`
+	Path              string `json:"path,omitempty"`
+	PciAddress        string `json:"pci-address,omitempty"`
+	PfPciAddress      string `json:"pf-pci-address,omitempty"`
+	RepresentorDevice string `json:"representor-device,omitempty"`
 }
 
 const (
@@ -106,6 +108,7 @@ type NetworkStatus struct {
 	Default    bool        `json:"default,omitempty"`
 	DNS        DNS         `json:"dns,omitempty"`
 	DeviceInfo *DeviceInfo `json:"device-info,omitempty"`
+	Gateway    []string    `json:"gateway,omitempty"`
 }
 
 // PortMapEntry for CNI PortMapEntry

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -75,7 +75,7 @@ github.com/imdario/mergo
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0
+# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 ## explicit; go 1.17
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1


### PR DESCRIPTION
Update network-attachment-definition-client package to support DeviceInfo spec 1.1.0

Related PRs:
https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/pull/49
https://github.com/k8snetworkplumbingwg/device-info-spec/pull/3

network-attachment-definition-client v1.4.0 content: https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/releases/tag/v1.4.0