### PR TITLE
[WIP] Ensure deviceID is set when a resource is requested

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -312,6 +312,10 @@ func getKubernetesDelegate(client *ClientInfo, net *types.NetworkSelectionElemen
 				entry.Index++ // increment Index for next delegate
 			}
 		}
+
+		if deviceID == "" {
+			return nil, resourceMap, logging.Errorf("getKubernetesDelegate: requested resource not found in resourceMap %+v", resourceMap)
+		}
 	}
 
 	configBytes, err := netutils.GetCNIConfig(customResource, confdir)


### PR DESCRIPTION
If a NAD has the resourceName annotation set, then it means that the subsequent CNI calls should provide the deviceID for that particular resource.

Previously, we were doing best effort to get the deviceID from kubelet. With this patch, we guarantee the deviceID will be passed in the CNI call and fail if we can't find any deviceID.