### PR TITLE
Refactoring thick daemon config processing

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -112,11 +112,7 @@ data:
     {
         "chrootDir": "/hostroot",
         "confDir": "/host/etc/cni/net.d",
-        "logToStderr": true,
         "logLevel": "verbose",
-        "logFile": "/tmp/multus.log",
-        "binDir": "/opt/cni/bin",
-        "cniDir": "/var/lib/cni/multus",
         "socketDir": "/host/run/multus/",
         "cniVersion": "0.3.1",
         "cniConfigDir": "/host/etc/cni/net.d",

--- a/pkg/server/config/manager.go
+++ b/pkg/server/config/manager.go
@@ -108,7 +108,7 @@ func newManager(config MultusConf, multusConfigDir, defaultCNIPluginName string,
 		configWatcher:        watcher,
 		multusConfig:         &config,
 		multusConfigDir:      multusConfigDir,
-		multusConfigFilePath: cniPluginConfigFilePath(config.CniConfigDir, multusConfigFileName),
+		multusConfigFilePath: cniPluginConfigFilePath(multusConfigDir, multusConfigFileName),
 		primaryCNIConfigPath: cniPluginConfigFilePath(multusConfigDir, defaultCNIPluginName),
 	}
 
@@ -144,16 +144,16 @@ func (m *Manager) OverrideNetworkName() error {
 	if networkName == "" {
 		return fmt.Errorf("the primary CNI Configuration does not feature the network name: %v", m.cniConfigData)
 	}
-	return m.multusConfig.Mutate(WithOverriddenName(networkName))
+	m.multusConfig.Name = networkName
+	return nil
 }
 
 func (m *Manager) loadPrimaryCNIConfigurationData(primaryCNIConfigData interface{}) error {
 	cniConfigData := primaryCNIConfigData.(map[string]interface{})
 
 	m.cniConfigData = cniConfigData
-	return m.multusConfig.Mutate(
-		withClusterNetwork(m.primaryCNIConfigPath),
-		withCapabilities(cniConfigData))
+	m.multusConfig.ClusterNetwork = m.primaryCNIConfigPath
+	return m.multusConfig.setCapabilities(cniConfigData)
 }
 
 // GenerateConfig generates a multus configuration from its current state

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -24,6 +24,15 @@ import (
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v3/pkg/k8sclient"
 )
 
+const (
+	// const block for multus-daemon configs
+
+	// DefaultMultusDaemonConfigFile is the Default path of the config file
+	DefaultMultusDaemonConfigFile = "/etc/cni/net.d/multus.d/daemon-config.json"
+	// DefaultMultusRunDir specifies default RunDir for multus
+	DefaultMultusRunDir = "/run/multus/"
+)
+
 // Metrics represents server's metrics.
 type Metrics struct {
 	requestCounter *prometheus.CounterVec
@@ -38,4 +47,20 @@ type Server struct {
 	exec         invoke.Exec
 	serverConfig []byte
 	metrics      *Metrics
+}
+
+// ControllerNetConf for the controller cni configuration
+type ControllerNetConf struct {
+	ChrootDir   string `json:"chrootDir,omitempty"`
+	LogFile     string `json:"logFile"`
+	LogLevel    string `json:"logLevel"`
+	LogToStderr bool   `json:"logToStderr,omitempty"`
+
+	MetricsPort *int `json:"metricsPort,omitempty"`
+
+	// Option to point to the path of the unix domain socket through which the
+	// multus client / server communicate.
+	SocketDir string `json:"socketDir"`
+
+	ConfigFileContents []byte `json:"-"`
 }

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -418,36 +418,6 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 	return netconf, nil
 }
 
-const (
-	// const block for multus-daemon configs
-
-	// DefaultMultusDaemonConfigFile is the Default path of the config file
-	DefaultMultusDaemonConfigFile = "/etc/cni/net.d/multus.d/daemon-config.json"
-	// DefaultMultusRunDir specifies default RunDir for multus
-	DefaultMultusRunDir           = "/run/multus/"
-)
-
-// LoadDaemonNetConf loads the configuration for the multus daemon
-func LoadDaemonNetConf(config []byte) (*ControllerNetConf, error) {
-	daemonNetConf := &ControllerNetConf{
-		SocketDir: DefaultMultusRunDir,
-	}
-	if err := json.Unmarshal(config, daemonNetConf); err != nil {
-		return nil, fmt.Errorf("failed to unmarshall the daemon configuration: %w", err)
-	}
-
-	logging.SetLogStderr(daemonNetConf.LogToStderr)
-	if daemonNetConf.LogFile != DefaultMultusDaemonConfigFile {
-		logging.SetLogFile(daemonNetConf.LogFile)
-	}
-	if daemonNetConf.LogLevel != "" {
-		logging.SetLogLevel(daemonNetConf.LogLevel)
-	}
-	daemonNetConf.ConfigFileContents = config
-
-	return daemonNetConf, nil
-}
-
 // AddDelegates appends the new delegates to the delegates list
 func (n *NetConf) AddDelegates(newDelegates []*DelegateNetConf) error {
 	logging.Debugf("AddDelegates: %v", newDelegates)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -181,19 +181,3 @@ type ResourceClient interface {
 	// GetPodResourceMap returns an instance of a map of Pod ResourceInfo given a (Pod name, namespace) tuple
 	GetPodResourceMap(*v1.Pod) (map[string]*ResourceInfo, error)
 }
-
-// ControllerNetConf for the controller cni configuration
-type ControllerNetConf struct {
-	ChrootDir   string `json:"chrootDir,omitempty"`
-	LogFile     string `json:"logFile"`
-	LogLevel    string `json:"logLevel"`
-	LogToStderr bool   `json:"logToStderr,omitempty"`
-
-	MetricsPort *int `json:"metricsPort,omitempty"`
-
-	// Option to point to the path of the unix domain socket through which the
-	// multus client / server communicate.
-	SocketDir string `json:"socketDir"`
-
-	ConfigFileContents []byte `json:"-"`
-}


### PR DESCRIPTION
to damonset config file, hence command line option parsing is no longer used. This change removes these parts.

Fix #1058.