### PR TITLE
Remove deprecated 'restart-crio' option

### DIFF
--- a/deployments/multus-daemonset-crio.yml
+++ b/deployments/multus-daemonset-crio.yml
@@ -186,7 +186,6 @@ spec:
         - "--cni-version=0.3.1"
         - "--cni-bin-dir=/host/usr/libexec/cni"
         - "--multus-conf-file=auto"
-        - "--restart-crio=true"
         resources:
           requests:
             cpu: "100m"

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -619,10 +619,6 @@ In some cases, the original CNI configuration that the Multus configuration was 
 
     --cleanup-config-on-exit=true
 
-When using CRIO, you may need to restart CRIO to get the Multus configuration file to take -- this is rarely necessary.
-
-    --restart-crio=false
-
 Additionally when using CRIO, you may wish to have the CNI config file that's used as the source for `--multus-conf-file=auto` renamed. This boolean option when set to true automatically renames the file with a `.old` suffix to the original filename.
 
     --rename-conf-file=true

--- a/docs/thick-plugin.md
+++ b/docs/thick-plugin.md
@@ -63,7 +63,6 @@ its thin counterpart allows - with the following exceptions:
 - `cniDir`
 - `multus-kubeconfig-file-host`
 - `rename-conf-file`
-- `restart-crio`
 - `skip-multus-binary-copy`
 
 It is important to refer that these are command line parameters to the golang

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -33,8 +33,6 @@ MULTUS_LOG_FILE=""
 MULTUS_READINESS_INDICATOR_FILE=""
 OVERRIDE_NETWORK_NAME=false
 MULTUS_CLEANUP_CONFIG_ON_EXIT=false
-RESTART_CRIO=false
-CRIO_RESTARTED_ONCE=false
 RENAME_SOURCE_CONFIG_FILE=false
 SKIP_BINARY_COPY=false
 FORCE_CNI_VERSION=false # force-cni-version is only for e2e-kind.
@@ -71,7 +69,6 @@ function usage()
     echo -e "\t--rename-conf-file=false (used only with --multus-conf-file=auto)"
     echo -e "\t--readiness-indicator-file=$MULTUS_READINESS_INDICATOR_FILE (used only with --multus-conf-file=auto)"
     echo -e "\t--additional-bin-dir=$ADDITIONAL_BIN_DIR (adds binDir option to configuration, used only with --multus-conf-file=auto)"
-    echo -e "\t--restart-crio=false (restarts CRIO after config file is generated)"
 }
 
 function log()
@@ -165,9 +162,6 @@ while [ "$1" != "" ]; do
             ;;
         --cleanup-config-on-exit)
             MULTUS_CLEANUP_CONFIG_ON_EXIT=$VALUE
-            ;;
-        --restart-crio)
-            RESTART_CRIO=$VALUE
             ;;
         --rename-conf-file)
             RENAME_SOURCE_CONFIG_FILE=$VALUE
@@ -443,15 +437,6 @@ EOF
       if [ "$RENAME_SOURCE_CONFIG_FILE" == true ]; then
         mv ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN} ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN}.old
         log "Original master file moved to ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN}.old"
-      fi
-
-      if [ "$RESTART_CRIO" == true ]; then
-        # Restart CRIO only once.
-        if [ "$CRIO_RESTARTED_ONCE" == false ]; then
-          log "Restarting crio"
-          systemctl restart crio
-          CRIO_RESTARTED_ONCE=true
-        fi
       fi
     fi
   done


### PR DESCRIPTION
'restart-crio' option was used for workaround crio issues. This issue no longer exists, hence make it obsolate and removed.