### PR TITLE
Add mountPropagation to host-var-lib-kubelet

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -180,6 +180,7 @@ spec:
               mountPath: /var/lib/cni/multus
             - name: host-var-lib-kubelet
               mountPath: /var/lib/kubelet
+              mountPropagation: HostToContainer
             - name: host-run-k8s-cni-cncf-io
               mountPath: /run/k8s.cni.cncf.io
             - name: host-run-netns


### PR DESCRIPTION
This is needed to avoid issues with volume unmounts when (other) pods exit as by default kubernetes mounts as private.