### PR TITLE
fix:extensions/v1beta1 is changed to apps/v1

### DIFF
--- a/deployments/deprecated/multus-daemonset-crio-pre1.16.yml
+++ b/deployments/deprecated/multus-daemonset-crio-pre1.16.yml
@@ -127,7 +127,7 @@ data:
       "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-amd64
@@ -198,7 +198,7 @@ spec:
             - key: cni-conf.json
               path: 70-multus.conf
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-ppc64le

--- a/deployments/deprecated/multus-daemonset-gke-pre-1.16.yml
+++ b/deployments/deprecated/multus-daemonset-gke-pre-1.16.yml
@@ -108,7 +108,7 @@ data:
       "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-amd64
@@ -169,7 +169,7 @@ spec:
               - key: cni-conf.json
                 path: 70-multus.conf
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-ppc64le

--- a/deployments/deprecated/multus-daemonset-pre-1.16.yml
+++ b/deployments/deprecated/multus-daemonset-pre-1.16.yml
@@ -127,7 +127,7 @@ data:
       "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-amd64
@@ -187,7 +187,7 @@ spec:
             - key: cni-conf.json
               path: 70-multus.conf
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-ppc64le


### PR DESCRIPTION
Signed-off-by: yulng <wei.yang@daocloud.io>

The apiversion extensions/v1beta1 for DaemonSet has been changed to apps/v1 from k8s v1.9 version

Thanks