### PR TITLE
fix multi-architecture for thick image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -19,8 +19,8 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:latest-amd64
           file: images/Dockerfile
 
-  build-amd64-thick:
-    name: Image build/amd64 thick plugin
+  build-xplatform-thick:
+    name: Image build xplatform thick plugin
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -34,8 +34,9 @@ jobs:
         with:
           context: .
           push: false
-          tags: ghcr.io/${{ github.repository }}:latest-amd64-thick
+          tags: ghcr.io/${{ github.repository }}:latest-thick
           file: images/Dockerfile.thick
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
 
   build-arm64:
     name: Image build/arm64

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -211,20 +211,6 @@ jobs:
       - name: Create manifest for multi-arch images
         if: github.repository_owner == 'k8snetworkplumbingwg'
         run: |
-          # snapshot-thick
-          # get artifacts from previous steps
-          docker pull ${{ env.REPOSITORY }}:snapshot-thick-amd64
-          docker manifest create ${{ env.REPOSITORY }}:snapshot-thick ${{ env.REPOSITORY }}:snapshot-thick-amd64
-          docker manifest annotate ${{ env.REPOSITORY }}:snapshot-thick ${{ env.REPOSITORY }}:snapshot-thick-amd64 --arch amd64
-          docker manifest push ${{ env.REPOSITORY }}:snapshot-thick
-
-          # latest-thick
-          # get artifacts from previous steps
-          docker pull ${{ env.REPOSITORY }}:latest-thick-amd64
-          docker manifest create ${{ env.REPOSITORY }}:latest-thick ${{ env.REPOSITORY }}:latest-thick-amd64
-          docker manifest annotate ${{ env.REPOSITORY }}:latest-thick ${{ env.REPOSITORY }}:latest-thick-amd64 --arch amd64
-          docker manifest push ${{ env.REPOSITORY }}:latest-thick
-
           # snapshot
           # get artifacts from previous steps
           docker pull ${{ env.REPOSITORY }}:snapshot-amd64

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -40,9 +40,10 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest-thick-amd64
-            ghcr.io/${{ github.repository }}:snapshot-thick-amd64
+            ghcr.io/${{ github.repository }}:latest-thick
+            ghcr.io/${{ github.repository }}:snapshot-thick
           file: images/Dockerfile.thick
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
 
   push-arm64:
     name: Image push/arm64

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -47,9 +47,10 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:stable-thick-amd64
-            ${{ steps.docker_meta.outputs.tags }}-thick-amd64
+            ghcr.io/${{ github.repository }}:stable-thick
+            ${{ steps.docker_meta.outputs.tags }}-thick
           file: images/Dockerfile.thick
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
 
   push-arm64:
     name: Image push/arm64

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -260,20 +260,6 @@ jobs:
       - name: Create manifest for multi-arch images
         if: github.repository_owner == 'k8snetworkplumbingwg'
         run: |
-          # <tag>-thick
-          # get artifacts from previous steps
-          docker pull ${{ steps.docker_meta.outputs.tags }}-thick-amd64
-          docker manifest create ${{ steps.docker_meta.outputs.tags }}-thick ${{ steps.docker_meta.outputs.tags }}-thick-amd64
-          docker manifest annotate ${{ steps.docker_meta.outputs.tags }}-thick ${{ steps.docker_meta.outputs.tags }}-thick-amd64 --arch amd64
-          docker manifest push ${{ steps.docker_meta.outputs.tags }}-thick
-
-          # stable-thick
-          # get artifacts from previous steps
-          docker pull ${{ env.REPOSITORY }}:stable-thick-amd64
-          docker manifest create ${{ env.REPOSITORY }}:stable-thick ${{ env.REPOSITORY }}:stable-thick-amd64
-          docker manifest annotate ${{ env.REPOSITORY }}:stable-thick ${{ env.REPOSITORY }}:stable-thick-amd64 --arch amd64
-          docker manifest push ${{ env.REPOSITORY }}:stable-thick
-
           # <tag>
           # get artifacts from previous steps
           docker pull ${{ steps.docker_meta.outputs.tags }}-amd64

--- a/images/Dockerfile.thick
+++ b/images/Dockerfile.thick
@@ -1,11 +1,21 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM golang:1.18 as build
+FROM --platform=$BUILDPLATFORM  golang:1.18 as build
 
 # Add everything
 ADD . /usr/src/multus-cni
 
-RUN  cd /usr/src/multus-cni && \
-     ./hack/build-go.sh
+ENV GOOS "linux"
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+    export GOARCH=amd64 ; \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    export GOARCH=arm64 ; \
+    elif [ "$TARGETPLATFORM" = "linux/arm/v7" ]; then \
+    export GOARCH=arm ; \
+    fi \
+    && cd /usr/src/multus-cni \
+    && ./hack/build-go.sh
 
 FROM debian:stable-slim
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni


### PR DESCRIPTION
updates to Dockerfile.thick to allow for elegant multi-architecture builds in a single Dockerfile.

```bash
#set target platforms
PLATFORM="linux/amd64,linux/arm64,linux/arm/v7"

#Create a new builder instance
docker buildx create --name multus-cni --use

#Start the build
docker buildx build \
    -f images/Dockerfile.thick \
    -t ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick \
    --platform $PLATFORM \
    --pull \
    .
```