### PR TITLE
Skips checking for readiness on CNI DEL

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -815,8 +815,13 @@ func CmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) er
 	}
 
 	if in.ReadinessIndicatorFile != "" {
-		if err := types.GetReadinessIndicatorFile(in.ReadinessIndicatorFile); err != nil {
-			return cmdErr(k8sArgs, "PollImmediate error waiting for ReadinessIndicatorFile (on del): %v", err)
+		readinessfileexists, err := types.ReadinessIndicatorExistsNow(in.ReadinessIndicatorFile)
+		if err != nil {
+			return cmdErr(k8sArgs, "error checking readinessindicatorfile on CNI DEL @ %v: %v", in.ReadinessIndicatorFile, err)
+		}
+
+		if !readinessfileexists {
+			logging.Verbosef("warning: readinessindicatorfile @ %v does not exist on CNI DEL", in.ReadinessIndicatorFile)
 		}
 	}
 

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
-
-	utilwait "k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/skel"
@@ -31,6 +30,7 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 	nadutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -610,11 +610,35 @@ func CheckSystemNamespaces(namespace string, systemNamespaces []string) bool {
 }
 
 // GetReadinessIndicatorFile waits for readinessIndicatorFile
-func GetReadinessIndicatorFile(readinessIndicatorFile string) error {
+func GetReadinessIndicatorFile(readinessIndicatorFileRaw string) error {
+	cleanpath := filepath.Clean(readinessIndicatorFileRaw)
+	readinessIndicatorFile, err := filepath.Abs(cleanpath)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path of readinessIndicatorFile: %v", err)
+	}
+
 	pollDuration := 1000 * time.Millisecond
 	pollTimeout := 45 * time.Second
 	return utilwait.PollImmediate(pollDuration, pollTimeout, func() (bool, error) {
 		_, err := os.Stat(readinessIndicatorFile)
 		return err == nil, nil
 	})
+}
+
+// ReadinessIndicatorExistsNow reports if the readiness indicator exists immediately.
+func ReadinessIndicatorExistsNow(readinessIndicatorFileRaw string) (bool, error) {
+	cleanpath := filepath.Clean(readinessIndicatorFileRaw)
+	readinessIndicatorFile, err := filepath.Abs(cleanpath)
+	if err != nil {
+		return false, fmt.Errorf("failed to get absolute path of readinessIndicatorFile: %v", err)
+	}
+
+	_, err = os.Stat(readinessIndicatorFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }


### PR DESCRIPTION
Because deletes should favor a successful path, the readiness check should be skipped for pod removals.

This can cause an issue where there's pods pending deletes and that might impact scheduling of a pod that may be necessary in order to set the readiness indicator.