### PR TITLE
Build multiarch thick images

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -35,8 +35,8 @@ jobs:
           sbom: false
           provenance: false
 
-  build-amd64-thick:
-    name: Image build/amd64 thick plugin
+  build-thick:
+    name: Image thick plugin
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -50,8 +50,11 @@ jobs:
         with:
           context: .
           push: false
-          tags: ghcr.io/${{ github.repository }}:latest-amd64-thick
+          tags: ghcr.io/${{ github.repository }}:latest-thick
           file: images/Dockerfile.thick
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8,linux/ppc64le,linux/s390x
+          sbom: false
+          provenance: false
 
   build-origin:
     name: Image build/origin

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -1,13 +1,13 @@
 name: Image push for master
-on: 
+on:
   push:
     branches:
       - master
 env:
   image-push-owner: 'k8snetworkplumbingwg'
 jobs:
-  push-thick-amd64:
-    name: Image push thick image/amd64
+  push-thick:
+    name: Image push thick image
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -34,7 +34,9 @@ jobs:
             ghcr.io/${{ github.repository }}:latest-thick
             ghcr.io/${{ github.repository }}:snapshot-thick
           file: images/Dockerfile.thick
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8,linux/ppc64le,linux/s390x
+          sbom: false
+          provenance: false
 
   push-thin:
     name: Image push thin image

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -1,13 +1,13 @@
 name: Image push release
-on: 
+on:
   push:
     tags:
       - v*
 env:
   image-push-owner: 'k8snetworkplumbingwg'
 jobs:
-  push-thick-amd64:
-    name: Image push thick image/amd64
+  push-thick:
+    name: Image push thick image
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -42,7 +42,9 @@ jobs:
             ghcr.io/${{ github.repository }}:stable-thick
             ${{ steps.docker_meta.outputs.tags }}-thick
           file: images/Dockerfile.thick
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8,linux/ppc64le,linux/s390x
+          sbom: false
+          provenance: false
 
   push-thin:
     name: Image push thin image/amd64


### PR DESCRIPTION
I'm not totally sure why the thick image is different from the thin one here, but it doesn't seem like there should be anything stopping the thick image from being multiarch.