### PR TITLE
Enables multiplatform thick plugin images

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -35,8 +35,8 @@ jobs:
           sbom: false
           provenance: false
 
-  build-amd64-thick:
-    name: Image build/amd64 thick plugin
+  build-thick:
+    name: Image build thick plugin
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -50,8 +50,11 @@ jobs:
         with:
           context: .
           push: false
-          tags: ghcr.io/${{ github.repository }}:latest-amd64-thick
+          tags: ghcr.io/${{ github.repository }}:latest-thick
           file: images/Dockerfile.thick
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+          sbom: false
+          provenance: false
 
   build-origin:
     name: Image build/origin

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -6,8 +6,8 @@ on:
 env:
   image-push-owner: 'k8snetworkplumbingwg'
 jobs:
-  push-thick-amd64:
-    name: Image push thick image/amd64
+  push-thick:
+    name: Image push thick image
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -34,7 +34,9 @@ jobs:
             ghcr.io/${{ github.repository }}:latest-thick
             ghcr.io/${{ github.repository }}:snapshot-thick
           file: images/Dockerfile.thick
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+          sbom: false
+          provenance: false
 
   push-thin:
     name: Image push thin image

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -6,8 +6,8 @@ on:
 env:
   image-push-owner: 'k8snetworkplumbingwg'
 jobs:
-  push-thick-amd64:
-    name: Image push thick image/amd64
+  push-thick:
+    name: Image push thick image
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -42,10 +42,12 @@ jobs:
             ghcr.io/${{ github.repository }}:stable-thick
             ${{ steps.docker_meta.outputs.tags }}-thick
           file: images/Dockerfile.thick
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+          sbom: false
+          provenance: false
 
   push-thin:
-    name: Image push thin image/amd64
+    name: Image push thin image
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory

--- a/images/Dockerfile.thick
+++ b/images/Dockerfile.thick
@@ -1,9 +1,10 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM golang:1.19 as build
+FROM --platform=$BUILDPLATFORM golang:1.19 as build
 
 # Add everything
 ADD . /usr/src/multus-cni
 
+ARG TARGETPLATFORM
 RUN  cd /usr/src/multus-cni && \
      ./hack/build-go.sh
 


### PR DESCRIPTION
v4.0.0-alpha (https://github.com/k8snetworkplumbingwg/multus-cni/pkgs/container/multus-cni/47662597?tag=v4.0.0-alpha) was published as thick plugin for arm64 and I've been running it for almost a year now without any issues.

Would be great to have it available for current versions on arm64.