### PR TITLE
Align the message with master plugin restoration logic

### DIFF
--- a/cmd/thin_entrypoint/main.go
+++ b/cmd/thin_entrypoint/main.go
@@ -587,7 +587,7 @@ func main() {
 
 			// if masterConfigFilePath is no longer exists
 			if os.IsNotExist(err) {
-				fmt.Printf("Master plugin @ %q has been deleted. Allowing 45 seconds for its restoration...\n", masterConfigFilePath)
+				fmt.Printf("Master plugin @ %q has been deleted. Wait until the master configuration is found...\n", masterConfigFilePath)
 				time.Sleep(10 * time.Second)
 
 				for range time.Tick(1 * time.Second) {


### PR DESCRIPTION
thin_entrypoint prints that it allows 45 seconds for its restoration, but it waits until "masterConfigFilePath" exists.
So, adjust the message to align with this logic.