### PR TITLE
Remove origin from CI build

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -108,21 +108,3 @@ jobs:
           push: false
           tags: ghcr.io/${{ github.repository }}:latest-s390x
           file: images/Dockerfile.s390x
-
-  build-origin:
-    name: Image build/origin
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build container image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: false
-          tags: ghcr.io/${{ github.repository }}:latest-origin
-          file: images/Dockerfile.openshift


### PR DESCRIPTION
This change remove origin build from CI pipeline because origin's golang version is too old.