### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,9 @@ Here's an illustration of the network interfaces attached to a pod, as provision
 
 ## Quickstart Installation Guide
 
-The quickstart installation method for Multus requires that you have first installed a Kubernetes CNI plugin to serve as your pod-to-pod network, which we refer to as your "default network" (a network interface that every pod will be created with). Each network attachment created by Multus will be in addition to this default network interface. For more detail on installing a default network CNI plugins, refer to our [quick-start guide](docs/quickstart.md).
+The quickstart installation method for Multus requires that you have first installed a Kubernetes CNI plugin to serve as your pod-to-pod network, which we refer to as your "default network" (a network interface that every pod will be created with). Each network attachment created by Multus will be in addition to this default network interface. For more detail on installing a default network CNI plugin, refer to our [quick-start guide](docs/quickstart.md).
 
-Clone this GitHub repository, we'll apply a daemonset which installs Multus using to `kubectl` from this repo. From the root directory of the clone, apply the daemonset YAML file:
-
-For thin-plugin (i.e. standalone implementation) case:
-
-```
-cat ./deployments/multus-daemonset.yml | kubectl apply -f -
-```
-
-For [thick-plugin](docs/thick-plugin.md) (i.e. client/server implementation) case:
+Clone this GitHub repository, and apply a daemonset which installs Multus using `kubectl`. From the root directory of the clone, apply the daemonset YAML file:
 
 ```
 cat ./deployments/multus-daemonset-thick.yml | kubectl apply -f -
@@ -42,14 +34,20 @@ This will configure your systems to be ready to use Multus CNI, but, to get star
 
 ## Thin Plugin v.s Thick Plugin
 
-With the multus 4.0 release, we introduce a new client/server style plugin deployment. This new deployment is called ['thick plugin'](docs/thick-plugin.md), in contrast to the previous deployment, which is now called 'thin plugin'. The new thick plugin consists of two binaries, multus-daemon and multus-shim CNI plugin. The 'multus-daemon' will be deployed to all nodes as local agent and supports additional features, such as metrics, which were not available with the 'thin plugin' deployment before. Due to those additional features, the 'thick plugin' comes with the trade-off of consuming more resources than the 'thin plugin'.
+With the multus 4.0 release, we introduce a new client/server-style plugin deployment. This new deployment is called ['thick plugin'](docs/thick-plugin.md), in contrast to deployments in previous versions, which is now called a 'thin plugin'. The new thick plugin consists of two binaries, multus-daemon and multus-shim CNI plugin. The 'multus-daemon' will be deployed to all nodes as a local agent and supports additional features, such as metrics, which were not available with the 'thin plugin' deployment before. Due to these additional features, the 'thick plugin' comes with the trade-off of consuming more resources than the 'thin plugin'.
 
+We recommend using the thick plugin in most environments, but if you wish to run the thin plugin, or are in a resource-constrained environment, you may do so with:
+
+```
+cat ./deployments/multus-daemonset.yml | kubectl apply -f -
+```
 
 ## Additional Installation Options
 
-- Install via daemonset using the quick-start guide, above.
+In addition to the [quick-start guide](docs/quickstart.md), you may:
+
 - Download binaries from [release page](https://github.com/k8snetworkplumbingwg/multus-cni/releases)
-- By Docker image from [Docker Hub](https://hub.docker.com/r/nfvpe/multus/tags/)
+- By Docker image from [GitHub Container Registry](https://github.com/orgs/k8snetworkplumbingwg/packages/container/package/multus-cni)
 - Or, roll-your-own and build from source
   - See [Development](docs/development.md)
 
@@ -63,4 +61,4 @@ With the multus 4.0 release, we introduce a new client/server style plugin deplo
 
 ## Contact Us
 
-For any questions about Multus CNI, feel free to ask a question in #general in the [NPWG Slack](https://npwg-team.slack.com/), or open up a GitHub issue. Request an invite to NPWG slack [here](https://intel-corp.herokuapp.com/).
+For any questions about Multus CNI, open up a GitHub issue or feel free to ask a question in #general in the [NPWG Slack](https://npwg-team.slack.com/).


### PR DESCRIPTION
Includes:

* removing outdated heroku app link
* change dockerhub to GHCR
* a couple typos
* default to thick plugin installation (moves thin plugin install to new section)
*

Fixes #991 