### PR TITLE
Update network-attachment-definition-client for multus v3 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/containernetworking/cni v0.8.1
 	github.com/containernetworking/plugins v0.9.1
 	github.com/fsnotify/fsnotify v1.4.9
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20220511184442-64cfb249bdbe
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20221215110210-ad3f3381681f
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20220511184442-64cfb249bdbe h1:VPiaEz+bUnFjUBBz3NnvmXbOtTs5Vpyzrsx9hcp/caM=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20220511184442-64cfb249bdbe/go.mod h1:+1DpV8uIwteAhxNO0lgRox8gHkTG6w3OeDfAlg+qqjA=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20221215110210-ad3f3381681f h1:SVJhARCyy2mmDUegdEBnYyLqjB4h6BxsfN5rfehExuU=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20221215110210-ad3f3381681f/go.mod h1:+1DpV8uIwteAhxNO0lgRox8gHkTG6w3OeDfAlg+qqjA=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1/types.go
+++ b/vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1/types.go
@@ -43,7 +43,7 @@ const (
 	DeviceInfoTypeVHostUser = "vhost-user"
 	DeviceInfoTypeMemif     = "memif"
 	DeviceInfoTypeVDPA      = "vdpa"
-	DeviceInfoVersion       = "1.0.0"
+	DeviceInfoVersion       = "1.1.0"
 )
 
 // DeviceInfo contains the information of the device associated
@@ -58,18 +58,20 @@ type DeviceInfo struct {
 }
 
 type PciDevice struct {
-	PciAddress   string `json:"pci-address,omitempty"`
-	Vhostnet     string `json:"vhost-net,omitempty"`
-	RdmaDevice   string `json:"rdma-device,omitempty"`
-	PfPciAddress string `json:"pf-pci-address,omitempty"`
+	PciAddress        string `json:"pci-address,omitempty"`
+	Vhostnet          string `json:"vhost-net,omitempty"`
+	RdmaDevice        string `json:"rdma-device,omitempty"`
+	PfPciAddress      string `json:"pf-pci-address,omitempty"`
+	RepresentorDevice string `json:"representor-device,omitempty"`
 }
 
 type VdpaDevice struct {
-	ParentDevice string `json:"parent-device,omitempty"`
-	Driver       string `json:"driver,omitempty"`
-	Path         string `json:"path,omitempty"`
-	PciAddress   string `json:"pci-address,omitempty"`
-	PfPciAddress string `json:"pf-pci-address,omitempty"`
+	ParentDevice      string `json:"parent-device,omitempty"`
+	Driver            string `json:"driver,omitempty"`
+	Path              string `json:"path,omitempty"`
+	PciAddress        string `json:"pci-address,omitempty"`
+	PfPciAddress      string `json:"pf-pci-address,omitempty"`
+	RepresentorDevice string `json:"representor-device,omitempty"`
 }
 
 const (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,7 +54,7 @@ github.com/googleapis/gnostic/openapiv2
 github.com/imdario/mergo
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
-# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20220511184442-64cfb249bdbe
+# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.2-0.20221215110210-ad3f3381681f
 ## explicit
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1


### PR DESCRIPTION
Update network-attachment-definition-client package to support DeviceInfo spec 1.1.0

Signed-off-by: Yury Kulazhenkov <ykulazhenkov@nvidia.com>