### PR TITLE
Fix race conditions in logging package functions and enable race detection in tests

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -19,5 +19,5 @@ if [ "$GO111MODULE" == "off" ]; then
 	bash -c "umask 0; cd ${GOPATH}/src/${REPO_PATH}; PATH=${GOROOT}/bin:$(pwd)/bin:${PATH} go test -v -covermode=count -coverprofile=coverage.out ./..."
 else
 	# test with go modules
-	bash -c "umask 0; go test -v -covermode=count -coverprofile=coverage.out ./..."
+	bash -c "umask 0; go test -v -race -covermode=atomic -coverprofile=coverage.out ./..."
 fi

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -57,24 +57,29 @@ type LogOptions struct {
 // SetLogOptions set the LoggingOptions of NetConf
 func SetLogOptions(options *LogOptions) {
 	// give some default value
-	logger.MaxSize = 100
-	logger.MaxAge = 5
-	logger.MaxBackups = 5
-	logger.Compress = true
+	updatedLogger := lumberjack.Logger{
+		Filename:   logger.Filename,
+		MaxAge:     5,
+		MaxBackups: 5,
+		Compress:   true,
+		MaxSize:    100,
+		LocalTime:  logger.LocalTime,
+	}
 	if options != nil {
 		if options.MaxAge != nil {
-			logger.MaxAge = *options.MaxAge
+			updatedLogger.MaxAge = *options.MaxAge
 		}
 		if options.MaxSize != nil {
-			logger.MaxSize = *options.MaxSize
+			updatedLogger.MaxSize = *options.MaxSize
 		}
 		if options.MaxBackups != nil {
-			logger.MaxBackups = *options.MaxBackups
+			updatedLogger.MaxBackups = *options.MaxBackups
 		}
 		if options.Compress != nil {
-			logger.Compress = *options.Compress
+			updatedLogger.Compress = *options.Compress
 		}
 	}
+	logger = &updatedLogger
 	loggingW = logger
 }
 
@@ -174,10 +179,16 @@ func SetLogFile(filename string) {
 	if filename == "" {
 		return
 	}
-
-	logger.Filename = filename
+	updatedLogger := lumberjack.Logger{
+		Filename:   filename,
+		MaxAge:     logger.MaxAge,
+		MaxBackups: logger.MaxBackups,
+		Compress:   logger.Compress,
+		MaxSize:    logger.MaxSize,
+		LocalTime:  logger.LocalTime,
+	}
+	logger = &updatedLogger
 	loggingW = logger
-
 }
 
 func init() {


### PR DESCRIPTION
This PR addresses the race conditions discovered during local testing using the Go race command. The race command detected potential data race conditions in the logging package's SetLogOptions and SetLogFile functions when multiple goroutines accessed and modified the shared logger struct concurrently.

 Before applying the fix, the race detector logs indicated conflicting accesses as can be seen here:

```
WARNING: DATA RACE
Write at 0x00c000040d38 by goroutine 35:
  [gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging.SetLogOptions()](http://gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging.SetLogOptions())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/pkg/logging/logging.go:61 +0x6e4
  [gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.LoadNetConf()](http://gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.LoadNetConf())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/pkg/types/conf.go:353 +0x652
  [gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.glob](http://gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.glob)..func1.6()
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/pkg/types/conf_test.go:155 +0x4a
  [github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()](http://github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/internal/node.go:445 +0x30
  [github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()](http://github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:820 +0x114

Previous read at 0x00c000040d38 by goroutine 31:
  [gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRunOnce()](http://gopkg.in/natefinch/lumberjack.v2.(*Logger).millRunOnce())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:336 +0x5f2
  [gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun()](http://gopkg.in/natefinch/lumberjack.v2.(*Logger).millRun())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:381 +0x56
  [gopkg.in/natefinch/lumberjack%2ev2.(*Logger).mill.func1.1()](http://gopkg.in/natefinch/lumberjack.v2.(*Logger).mill.func1.1())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:390 +0x39

Goroutine 35 (running) created at:
  [github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()](http://github.com/onsi/ginkgo/v2/internal.(*Suite).runNode())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:807 +0x1359
  [github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()](http://github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/internal/group.go:190 +0x1124
  [github.com/onsi/ginkgo/v2/internal.(*group).run()](http://github.com/onsi/ginkgo/v2/internal.(*group).run())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/internal/group.go:330 +0xf67
  [github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()](http://github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:441 +0x1146
  [github.com/onsi/ginkgo/v2/internal.(*Suite).Run()](http://github.com/onsi/ginkgo/v2/internal.(*Suite).Run())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:110 +0x5f5
  [github.com/onsi/ginkgo/v2.RunSpecs()](http://github.com/onsi/ginkgo/v2.RunSpecs())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/core_dsl.go:296 +0x16ca
  [gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.TestConf()](http://gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.TestConf())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/pkg/types/conf_test.go:37 +0x55
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1629 +0x47

Goroutine 31 (running) created at:
  [gopkg.in/natefinch/lumberjack%2ev2.(*Logger).mill.func1()](http://gopkg.in/natefinch/lumberjack.v2.(*Logger).mill.func1())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:390 +0xee
  sync.(*Once).doSlow()
      /usr/local/go/src/sync/once.go:74 +0x101
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:65 +0x46
  [gopkg.in/natefinch/lumberjack%2ev2.(*Logger).mill()](http://gopkg.in/natefinch/lumberjack.v2.(*Logger).mill())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:388 +0x55
  [gopkg.in/natefinch/lumberjack%2ev2.(*Logger).openExistingOrNew()](http://gopkg.in/natefinch/lumberjack.v2.(*Logger).openExistingOrNew())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:265 +0x51
  [gopkg.in/natefinch/lumberjack%2ev2.(*Logger).Write()](http://gopkg.in/natefinch/lumberjack.v2.(*Logger).Write())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:147 +0x2d2
  fmt.Fprintf()
      /usr/local/go/src/fmt/print.go:225 +0xb1
  [gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging.printf()](http://gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging.printf())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/pkg/logging/logging.go:109 +0x271
  [gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging.Debugf()](http://gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging.Debugf())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/pkg/logging/logging.go:117 +0x179
  [gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.LoadDelegateNetConf()](http://gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.LoadDelegateNetConf())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/pkg/types/conf.go:69 +0xbb
  [gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.LoadNetConf()](http://gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.LoadNetConf())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/pkg/types/conf.go:410 +0x1444
  [gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.glob](http://gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types.glob)..func1.5()
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/pkg/types/conf_test.go:129 +0x3c
  [github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()](http://github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/internal/node.go:445 +0x30
  [github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()](http://github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3())
      /home/asudakov/go/src/github.com/AlinaSecret/multus-cni/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:820 +0x114
==================
==================
```


To resolve these race conditions, a copy of the logger struct is now created within each function.


This PR enables race detection in unit tests by modifying the  the test-go.sh script . The test configuration is updated to include the '-race' flag, allowing thorough race detection during testing. 

for further reference about race detection view: https://go.dev/doc/articles/race_detector)