### PR TITLE
Deployments: Add watch permission to thick example

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -71,6 +71,7 @@ rules:
       - get
       - list
       - update
+      - watch
   - apiGroups:
       - ""
       - events.k8s.io


### PR DESCRIPTION
The ClusterRole was missing the watch permission on pods, which resulted in Multus throwing this error message every few seconds:

```
Failed to watch *v1.Pod: unknown (get pods)
```

I am unsure if this permission is also needed for the other 2 example yamls, so I've just added it to the one I tested for the moment.