### PR TITLE
Removes command line arguments in favor of configMap/JSON config

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -62,12 +62,21 @@ const (
 func main() {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
+	//XXX: one section (multus CNI config)
 	cniConfigDir := flag.String("cni-config-dir", defaultCniConfigDir, "CNI config dir")
 	multusConfigFile := flag.String("multus-conf-file", "auto", "The multus configuration file to use. By default, a new configuration is generated.")
+	cniVersion := flag.String("cni-version", "", "Allows you to specify CNI spec version. Used only with --multus-conf-file=auto.")
 	multusMasterCni := flag.String("multus-master-cni-file", "", "The relative name of the configuration file of the cluster primary CNI.")
 	multusAutoconfigDir := flag.String("multus-autoconfig-dir", *cniConfigDir, "The directory path for the generated multus configuration.")
+	forceCNIVersion := flag.Bool("force-cni-version", false, "Force to use given CNI version. only for kind-e2e testing") // this is only for kind-e2e
+	overrideNetworkName := flag.Bool("override-network-name", false, "Used when we need overrides the name of the multus configuration with the name of the delegated primary CNI")
+	socketDir := flag.String("socket-dir", defaultSocketDir, "Specifies the directory where the socket file resides.")
+
+	// namespaces
 	namespaceIsolation := flag.Bool("namespace-isolation", false, "If the network resources are only available within their defined namespaces.")
 	globalNamespaces := flag.String("global-namespaces", "", "Comma-separated list of namespaces which can be referred to globally when namespace isolation is enabled.")
+
+	// logging
 	logToStdErr := flag.Bool("multus-log-to-stderr", false, "If the multus logs are also to be echoed to stderr.")
 	logLevel := flag.String("multus-log-level", "", "One of: debug/verbose/error/panic. Used only with --multus-conf-file=auto.")
 	logFile := flag.String("multus-log-file", "", "Path where to multus will log. Used only with --multus-conf-file=auto.")
@@ -75,11 +84,11 @@ func main() {
 	logMaxAge := flag.Int("multus-log-max-age", defaultMultusLogMaxAge, "The maximum number of days to retain old log files in their filename")
 	logMaxBackups := flag.Int("multus-log-max-backups", defaultMultusLogMaxBackups, "The maximum number of old log files to retain")
 	logCompress := flag.Bool("multus-log-compress", defaultMultusLogCompress, "Compress determines if the rotated log files should be compressed using gzip")
-	cniVersion := flag.String("cni-version", "", "Allows you to specify CNI spec version. Used only with --multus-conf-file=auto.")
-	socketDir := flag.String("socket-dir", defaultSocketDir, "Specifies the directory where the socket file resides.")
-	forceCNIVersion := flag.Bool("force-cni-version", false, "Force to use given CNI version. only for kind-e2e testing") // this is only for kind-e2e
+
 	readinessIndicator := flag.String("readiness-indicator-file", "", "Which file should be used as the readiness indicator. Used only with --multus-conf-file=auto.")
-	overrideNetworkName := flag.Bool("override-network-name", false, "Used when we need overrides the name of the multus configuration with the name of the delegated primary CNI")
+	//----
+
+	// keep in command line option
 	version := flag.Bool("version", false, "Show version")
 
 	configFilePath := flag.String("config", types.DefaultMultusDaemonConfigFile, "Specify the path to the multus-daemon configuration")

--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -113,11 +113,14 @@ data:
         "chrootDir": "/hostroot",
         "confDir": "/host/etc/cni/net.d",
         "logToStderr": true,
-        "logLevel": "debug",
+        "logLevel": "verbose",
         "logFile": "/tmp/multus.log",
         "binDir": "/opt/cni/bin",
         "cniDir": "/var/lib/cni/multus",
-        "socketDir": "/host/run/multus/"
+        "socketDir": "/host/run/multus/",
+        "cniVersion": "0.3.1",
+        "cniConfigDir": "/host/etc/cni/net.d",
+        "multusAutoconfigDir": "/host/etc/cni/net.d"
     }
 ---
 apiVersion: apps/v1
@@ -154,12 +157,6 @@ spec:
         - name: kube-multus
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
           command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
-          args:
-            - "-cni-version=0.3.1"
-            - "-cni-config-dir=/host/etc/cni/net.d"
-            - "-multus-autoconfig-dir=/host/etc/cni/net.d"
-            - "-multus-log-to-stderr=true"
-            - "-multus-log-level=verbose"
           resources:
             requests:
               cpu: "100m"

--- a/pkg/server/config/generator.go
+++ b/pkg/server/config/generator.go
@@ -56,6 +56,15 @@ type MultusConf struct {
 	CniDir                   string          `json:"cniDir,omitempty"`
 	CniConfigDir             string          `json:"cniConfigDir,omitempty"`
 	SocketDir                string          `json:"socketDir,omitempty"`
+	MultusConfigFile         string          `json:"multusConfigFile,omitempty"`
+	LogMaxAge                int             `json:"logMaxAge,omitempty"`
+	LogMaxSize               int             `json:"logMaxSize,omitempty"`
+	LogMaxBackups            int             `json:"logMaxBackups,omitempty"`
+	LogCompress              bool            `json:"logCompress,omitempty"`
+	MultusMasterCni          string          `json:"multusMasterCNI,omitempty"`
+	MultusAutoconfigDir      string          `json:"multusAutoconfigDir,omitempty"`
+	ForceCNIVersion          bool            `json:"forceCNIVersion,omitempty"`
+	OverrideNetworkName      bool            `json:"overrideNetworkName,omitempty"`
 }
 
 // LogOptions specifies the configuration of the log
@@ -78,6 +87,28 @@ func NewMultusConfig(pluginName string, cniVersion string, configurationOptions 
 
 	err := multusConfig.Mutate(configurationOptions...)
 	return multusConfig, err
+}
+
+func ParseMultusConfig(configPath string) (*MultusConf, error) {
+	config, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("ParseMultusConfig failed to read the config file's contents: %w", err)
+	}
+
+	multusconf := &MultusConf{
+		/*
+			Name:         MultusDefaultNetworkName,
+			CNIVersion:   cniVersion,
+			Type:         pluginName,
+			Capabilities: map[string]bool{},
+		*/
+	}
+
+	if err := json.Unmarshal(config, multusconf); err != nil {
+		return nil, fmt.Errorf("failed to unmarshall the daemon configuration: %w", err)
+	}
+
+	return multusconf, nil
 }
 
 // CheckVersionCompatibility checks compatibilty of the

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -89,6 +89,7 @@ func (s *Server) HandleDelegateRequest(cmd string, k8sArgs *types.K8sArgs, cniCm
 	var err error
 	var multusConfByte []byte
 
+	// !bang need to not have both of these?
 	multusConfByte = bytes.Replace(s.serverConfig, []byte(","), []byte("{"), 1)
 	multusConfig := types.GetDefaultNetConf()
 	if err = json.Unmarshal(multusConfByte, multusConfig); err != nil {
@@ -151,6 +152,7 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 	// preprocess server config to be used to override multus CNI config
 	// see extractCniData() for the detail
 	if servConfig != nil {
+		// !bang need to not have both of these?
 		servConfig = bytes.Replace(servConfig, []byte("{"), []byte(","), 1)
 	}
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -50,17 +50,3 @@ type ShimNetConf struct {
 	LogLevel        string `json:"logLevel,omitempty"`
 	LogToStderr     bool   `json:"logToStderr,omitempty"`
 }
-
-// ControllerNetConf for the controller cni configuration
-type ControllerNetConf struct {
-	ConfDir     string `json:"confDir"`
-	CNIDir      string `json:"cniDir"`
-	BinDir      string `json:"binDir"`
-	LogFile     string `json:"logFile"`
-	LogLevel    string `json:"logLevel"`
-	LogToStderr bool   `json:"logToStderr,omitempty"`
-
-	// Option to point to the path of the unix domain socket through which the
-	// multus client / server communicate.
-	MultusSocketDir string `json:"socketDir"`
-}

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -445,18 +445,6 @@ func LoadDaemonNetConf(configPath string) (*ControllerNetConf, []byte, error) {
 		logging.SetLogLevel(daemonNetConf.LogLevel)
 	}
 
-	if daemonNetConf.CNIDir == "" {
-		daemonNetConf.CNIDir = defaultCNIDir
-	}
-
-	if daemonNetConf.ConfDir == "" {
-		daemonNetConf.ConfDir = defaultConfDir
-	}
-
-	if daemonNetConf.BinDir == "" {
-		daemonNetConf.BinDir = defaultBinDir
-	}
-
 	if daemonNetConf.MultusSocketDir == "" {
 		daemonNetConf.MultusSocketDir = defaultMultusRunDir
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -16,8 +16,9 @@
 package types
 
 import (
-	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/logging"
 	"net"
+
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/logging"
 
 	"github.com/containernetworking/cni/pkg/types"
 	cni100 "github.com/containernetworking/cni/pkg/types/100"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -184,9 +184,6 @@ type ResourceClient interface {
 // ControllerNetConf for the controller cni configuration
 type ControllerNetConf struct {
 	ChrootDir   string `json:"chrootDir,omitempty"`
-	ConfDir     string `json:"confDir"`
-	CNIDir      string `json:"cniDir"`
-	BinDir      string `json:"binDir"`
 	LogFile     string `json:"logFile"`
 	LogLevel    string `json:"logLevel"`
 	LogToStderr bool   `json:"logToStderr,omitempty"`


### PR DESCRIPTION
Work in progress for making so that users only have to specify configurations in a single place -- the configMap.

Keeps only the bare minimum of command line options (in particular: where the config file lives, and the version flag)

Currently just attempts to remove command line arguments and see what needs to change from there (before further changes)