### PR TITLE
Fix defaultnetworkfile in unit test

### DIFF
--- a/pkg/multus/multus_cni020_test.go
+++ b/pkg/multus/multus_cni020_test.go
@@ -101,7 +101,7 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -164,7 +164,7 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -225,7 +225,7 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -279,7 +279,7 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -346,7 +346,7 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 			StdinData: []byte(fmt.Sprintf(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [%s,%s]
 	}`, expectedConf1, expectedConf2)),
@@ -392,7 +392,7 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 			StdinData: []byte(fmt.Sprintf(`{
 		    "name": "node-cni-network",
 		    "type": "multus",
-		    "defaultnetworkfile": "/tmp/foo.multus.conf",
+		    "readinessindicatorfile": "/tmp/foo.multus.conf",
 		    "defaultnetworkwaitseconds": 3,
 		    "delegates": [%s,%s]
 		}`, expectedConf1, expectedConf2)),
@@ -777,7 +777,7 @@ var _ = Describe("multus operations cniVersion 0.2.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",

--- a/pkg/multus/multus_cni040_test.go
+++ b/pkg/multus/multus_cni040_test.go
@@ -80,7 +80,7 @@ var _ = Describe("multus operations cniVersion 0.3.1 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -257,7 +257,7 @@ var _ = Describe("multus operations cniVersion 0.3.1 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -653,7 +653,7 @@ var _ = Describe("multus operations cniVersion 0.4.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -721,7 +721,7 @@ var _ = Describe("multus operations cniVersion 0.4.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -777,7 +777,7 @@ var _ = Describe("multus operations cniVersion 0.4.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -853,7 +853,7 @@ var _ = Describe("multus operations cniVersion 0.4.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -922,7 +922,7 @@ var _ = Describe("multus operations cniVersion 0.4.0 config", func() {
 			StdinData: []byte(fmt.Sprintf(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [%s,%s]
 	}`, expectedConf1, expectedConf2)),
