### PR TITLE
Not exposed APIReadyCheckFunc to outside of package

### DIFF
--- a/pkg/server/api/shim.go
+++ b/pkg/server/api/shim.go
@@ -40,8 +40,8 @@ type ShimNetConf struct {
 	LogToStderr     bool   `json:"logToStderr,omitempty"`
 }
 
-// Define a type for API readiness check functions
-type APIReadyCheckFunc func(string) error
+// readyCheckFunc defines a type for API readiness check functions
+type readyCheckFunc func(string) error
 
 // CmdAdd implements the CNI spec ADD command handler
 func CmdAdd(args *skel.CmdArgs) error {
@@ -74,7 +74,7 @@ func CmdDel(args *skel.CmdArgs) error {
 	return nil
 }
 
-func postRequest(args *skel.CmdArgs, readinessCheck APIReadyCheckFunc) (*Response, string, error) {
+func postRequest(args *skel.CmdArgs, readinessCheck readyCheckFunc) (*Response, string, error) {
 	multusShimConfig, err := shimConfig(args.StdinData)
 	if err != nil {
 		return nil, "", fmt.Errorf("invalid CNI configuration passed to multus-shim: %w", err)


### PR DESCRIPTION
https://github.com/k8snetworkplumbingwg/multus-cni/actions/runs/9225475657 recommends to change the code, so this PR fix the code. In addition, APIReadyCheckFunc  can be decaptalize (i.e not expose this type to outisde of package), so change it decaptalized.

```
comment on exported type APIReadyCheckFunc should be of the form "APIReadyCheckFunc ..." (with optional leading article) test (1.21.x, ubuntu-latest): pkg/server/api/shim.go#L44
type name will be used as api.APIReadyCheckFunc by other packages, and that stutters; consider calling this ReadyCheckFunc
```