### PR TITLE
supplement log with stringified version of StdinData to enhance debug

### DIFF
--- a/pkg/server/api/shim.go
+++ b/pkg/server/api/shim.go
@@ -90,7 +90,7 @@ func postRequest(args *skel.CmdArgs) (*Response, string, error) {
 	var body []byte
 	body, err = DoCNI("http://dummy/cni", cniRequest, SocketPath(multusShimConfig.MultusSocketDir))
 	if err != nil {
-		return nil, multusShimConfig.CNIVersion, err
+		return nil, multusShimConfig.CNIVersion, fmt.Errorf("%s: StdinData: %s", err.Error(), string(args.StdinData))
 	}
 
 	response := &Response{}


### PR DESCRIPTION
In a job like [this](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.15-e2e-azure-ovn/1746349261781471232), we a have failure log like the one below (note the `StdinData:[123 34 98 ... 34 125]}` []byte which, as-is, is not as helpful for debugging as it could be:

```
: [sig-network] pods should successfully create sandboxes by adding pod to network expand_less | 0s
-- | --
{  1 failures to create the sandbox  namespace/e2e-deployment-9011 node/ci-op-ggi2sw56-08da5-pvlps-worker-westus-ncbwh pod/webserver-556cc9d77-pbbkd hmsg/c8f1f77703 - 7.83 seconds after deletion - interesting/true reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox
 k8s_webserver-556cc9d77-pbbkd_e2e-deployment-9011_ee30da87-8670-4b7e-b59f-6936fafca599_0(16c0f727ca5ce4b8819ad519ec29b30145e116cf7d78aeacfe3f1128546d1267): error adding pod e2e-deployment-9011_webserver-556cc9d77-pbbkd to CNI network "multus-cni-network": plugin type="multus-shim" name="multus-cni-network" failed (add): CmdAdd (shim): CNI request failed with status 400:
 '&{ContainerID:16c0f727ca5ce4b8819ad519ec29b30145e116cf7d78aeacfe3f1128546d1267 Netns:/var/run/netns/c4864d9a-7928-4af9-b79d-6d4e206dee0e IfName:eth0 Args:IgnoreUnknown=1;K8S_POD_NAMESPACE=e2e-deployment-9011;K8S_POD_NAME=webserver-556cc9d77-pbbkd;K8S_POD_INFRA_CONTAINER_ID=16c0f727ca5ce4b8819ad519ec29b30145e116cf7d78aeacfe3f1128546d1267;K8S_POD_UID=ee30da87-8670-4b7e-b59f-6936fafca599 
Path: StdinData:[123 34 98 ... 34 125]} ContainerID:"16c0f727ca5ce4b8819ad519ec29b30145e116cf7d78aeacfe3f1128546d1267" Netns:"/var/run/netns/c4864d9a-7928-4af9-b79d-6d4e206dee0e" IfName:"eth0" Args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=e2e-deployment-9011;K8S_POD_NAME=webserver-556cc9d77-pbbkd;K8S_POD_INFRA_CONTAINER_ID=16c0f727ca5ce4b8819ad519ec29b30145e116cf7d78aeacfe3f1128546d1267;K8S_POD_UID=ee30da87-8670-4b7e-b59f-6936fafca599" 
Path:"" ERRORED: error configuring pod [e2e-deployment-9011/webserver-556cc9d77-pbbkd] networking: Multus: [e2e-deployment-9011/webserver-556cc9d77-pbbkd/ee30da87-8670-4b7e-b59f-6936fafca599]: error waiting for pod: pods "webserver-556cc9d77-pbbkd" not found '}
```

This change supplements that byte slice with a stringified version which will help aid in debugging.