### PR TITLE
avoid panic when array length =0.

### DIFF
--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -54,7 +54,7 @@ func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error 
 		return logging.Errorf("LoadDelegateNetConfList: error unmarshalling delegate conflist: %v", err)
 	}
 
-	if delegateConf.ConfList.Plugins == nil {
+	if delegateConf.ConfList.Plugins == nil || len(delegateConf.ConfList.Plugins) == 0 {
 		return logging.Errorf("LoadDelegateNetConfList: delegate must have the 'type' or 'plugin' field")
 	}
 


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

Make code more robust for panic array.