### PR TITLE
Bidirectional mount propagation for hostroot

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -190,7 +190,7 @@ spec:
               readOnly: true
             - name: hostroot
               mountPath: /hostroot
-              mountPropagation: HostToContainer
+              mountPropagation: Bidirectional
           env:
             - name: MULTUS_NODE_NAME
               valueFrom:


### PR DESCRIPTION
Modifies the `hostroot` volume in the `multus-daemonset-thick.yml` example/quickstart deployment file from `HostToContainer` to `Bidirectional`. This change enables the volume to be accessible in both directions, which is necessary for users who need to share a mount with another container/pod.

This is motivated by the fact that in thin plugin mode, since all things were run on the host directly, CNI plugins wouldn't be limited by the mount propagation.

One example that has come up recently is userspace CNI interaction with kubevirt, and sharing the usage of the socket as mounted by kubevirt.

This does expose some level of risk (as noted in the mount propagation docs regarding changing of mounts), however, I don't believe it's significantly more than would've been the case in thin plugin mode.

References
- [Kubernetes Volume Mount Propagation Documentation](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation)