### PR TITLE
Fix bug: when missing K8S_POD_UID, not release ip

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -486,7 +486,8 @@ func kubernetesRuntimeArgs(cniRequestEnvVariables map[string]string, kubeClient 
 
 	uid, err := podUID(kubeClient, cniEnv, podNamespace, podName)
 	if err != nil {
-		return nil, err
+		logging.Errorf("missing K8S_POD_UID", err.Error())
+		uid = "unknownUID"
 	}
 
 	sandboxID := cniRequestEnvVariables["K8S_POD_INFRA_CONTAINER_ID"]


### PR DESCRIPTION

![image](https://github.com/k8snetworkplumbingwg/multus-cni/assets/116237787/82e81d8e-6eaf-4f64-8d6c-972391a72f5a)
When missing K8S_POD_UID, cmdDel does not execute. multus-cni cannot release calico ip.