### PR TITLE
Per node certificates: Add duration parameter

### DIFF
--- a/pkg/k8sclient/kubeconfig.go
+++ b/pkg/k8sclient/kubeconfig.go
@@ -75,7 +75,7 @@ func getPerNodeKubeconfig(bootstrap *rest.Config, certDir string) *rest.Config {
 }
 
 // PerNodeK8sClient creates/reload new multus kubeconfig per-node.
-func PerNodeK8sClient(nodeName, bootstrapKubeconfigFile, certDir string) (*ClientInfo, error) {
+func PerNodeK8sClient(nodeName, bootstrapKubeconfigFile string, certDuration time.Duration, certDir string) (*ClientInfo, error) {
 	bootstrapKubeconfig, err := clientcmd.BuildConfigFromFlags("", bootstrapKubeconfigFile)
 	if err != nil {
 		return nil, logging.Errorf("failed to load bootstrap kubeconfig %s: %v", bootstrapKubeconfigFile, err)
@@ -98,7 +98,6 @@ func PerNodeK8sClient(nodeName, bootstrapKubeconfigFile, certDir string) (*Clien
 		return nil, logging.Errorf("failed to initialize the certificate store: %v", err)
 	}
 
-	certDuration := 10 * time.Minute
 	certManager, err := certificate.NewManager(&certificate.Config{
 		ClientsetFn: newClientsetFn,
 		Template: &x509.CertificateRequest{

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/containernetworking/cni/pkg/invoke"
 
@@ -34,6 +35,8 @@ const (
 	DefaultMultusDaemonConfigFile = "/etc/cni/net.d/multus.d/daemon-config.json"
 	// DefaultMultusRunDir specifies default RunDir for multus
 	DefaultMultusRunDir = "/run/multus/"
+	// DefaultCertDuration specifies default duration for certs in per-node-certs config
+	DefaultCertDuration = 10 * time.Minute
 )
 
 // Metrics represents server's metrics.
@@ -61,6 +64,7 @@ type PerNodeCertificate struct {
 	Enabled             bool   `json:"enabled,omitempty"`
 	BootstrapKubeconfig string `json:"bootstrapKubeconfig,omitempty"`
 	CertDir             string `json:"certDir,omitempty"`
+	CertDuration        string `json:"certDuration,omitempty"`
 }
 
 // ControllerNetConf for the controller cni configuration


### PR DESCRIPTION
This change introduces certDuration as parameter to customize cert duration. In addition, environment variable for node name is matched to other usages.