### PR TITLE
pass through the pod annotations when multus receives them

### DIFF
--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -268,6 +268,9 @@ func newCNIRuntimeConf(containerID, sandboxID, podName, podNamespace, podUID, ne
 		if delegateRc.CNIDeviceInfoFile != "" {
 			capabilityArgs["CNIDeviceInfoFile"] = delegateRc.CNIDeviceInfoFile
 		}
+		if delegateRc.PodAnnotations != nil {
+			capabilityArgs["io.kubernetes.cri.pod-annotations"] = delegateRc.PodAnnotations
+		}
 		rt.CapabilityArgs = capabilityArgs
 	}
 	return rt, cniDeviceInfoFile

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -69,13 +69,14 @@ type NetConf struct {
 
 // RuntimeConfig specifies CNI RuntimeConfig
 type RuntimeConfig struct {
-	PortMaps          []*PortMapEntry `json:"portMappings,omitempty"`
-	Bandwidth         *BandwidthEntry `json:"bandwidth,omitempty"`
-	IPs               []string        `json:"ips,omitempty"`
-	Mac               string          `json:"mac,omitempty"`
-	InfinibandGUID    string          `json:"infinibandGUID,omitempty"`
-	DeviceID          string          `json:"deviceID,omitempty"`
-	CNIDeviceInfoFile string          `json:"CNIDeviceInfoFile,omitempty"`
+	PortMaps          []*PortMapEntry    `json:"portMappings,omitempty"`
+	Bandwidth         *BandwidthEntry    `json:"bandwidth,omitempty"`
+	IPs               []string           `json:"ips,omitempty"`
+	Mac               string             `json:"mac,omitempty"`
+	InfinibandGUID    string             `json:"infinibandGUID,omitempty"`
+	DeviceID          string             `json:"deviceID,omitempty"`
+	CNIDeviceInfoFile string             `json:"CNIDeviceInfoFile,omitempty"`
+	PodAnnotations    *map[string]string `json:"io.kubernetes.cri.pod-annotations,omitempty"`
 }
 
 // PortMapEntry for CNI PortMapEntry


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/issues/69882#issuecomment-1509077177

Passing the annotations seems not to be a standardized behaviour, but it is very useful nontheless.