### PR TITLE
Add filepath sanity check

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -154,7 +154,7 @@ func startMultusDaemon(ctx context.Context, daemonConfig *srv.ControllerNetConf,
 	}
 
 	if daemonConfig.MetricsPort != nil {
-		go utilwait.UntilWithContext(ctx, func(ctx context.Context) {
+		go utilwait.UntilWithContext(ctx, func(_ context.Context) {
 			http.Handle("/metrics", promhttp.Handler())
 			logging.Debugf("metrics port: %d", *daemonConfig.MetricsPort)
 			logging.Debugf("metrics: %s", http.ListenAndServe(fmt.Sprintf(":%d", *daemonConfig.MetricsPort), nil))
@@ -177,7 +177,12 @@ func startMultusDaemon(ctx context.Context, daemonConfig *srv.ControllerNetConf,
 }
 
 func cniServerConfig(configFilePath string) (*srv.ControllerNetConf, error) {
-	configFileContents, err := os.ReadFile(configFilePath)
+	path, err := filepath.Abs(configFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("illegal path %s in server config path %s: %w", path, configFilePath, err)
+	}
+
+	configFileContents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -185,9 +190,14 @@ func cniServerConfig(configFilePath string) (*srv.ControllerNetConf, error) {
 }
 
 func copyUserProvidedConfig(multusConfigPath string, cniConfigDir string) error {
-	srcFile, err := os.Open(multusConfigPath)
+	path, err := filepath.Abs(multusConfigPath)
 	if err != nil {
-		return fmt.Errorf("failed to open (READ only) file %s: %w", multusConfigPath, err)
+		return fmt.Errorf("illegal path %s in multusConfigPath %s: %w", path, multusConfigPath, err)
+	}
+
+	srcFile, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open (READ only) file %s: %w", path, err)
 	}
 
 	dstFileName := cniConfigDir + "/" + filepath.Base(multusConfigPath)

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -53,7 +53,7 @@ func DoCNI(url string, req interface{}, socketPath string) ([]byte, error) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			Dial: func(proto, addr string) (net.Conn, error) {
+			Dial: func(_, _ string) (net.Conn, error) {
 				return net.Dial("unix", socketPath)
 			},
 		},

--- a/pkg/server/config/manager.go
+++ b/pkg/server/config/manager.go
@@ -66,9 +66,14 @@ func NewManager(config MultusConf) (*Manager, error) {
 
 // overrideCNIVersion overrides cniVersion in cniConfigFile, it should be used only in kind case
 func overrideCNIVersion(cniConfigFile string, multusCNIVersion string) error {
-	masterCNIConfigData, err := os.ReadFile(cniConfigFile)
+	path, err := filepath.Abs(cniConfigFile)
 	if err != nil {
-		return fmt.Errorf("failed to read cni config %s: %v", cniConfigFile, err)
+		return fmt.Errorf("illegal path %s in cni config path %s: %w", path, cniConfigFile, err)
+	}
+
+	masterCNIConfigData, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read cni config %s: %v", path, err)
 	}
 
 	var primaryCNIConfigData map[string]interface{}
@@ -82,7 +87,7 @@ func overrideCNIVersion(cniConfigFile string, multusCNIVersion string) error {
 		return fmt.Errorf("couldn't update cluster network config: %v", err)
 	}
 
-	err = os.WriteFile(cniConfigFile, configBytes, 0644)
+	err = os.WriteFile(path, configBytes, 0644)
 	if err != nil {
 		return fmt.Errorf("couldn't update cluster network config: %v", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -353,7 +353,7 @@ func (s *Server) Start(ctx context.Context, l net.Listener) {
 	waitCancel()
 
 	go func() {
-		utilwait.UntilWithContext(ctx, func(ctx context.Context) {
+		utilwait.UntilWithContext(ctx, func(_ context.Context) {
 			logging.Debugf("open for business")
 			if err := s.Serve(l); err != nil {
 				utilruntime.HandleError(fmt.Errorf("CNI server Serve() failed: %v", err))


### PR DESCRIPTION
Uses `filepath.Abs()` to check that paths passed  in are truly absolute paths, and not garbage data (for example). 