### PR TITLE
Recreate configs only if base files changed (thin_entrypoint)

### DIFF
--- a/cmd/thin_entrypoint/main_test.go
+++ b/cmd/thin_entrypoint/main_test.go
@@ -105,14 +105,15 @@ var _ = Describe("thin entrypoint testing", func() {
 		}`
 		Expect(os.WriteFile(fmt.Sprintf("%s/10-testcni.conf", multusAutoConfigDir), []byte(masterCNIConfig), 0755)).To(Succeed())
 
-		masterConfigPath, err := (&Options{
+		masterConfigPath, masterConfigHash, err := (&Options{
 			MultusAutoconfigDir:      multusAutoConfigDir,
 			CNIConfDir:               cniConfDir,
 			MultusKubeConfigFileHost: "/etc/foobar_kubeconfig",
-		}).createMultusConfig()
+		}).createMultusConfig(nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(masterConfigPath).NotTo(Equal(""))
+		Expect(masterConfigHash).NotTo(Equal(""))
 
 		expectedResult := `{
         "cniVersion": "0.3.1",
@@ -153,14 +154,15 @@ var _ = Describe("thin entrypoint testing", func() {
 		}`
 		Expect(os.WriteFile(fmt.Sprintf("%s/10-testcni.conf", multusAutoConfigDir), []byte(masterCNIConfig), 0755)).To(Succeed())
 
-		masterConfigPath, err := (&Options{
+		masterConfigPath, masterConfigHash, err := (&Options{
 			MultusAutoconfigDir:      multusAutoConfigDir,
 			CNIConfDir:               cniConfDir,
 			MultusKubeConfigFileHost: "/etc/foobar_kubeconfig",
-		}).createMultusConfig()
+		}).createMultusConfig(nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(masterConfigPath).NotTo(Equal(""))
+		Expect(masterConfigHash).NotTo(Equal(""))
 
 		expectedResult := `{
         "cniVersion": "0.3.1",
@@ -202,7 +204,7 @@ var _ = Describe("thin entrypoint testing", func() {
 		err = os.WriteFile(fmt.Sprintf("%s/10-testcni.conf", multusAutoConfigDir), []byte(masterCNIConfig), 0755)
 		Expect(err).NotTo(HaveOccurred())
 
-		masterConfigPath, err := (&Options{
+		masterConfigPath, masterConfigHash, err := (&Options{
 			MultusAutoconfigDir:      multusAutoConfigDir,
 			CNIConfDir:               cniConfDir,
 			MultusKubeConfigFileHost: "/etc/foobar_kubeconfig",
@@ -214,10 +216,11 @@ var _ = Describe("thin entrypoint testing", func() {
 			AdditionalBinDir:         "/tmp/add_bin_dir",
 			MultusCNIConfDir:         "/tmp/multus/net.d",
 			ReadinessIndicatorFile:   "/var/lib/foobar_indicator",
-		}).createMultusConfig()
+		}).createMultusConfig(nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(masterConfigPath).NotTo(Equal(""))
+		Expect(masterConfigHash).NotTo(Equal(""))
 
 		expectedResult := `{
         "cniVersion": "0.3.1",
@@ -262,14 +265,15 @@ var _ = Describe("thin entrypoint testing", func() {
 		}`
 		Expect(os.WriteFile(fmt.Sprintf("%s/10-testcni.conf", multusAutoConfigDir), []byte(masterCNIConfig), 0755)).To(Succeed())
 
-		masterConfigPath, err := (&Options{
+		masterConfigPath, masterConfigHash, err := (&Options{
 			MultusAutoconfigDir:      multusAutoConfigDir,
 			CNIConfDir:               cniConfDir,
 			MultusKubeConfigFileHost: "/etc/foobar_kubeconfig",
-		}).createMultusConfig()
+		}).createMultusConfig(nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(masterConfigPath).NotTo(Equal(""))
+		Expect(masterConfigHash).NotTo(Equal(""))
 
 		expectedResult :=
 			`{
@@ -312,14 +316,15 @@ var _ = Describe("thin entrypoint testing", func() {
 		}`
 		Expect(os.WriteFile(fmt.Sprintf("%s/10-testcni.conflist", multusAutoConfigDir), []byte(masterCNIConfig), 0755)).To(Succeed())
 
-		masterConfigPath, err := (&Options{
+		masterConfigPath, masterConfigHash, err := (&Options{
 			MultusAutoconfigDir:      multusAutoConfigDir,
 			CNIConfDir:               cniConfDir,
 			MultusKubeConfigFileHost: "/etc/foobar_kubeconfig",
-		}).createMultusConfig()
+		}).createMultusConfig(nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(masterConfigPath).NotTo(Equal(""))
+		Expect(masterConfigHash).NotTo(Equal(""))
 
 		expectedResult :=
 			`{
@@ -362,7 +367,7 @@ var _ = Describe("thin entrypoint testing", func() {
 		}`
 		Expect(os.WriteFile(fmt.Sprintf("%s/10-testcni.conflist", multusAutoConfigDir), []byte(masterCNIConfig), 0755)).To(Succeed())
 
-		masterConfigPath, err := (&Options{
+		masterConfigPath, masterConfigHash, err := (&Options{
 			MultusAutoconfigDir:      multusAutoConfigDir,
 			CNIConfDir:               cniConfDir,
 			MultusKubeConfigFileHost: "/etc/foobar_kubeconfig",
@@ -374,10 +379,11 @@ var _ = Describe("thin entrypoint testing", func() {
 			AdditionalBinDir:         "/tmp/add_bin_dir",
 			MultusCNIConfDir:         "/tmp/multus/net.d",
 			ReadinessIndicatorFile:   "/var/lib/foobar_indicator",
-		}).createMultusConfig()
+		}).createMultusConfig(nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(masterConfigPath).NotTo(Equal(""))
+		Expect(masterConfigHash).NotTo(Equal(""))
 
 		expectedResult :=
 			`{


### PR DESCRIPTION
Changes how new kubeconfig is created after CA/token change. Instead of always creating new file on disk and comparing it to existing, it will compare base files (`ca.crt` and `token`) and recreate kubeconfig only if they changed.
Multus CNI config is now treated the same way - as base file the master cni config is used.

As a result `thin_entrypoint` will no longer create new kubeconfig and 00-multus on each iteration of the watch loop and only recreate them when underlying base files change.

This approach was chosen over using a fsnotify because it wasn't reliable watching `/var/run/secrets/kubernetes.io/serviceaccount/` - it would just stop noticing changes to files, possible reason is underlying filesystem being `tmpfs`.