### PR TITLE
Fix crio fails without systemctl

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -449,7 +449,7 @@ EOF
         # Restart CRIO only once.
         if [ "$CRIO_RESTARTED_ONCE" == false ]; then
           log "Restarting crio"
-          systemctl restart crio
+          systemctl restart crio || service crio restart
           CRIO_RESTARTED_ONCE=true
         fi
       fi


### PR DESCRIPTION
If the crio version is deployed on a system without systemctl (like Alpine Linux or Devuan) it fails to start.

Fixes #975