### PR TITLE
Cleanup : github.com/pkg/errors has been archived.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
 	github.com/onsi/ginkgo/v2 v2.5.1
 	github.com/onsi/gomega v1.24.0
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	golang.org/x/net v0.1.0
 	golang.org/x/sys v0.2.0

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -16,13 +16,13 @@
 package logging
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 )
 


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>
[https://github.com/pkg/errors](https://github.com/pkg/errors)  says : This repository has been archived by the owner on Dec 1, 2021. It is now read-only.

I suggest we should delete that , replaced by the go's error package.