### PR TITLE
Remove 'cni-version' option in default deployment

### DIFF
--- a/deployments/multus-daemonset.yml
+++ b/deployments/multus-daemonset.yml
@@ -183,7 +183,6 @@ spec:
         command: ["/thin_entrypoint"]
         args:
         - "--multus-conf-file=auto"
-        - "--cni-version=0.3.1"
         - "--multus-autoconfig-dir=/host/etc/cni/net.d"
         - "--cni-conf-dir=/host/etc/cni/net.d"
         resources:


### PR DESCRIPTION
This change removes 'cni-version' option in entrypoint from default deployment manifest. This change uses cniVersion of delegate CNI, cluster network.