### PR TITLE
docs, thick plugin: align docs with new configuration reference

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -133,7 +133,7 @@ func main() {
 		configurationOptions = append(
 			configurationOptions,
 			config.WithCniConfigDir(multusConf.CniConfigDir),
-			config.WithSocketDir(daemonConf.DaemonSocketDir))
+			config.WithSocketDir(daemonConf.SocketDir))
 
 		var logOptionFuncs []config.LogOptionFunc
 		if multusConf.LogMaxAge != defaultMultusLogMaxAge {
@@ -226,7 +226,7 @@ func startMultusDaemon(daemonConfig *types.ControllerNetConf, stopCh chan struct
 		return fmt.Errorf("failed to run multus-daemon with root: %v, now running in uid: %s", err, user.Uid)
 	}
 
-	if err := srv.FilesystemPreRequirements(daemonConfig.DaemonSocketDir); err != nil {
+	if err := srv.FilesystemPreRequirements(daemonConfig.SocketDir); err != nil {
 		return fmt.Errorf("failed to prepare the cni-socket for communicating with the shim: %w", err)
 	}
 
@@ -243,9 +243,9 @@ func startMultusDaemon(daemonConfig *types.ControllerNetConf, stopCh chan struct
 		}, 0, stopCh)
 	}
 
-	l, err := srv.GetListener(api.SocketPath(daemonConfig.DaemonSocketDir))
+	l, err := srv.GetListener(api.SocketPath(daemonConfig.SocketDir))
 	if err != nil {
-		return fmt.Errorf("failed to start the CNI server using socket %s. Reason: %+v", api.SocketPath(daemonConfig.DaemonSocketDir), err)
+		return fmt.Errorf("failed to start the CNI server using socket %s. Reason: %+v", api.SocketPath(daemonConfig.SocketDir), err)
 	}
 
 	server.SetKeepAlivesEnabled(false)

--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -117,7 +117,7 @@ data:
         "logFile": "/tmp/multus.log",
         "binDir": "/opt/cni/bin",
         "cniDir": "/var/lib/cni/multus",
-        "daemonSocketDir": "/host/run/multus/",
+        "socketDir": "/host/run/multus/",
         "cniVersion": "0.3.1",
         "cniConfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",

--- a/docs/thick-plugin.md
+++ b/docs/thick-plugin.md
@@ -53,37 +53,58 @@ kubectl apply -f deployments/multus-daemonset-thick.yml
 
 ### Command line parameters
 
