### PR TITLE
Use same base image as thick plugin

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETPLATFORM
 RUN  cd /usr/src/multus-cni && \
      ./hack/build-go.sh
 
-FROM gcr.io/distroless/base-debian11:latest
+FROM debian:stable-slim
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 COPY --from=build /usr/src/multus-cni/LICENSE /usr/src/multus-cni/LICENSE

--- a/images/Dockerfile.debug
+++ b/images/Dockerfile.debug
@@ -8,7 +8,7 @@ ARG TARGETPLATFORM
 RUN  cd /usr/src/multus-cni && \
      ./hack/build-go.sh
 
-FROM gcr.io/distroless/base-debian11:debug
+FROM debian:stable-slim
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 COPY --from=build /usr/src/multus-cni/LICENSE /usr/src/multus-cni/LICENSE


### PR DESCRIPTION
change thin plugin dockerfile to use the same
base image as the thick plugin.

this will allow users to implement simple lifecycle hooks e.g exec simple shell cmd to delete multus conf file on container exit which allows to remove multus (thin) from the cluster without breaking it.

this functionality was possible in v3.

Related issue: #592