### PR TITLE
Refine and fix parameters

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -80,8 +80,6 @@ func main() {
 			_ = logging.Errorf("the CNI version is a mandatory parameter when the '-multus-config-file=auto' option is used")
 		}
 
-		multusConf.SocketDir = daemonConf.SocketDir
-
 		var configManager *config.Manager
 		if multusConf.MultusMasterCni == "" {
 			configManager, err = config.NewManager(*multusConf, multusConf.MultusAutoconfigDir, multusConf.ForceCNIVersion)

--- a/cmd/thin_entrypoint/main_test.go
+++ b/cmd/thin_entrypoint/main_test.go
@@ -210,6 +210,7 @@ var _ = Describe("thin entrypoint testing", func() {
 			MultusLogLevel:           "DEBUG",
 			MultusLogFile:            "/tmp/foobar.log",
 			AdditionalBinDir:         "/tmp/add_bin_dir",
+			MultusCNIConfDir:         "/tmp/multus/net.d",
 			ReadinessIndicatorFile:   "/var/lib/foobar_indicator",
 		}).createMultusConfig()
 		Expect(err).NotTo(HaveOccurred())
@@ -225,6 +226,7 @@ var _ = Describe("thin entrypoint testing", func() {
         "logLevel": "debug",
         "logFile": "/tmp/foobar.log",
         "binDir": "/tmp/add_bin_dir",
+        "cniConf": "/tmp/multus/net.d",
         "readinessindicatorfile": "/var/lib/foobar_indicator",
         "kubeconfig": "/etc/foobar_kubeconfig",
         "delegates": [
@@ -368,6 +370,7 @@ var _ = Describe("thin entrypoint testing", func() {
 			MultusLogLevel:           "DEBUG",
 			MultusLogFile:            "/tmp/foobar.log",
 			AdditionalBinDir:         "/tmp/add_bin_dir",
+			MultusCNIConfDir:         "/tmp/multus/net.d",
 			ReadinessIndicatorFile:   "/var/lib/foobar_indicator",
 		}).createMultusConfig()
 		Expect(err).NotTo(HaveOccurred())
@@ -385,6 +388,7 @@ var _ = Describe("thin entrypoint testing", func() {
         "logLevel": "debug",
         "logFile": "/tmp/foobar.log",
         "binDir": "/tmp/add_bin_dir",
+        "cniConf": "/tmp/multus/net.d",
         "readinessindicatorfile": "/var/lib/foobar_indicator",
         "kubeconfig": "/etc/foobar_kubeconfig",
         "delegates": [

--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -111,13 +111,12 @@ data:
   daemon-config.json: |
     {
         "chrootDir": "/hostroot",
-        "confDir": "/host/etc/cni/net.d",
-        "logLevel": "verbose",
-        "socketDir": "/host/run/multus/",
         "cniVersion": "0.3.1",
-        "cniConfigDir": "/host/etc/cni/net.d",
+        "logLevel": "verbose",
+        "logToStderr": true,
+        "multusAutoconfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",
-        "multusAutoconfigDir": "/host/etc/cni/net.d"
+        "socketDir": "/host/run/multus/"
     }
 ---
 apiVersion: apps/v1

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -651,7 +651,7 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 
 		// check Interfaces and IPs because some CNI plugin does not create any interface
 		// and just returns empty result
-		if res != nil &&  (res.Interfaces != nil || res.IPs != nil) {
+		if res != nil && (res.Interfaces != nil || res.IPs != nil) {
 			// Remove gateway from routing table if the gateway is not used
 			deleteV4gateway := false
 			deleteV6gateway := false

--- a/pkg/server/config/generator.go
+++ b/pkg/server/config/generator.go
@@ -55,7 +55,7 @@ type MultusConf struct {
 	Type                     string              `json:"type"`
 	CniDir                   string              `json:"cniDir,omitempty"`
 	CniConfigDir             string              `json:"cniConfigDir,omitempty"`
-	SocketDir                string              `json:"socketDir,omitempty"`
+	DaemonSocketDir          string              `json:"daemonSocketDir,omitempty"`
 	MultusConfigFile         string              `json:"multusConfigFile,omitempty"`
 	MultusMasterCni          string              `json:"multusMasterCNI,omitempty"`
 	MultusAutoconfigDir      string              `json:"multusAutoconfigDir,omitempty"`

--- a/pkg/server/config/manager.go
+++ b/pkg/server/config/manager.go
@@ -108,7 +108,7 @@ func newManager(config MultusConf, multusConfigDir, defaultCNIPluginName string,
 		configWatcher:        watcher,
 		multusConfig:         &config,
 		multusConfigDir:      multusConfigDir,
-		multusConfigFilePath: cniPluginConfigFilePath(multusConfigDir, multusConfigFileName),
+		multusConfigFilePath: cniPluginConfigFilePath(config.CniConfigDir, multusConfigFileName),
 		primaryCNIConfigPath: cniPluginConfigFilePath(multusConfigDir, defaultCNIPluginName),
 	}
 


### PR DESCRIPTION
This changes refines parameters in multus thick/thin.
- delete unused parameter, confDir
- add multus-cni-conf-dir
- fix multusConfigPath in non-default params case