### PR TITLE
Add watch permission to thick e2e template

### DIFF
--- a/e2e/templates/multus-daemonset-thick.yml.j2
+++ b/e2e/templates/multus-daemonset-thick.yml.j2
@@ -45,6 +45,7 @@ rules:
       - get
       - list
       - update
+      - watch
   - apiGroups:
       - ""
       - events.k8s.io


### PR DESCRIPTION
As described in #1171, the watch function is required in the clusterrole for the thick Multus version, otherwise "Failed to watch *v1.Pod" would be returned.

This permission is still missing in `e2e/templates/multus-daemonset-thick.yml.j2`