-Multus thick plugin variant accepts the same
-[entrypoint arguments](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/how-to-use.md#entrypoint-script-parameters)
-its thin counterpart allows - with the following exceptions:
-
-- `additional-bin-dir`
-- `binDir`
-- `cleanup-config-on-exit`
-- `cniDir`
-- `multus-kubeconfig-file-host`
-- `rename-conf-file`
-- `skip-multus-binary-copy`
-
-It is important to refer that these are command line parameters to the golang
-binary; as such, they should be passed using a single dash ("-") e.g.
-`-additional-bin-dir=/opt/multus/bin`, `-multus-log-level=debug`, etc.
-
-Furthermore, it also accepts a new command line parameter, where the user
-specifies the path to the server configuration:
+The available command line parameters are:
 
 - `config`: Defaults to `"/etc/cni/net.d/multus.d/daemon-config.json"`
-- `metricsPort`: Metrics port (of multus' metric exporter), default is disable
+- `version`: Prints the daemon config version and exits
 
-### Server configuration
+### Server / Daemon configuration
 
 The server configuration is encoded in JSON, and allows the following keys:
 
 - `"chrootDir"`: Specify the directory which points to host root from the pod. See 'Chroot configuration' section for the details.
-- `"socketDir"`: Specify the location where the unix domain socket used for
-client/server communication will be located. Defaults to `"/run/multus"`.
+- `"socketDir"`: Specify the location where the unix domain socket used
+for client/server communication will be located. This is the location where the
+**Daemon** will read the configuration from. Defaults to `"/run/multus"`.
+- `"metricsPort"`: Metrics port (of multus' metric exporter); by default, no port
+is provided.
+- `"logFile"`: the path to where the daemon logs will be persisted.
+- `"logLevel"`: the logging level for the multus daemon logs.
+- `"logToStderr"`: enable this to have the daemon multus logs echoed to stderr
+as well. By default, it is disabled.
 
 In addition, you can add any configuration which is in [configuration reference](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/docs/configuration.md#multus-cni-configuration-reference). Server configuration override multus CNI configuration (e.g. `/etc/cni/net.d/00-multus.conf`)
+
+Below you can see an example of the daemon configuration:
+```json
+{
+        "chrootDir": "/hostroot",
+        "confDir": "/host/etc/cni/net.d",
+        "logToStderr": true,
+        "logLevel": "verbose",
+        "logFile": "/tmp/multus.log",
+        "binDir": "/opt/cni/bin",
+        "cniDir": "/var/lib/cni/multus",
+        "socketDir": "/host/run/multus/",
+        "cniVersion": "0.3.1",
+        "cniConfigDir": "/host/etc/cni/net.d",
+        "multusConfigFile": "auto",
+        "multusAutoconfigDir": "/host/etc/cni/net.d"
+    }
+```
+
+### Client / Shim configuration
+
+The multus shim configuration is encoded in JSON, and essentially is just a
+regular CNI configuration, usually available in `/etc/cni/net.d/00-multus.conf`.
+
+It allows the following keys:
+
+- `"cniVersion"`: the CNI version for the Multus CNI plugin.
+- `"logFile"`:  the path to where the daemon logs will be persisted.
+- `"logLevel"`: the logging level for the multus daemon logs.
+- `"logToStderr"`: enable this to have the daemon multus logs echoed to stderr
+  as well. By default, it is disabled.
 
 #### Chroot configuration
 

--- a/e2e/templates/multus-daemonset-thick.yml.j2
+++ b/e2e/templates/multus-daemonset-thick.yml.j2
@@ -90,7 +90,7 @@ data:
         "logFile": "/tmp/multus.log",
         "binDir": "/host/opt/cni/bin",
         "cniDir": "/var/lib/cni/multus",
-        "daemonSocketDir": "/host/run/multus",
+        "socketDir": "/host/run/multus",
         "cniVersion": "{{ CNI_VERSION }}",
         "cniConfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",

--- a/pkg/server/api/shim.go
+++ b/pkg/server/api/shim.go
@@ -34,7 +34,7 @@ type ShimNetConf struct {
 	// types.NetConf
 
 	CNIVersion      string `json:"cniVersion,omitempty"`
-	MultusSocketDir string `json:"shimSocketDir"`
+	MultusSocketDir string `json:"daemonSocketDir"`
 	LogFile         string `json:"logFile,omitempty"`
 	LogLevel        string `json:"logLevel,omitempty"`
 	LogToStderr     bool   `json:"logToStderr,omitempty"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -143,7 +143,7 @@ func NewCNIServer(daemonConfig *types.ControllerNetConf, serverConfig []byte) (*
 		logging.Verbosef("server configured with chroot: %s", daemonConfig.ChrootDir)
 	}
 
-	return newCNIServer(daemonConfig.DaemonSocketDir, kubeClient, exec, serverConfig)
+	return newCNIServer(daemonConfig.SocketDir, kubeClient, exec, serverConfig)
 }
 
 func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, servConfig []byte) (*Server, error) {

--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -285,7 +285,7 @@ func referenceConfig(thickPluginSocketDir string) string {
 	"cniVersion": "0.4.0",
         "name": "node-cni-network",
         "type": "multus",
-        "shimSocketDir": "%s",
+        "daemonSocketDir": "%s",
         "defaultnetworkfile": "/tmp/foo.multus.conf",
         "defaultnetworkwaitseconds": 3,
         "delegates": [{

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -428,7 +428,7 @@ const (
 // LoadDaemonNetConf loads the configuration for the multus daemon
 func LoadDaemonNetConf(config []byte) (*ControllerNetConf, error) {
 	daemonNetConf := &ControllerNetConf{
-		DaemonSocketDir: DefaultMultusRunDir,
+		SocketDir: DefaultMultusRunDir,
 	}
 	if err := json.Unmarshal(config, daemonNetConf); err != nil {
 		return nil, fmt.Errorf("failed to unmarshall the daemon configuration: %w", err)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -195,10 +195,5 @@ type ControllerNetConf struct {
 	// multus client / server communicate.
 	DaemonSocketDir string `json:"daemonSocketDir"`
 
-	// Option to point to the path of the unix domain socket through which the
-	// multus client / server communicate.
-	// This attribute is only relevant for the client / shim.
-	ShimSocketDir string `json:"shimSocketDir"`
-
 	ConfigFileContents []byte `json:"-"`
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -193,7 +193,7 @@ type ControllerNetConf struct {
 
 	// Option to point to the path of the unix domain socket through which the
 	// multus client / server communicate.
-	DaemonSocketDir string `json:"daemonSocketDir"`
+	SocketDir string `json:"socketDir"`
 
 	ConfigFileContents []byte `json:"-"`
 }


### PR DESCRIPTION
PR #1053 changed the thick plugin configuration to happen exclusively via the user provided config map.

This PR aligns the multus documentation with the existing code.

It also renames the multus socket dir configuration to something that does not stutter (daemon.DaemonSocketDir stutters).
