### PR TITLE
Create an openshift origin (OKD) golang builder image in build pipeline

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -108,3 +108,22 @@ jobs:
           push: false
           tags: ghcr.io/${{ github.repository }}:latest-s390x
           file: images/Dockerfile.s390x
+
+  build-origin:
+    name: Image build/origin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Download OKD Builder Dockerfile
+        run: curl https://raw.githubusercontent.com/okd-project/images/main/okd-builder.Dockerfile -o images/okd-builder.Dockerfile
+      
+      - name: Organically build golang builder image
+        run: docker build -t local/okdbuilder:latest -f images/okd-builder.Dockerfile .
+
+      - name: Organically build Multus origin image
+        run: docker build -t local/multus-cni:latest-origin -f images/Dockerfile.openshift .

--- a/images/Dockerfile.openshift
+++ b/images/Dockerfile.openshift
@@ -1,5 +1,6 @@
 # This dockerfile is specific to building Multus for OpenShift
-FROM openshift/origin-release:golang-1.16 as builder
+# The okd-builder image is locally built from https://raw.githubusercontent.com/okd-project/images/main/okd-builder.Dockerfile
+FROM local/okdbuilder:latest as builder
 
 ADD . /usr/src/multus-cni
 
@@ -7,7 +8,7 @@ WORKDIR /usr/src/multus-cni
 ENV GO111MODULE=off
 RUN ./hack/build-go.sh
 
-FROM openshift/origin-base
+FROM quay.io/openshift/origin-base:latest
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 RUN mkdir -p /usr/src/multus-cni/images && mkdir -p /usr/src/multus-cni/bin
 COPY --from=builder /usr/src/multus-cni/bin/multus /usr/src/multus-cni/bin


### PR DESCRIPTION
This has a build against openshift origin, since the original image was out of date, this builds a golang builder image prior to the origin Multus build using the dockerfile provided by OKD.