### PR TITLE
update deploy file: use install_multus bin to update cni file

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -199,9 +199,11 @@ spec:
         - name: install-multus-binary
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
           command:
-            - "cp"
-            - "/usr/src/multus-cni/bin/multus-shim"
-            - "/host/opt/cni/bin/multus-shim"
+            - "/usr/src/multus-cni/bin/install_multus"
+            - "-d"
+            - "/host/opt/cni/bin"
+            - "-t"
+            - "thick"
           resources:
             requests:
               cpu: "10m"


### PR DESCRIPTION
install cni initcontiainer can't execute sometimes 

a sample error logs looks like:

cp: cannot create regular file '/host/opt/cni/bin/multus-shim': Text file busy

