### PR TITLE
Add mutex lock for load confs in GetDefaultNetworks

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -542,6 +542,13 @@ func getNetDelegate(client *ClientInfo, pod *v1.Pod, netname, confdir, namespace
 		}
 
 		// option2) search CNI json config file, which has <netname> as CNI name, from confDir
+
+		// acquire lock to access file
+		if types.ChrootMutex != nil {
+			types.ChrootMutex.Lock()
+			defer types.ChrootMutex.Unlock()
+		}
+
 		configBytes, err = netutils.GetCNIConfigFromFile(netname, confdir)
 		if err == nil {
 			delegate, err := types.LoadDelegateNetConf(configBytes, nil, "", "")
@@ -551,6 +558,12 @@ func getNetDelegate(client *ClientInfo, pod *v1.Pod, netname, confdir, namespace
 			return delegate, resourceMap, nil
 		}
 	} else {
+		// acquire lock to access file
+		if types.ChrootMutex != nil {
+			types.ChrootMutex.Lock()
+			defer types.ChrootMutex.Unlock()
+		}
+
 		fInfo, err := os.Stat(netname)
 		if err != nil {
 			return nil, resourceMap, err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -136,10 +136,12 @@ func NewCNIServer(daemonConfig *ControllerNetConf, serverConfig []byte) (*Server
 
 	exec := invoke.Exec(nil)
 	if daemonConfig.ChrootDir != "" {
-		exec = &ChrootExec{
+		chrootExec := &ChrootExec{
 			Stderr:    os.Stderr,
 			chrootDir: daemonConfig.ChrootDir,
 		}
+		types.ChrootMutex = &chrootExec.mu
+		exec = chrootExec
 		logging.Verbosef("server configured with chroot: %s", daemonConfig.ChrootDir)
 	}
 

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/skel"
@@ -38,6 +39,9 @@ const (
 	defaultMultusNamespace        = "kube-system"
 	defaultNonIsolatedNamespace   = "default"
 )
+
+// ChrootMutex provides lock to access host filesystem
+var ChrootMutex *sync.Mutex
 
 // LoadDelegateNetConfList reads DelegateNetConf from bytes
 func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error {


### PR DESCRIPTION
Thick server's chroot mutex is missing in GetDefaultNetworks, that touch the pod filesystem. This change adds mutex lock there and prevent race condition.

Fix #1072