### PR TITLE
Add additional sleep in thick entrypoint

### DIFF
--- a/cmd/thin_entrypoint/main.go
+++ b/cmd/thin_entrypoint/main.go
@@ -603,6 +603,7 @@ func main() {
 				fmt.Fprintf(os.Stderr, "failed to create multus config: %v\n", err)
 				return
 			}
+			time.Sleep(1 * time.Second)
 		}
 	} else {
 		// sleep infinitely


### PR DESCRIPTION
This change adds 1sec sleep for kubeconfig watch loop to prevent CPU high utlization.