@@ -968,7 +968,7 @@ var _ = Describe("multus operations cniVersion 0.4.0 config", func() {
 			StdinData: []byte(fmt.Sprintf(`{
 		    "name": "node-cni-network",
 		    "type": "multus",
-		    "defaultnetworkfile": "/tmp/foo.multus.conf",
+		    "readinessindicatorfile": "/tmp/foo.multus.conf",
 		    "defaultnetworkwaitseconds": 3,
 		    "delegates": [%s,%s]
 		}`, expectedConf1, expectedConf2)),
@@ -1510,7 +1510,7 @@ var _ = Describe("multus operations cniVersion 0.4.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",

--- a/pkg/multus/multus_cni100_test.go
+++ b/pkg/multus/multus_cni100_test.go
@@ -142,7 +142,7 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -210,7 +210,7 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -266,7 +266,7 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -331,7 +331,7 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -407,7 +407,7 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",
@@ -476,7 +476,7 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 			StdinData: []byte(fmt.Sprintf(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [%s,%s]
 	}`, expectedConf1, expectedConf2)),
@@ -522,7 +522,7 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 			StdinData: []byte(fmt.Sprintf(`{
 		    "name": "node-cni-network",
 		    "type": "multus",
-		    "defaultnetworkfile": "/tmp/foo.multus.conf",
+		    "readinessindicatorfile": "/tmp/foo.multus.conf",
 		    "defaultnetworkwaitseconds": 3,
 		    "delegates": [%s,%s]
 		}`, expectedConf1, expectedConf2)),
@@ -1171,7 +1171,7 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 			StdinData: []byte(`{
 	    "name": "node-cni-network",
 	    "type": "multus",
-	    "defaultnetworkfile": "/tmp/foo.multus.conf",
+	    "readinessindicatorfile": "/tmp/foo.multus.conf",
 	    "defaultnetworkwaitseconds": 3,
 	    "delegates": [{
 	        "name": "weave1",

--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -96,6 +96,7 @@ var _ = Describe(suiteName, func() {
 			containerID = "123456789"
 			ifaceName   = "eth0"
 			podName     = "my-little-pod"
+			configPath  = "/tmp/foo.multus.conf"
 		)
 
 		var (
@@ -109,6 +110,8 @@ var _ = Describe(suiteName, func() {
 		BeforeEach(func() {
 			var err error
 			K8sClient = fakeK8sClient()
+			// Touch the default network file.
+			os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
 
 			Expect(FilesystemPreRequirements(thickPluginRunDir)).To(Succeed())
 
@@ -126,6 +129,11 @@ var _ = Describe(suiteName, func() {
 
 		AfterEach(func() {
 			cancel()
+			// Cleanup default network file.
+			if _, errStat := os.Stat(configPath); errStat == nil {
+				errRemove := os.Remove(configPath)
+				Expect(errRemove).NotTo(HaveOccurred())
+			}
 			unregisterMetrics(cniServer)
 			Expect(cniServer.Close()).To(Succeed())
 			Expect(teardownCNIEnv()).To(Succeed())
@@ -150,6 +158,7 @@ var _ = Describe(suiteName, func() {
 			containerID = "123456789"
 			ifaceName   = "eth0"
 			podName     = "my-little-pod"
+			configPath  = "/tmp/foo.multus.conf"
 		)
 
 		var (
@@ -169,6 +178,8 @@ var _ = Describe(suiteName, func() {
 				"dummy_key2": "dummy_val2"
 			}`
 
+			// Touch the default network file.
+			os.OpenFile(configPath, os.O_RDONLY|os.O_CREATE, 0755)
 			Expect(FilesystemPreRequirements(thickPluginRunDir)).To(Succeed())
 
 			ctx, cancel = context.WithCancel(context.TODO())
@@ -185,6 +196,11 @@ var _ = Describe(suiteName, func() {
 
 		AfterEach(func() {
 			cancel()
+			// Cleanup default network file.
+			if _, errStat := os.Stat(configPath); errStat == nil {
+				errRemove := os.Remove(configPath)
+				Expect(errRemove).NotTo(HaveOccurred())
+			}
 			unregisterMetrics(cniServer)
 			Expect(cniServer.Close()).To(Succeed())
 			Expect(teardownCNIEnv()).To(Succeed())
@@ -286,7 +302,7 @@ func referenceConfig(thickPluginSocketDir string) string {
         "name": "node-cni-network",
         "type": "multus",
         "daemonSocketDir": "%s",
-        "defaultnetworkfile": "/tmp/foo.multus.conf",
+        "readinessindicatorfile": "/tmp/foo.multus.conf",
         "defaultnetworkwaitseconds": 3,
         "delegates": [{
             "name": "weave1",

--- a/pkg/types/conf_test.go
+++ b/pkg/types/conf_test.go
@@ -601,7 +601,7 @@ var _ = Describe("config operations", func() {
 			StdinData: []byte(`{
     "name": "node-cni-network",
     "type": "multus",
-    "defaultnetworkfile": "/tmp/foo.multus.conf",
+    "readinessindicatorfile": "/tmp/foo.multus.conf",
     "defaultnetworkwaitseconds": 3,
     "delegates": [{
         "name": "weave1",
@@ -649,7 +649,7 @@ var _ = Describe("config operations", func() {
 			StdinData: []byte(`{
     "name": "node-cni-network",
     "type": "multus",
-    "defaultnetworkfile": "/tmp/foo.multus.conf",
+    "readinessindicatorfile": "/tmp/foo.multus.conf",
     "defaultnetworkwaitseconds": 3,
     "delegates": [{
         "name": "weave1",


### PR DESCRIPTION
As https://github.com/k8snetworkplumbingwg/multus-cni/pull/98#issuecomment-413552685, 'defaultnetworkfile' should be 'readinessindicatorfile'.