### PR TITLE
Enhance CNI flexibility to read and write deviceInfo by removing the deviceID restriction

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -640,6 +640,16 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 			if err != nil {
 				logging.Debugf("CmdAdd: CopyDeviceInfoForCNIFromDP returned an error - err=%v", err)
 			}
+		} else if delegate.Conf.Capabilities["CNIDeviceInfoFile"] {
+			devInfo := &nettypes.DeviceInfo{}
+			err = nadutils.SaveDeviceInfoForCNI(cniDeviceInfoPath, devInfo)
+			// For CNIs with Capabilities["CNIDeviceInfoFile"] set to true, a deviceinfofile is
+			// created to conveniently pass the CNIDeviceInfoFile to the CNI. This allows the CNI
+			// to flexibly read and write DeviceInfo in annotations, not limited to CNIs with
+			// deviceID present.
+			if err != nil {
+				logging.Debugf("CmdAdd: SaveDeviceInfoForCNI returned an error - err=%v", err)
+			}
 		}
 
 		// We collect the delegate netName for the cachefile name as well as following errors

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -303,6 +303,11 @@ func delegateRuntimeConfig(containerID string, delegate *DelegateNetConf, rc *Ru
 			autoDeviceInfo := fmt.Sprintf("%s-%s_%s", delegate.Name, containerID, ifName)
 			delegateRc.CNIDeviceInfoFile = nadutils.GetCNIDeviceInfoPath(autoDeviceInfo)
 			logging.Debugf("Adding auto-generated CNIDeviceInfoFile: %s", delegateRc.CNIDeviceInfoFile)
+		} else if delegate.Conf.Capabilities["CNIDeviceInfoFile"] {
+			// generater empty CNIDeviceInfoFile filepath
+			autoDeviceInfo := fmt.Sprintf("%s-%s_%s", delegate.Name, containerID, ifName)
+			delegateRc.CNIDeviceInfoFile = nadutils.GetCNIDeviceInfoPath(autoDeviceInfo)
+			logging.Debugf("CNIDeviceInfoFile is true, Adding auto-generated empty CNIDeviceInfoFile: %s", delegateRc.CNIDeviceInfoFile)
 		}
 	} else {
 		delegateRc = rc


### PR DESCRIPTION
Based on the Device Information Specification described in the provided links 
[https://github.com/k8snetworkplumbingwg/device-info-spec/]
[https://github.com/k8snetworkplumbingwg/device-info-spec/blob/main/SPEC.md]

The NPWG Implementation Requirements necessitate checking the deviceID for creating the "CNIDeviceInfoFile", which lacks flexibility. My understanding is that CNIs should also have read and write permissions for deviceInfo. However, in the current Multus code, if the deviceID is not configured in the NetworkAttachmentDefinition (NAD), the "CNIDeviceInfoFile" is not created and passed to the CNI. I believe this part of the code has limitations.

In the current code, I added a condition for generating the "CNIDeviceInfoFile". As long as Capabilities["CNIDeviceInfoFile"] is configured as true in the NAD, an empty file is generated. This way, the "CNIDeviceInfoFile" can be passed to the CNI, allowing CNIs without a deviceID to participate in reading and writing deviceInfo. All the deviceInfo will eventually be returned to the kubelet.

Furthermore, I plan to extend the Device Information Specification in the future to include more adaptable fields, enhancing its flexibility and accommodating a wider range of scenarios.