### PR TITLE
Update DRA integration info and fix e2e test

### DIFF
--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -640,6 +640,9 @@ If you wish to have auto configuration use the `readinessindicatorfile` in the c
 > :warning: Dynamic Resource Allocation (DRA) is [currently an alpha](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/),
 > and is subject to change. Please consider this functionality as a preview. The architecture and usage of DRA in
 > Multus CNI may change in the future as this technology matures.
+>
+> The current DRA integration is based on the DRA API for Kubernetes 1.26 to 1.30. With Kubernetes 1.31, the DRA API
+> will change and multus doesn't integrate with the new API yet.
 
 Dynamic Resource Allocation is alternative mechanism to device plugin which allows to requests pod and container
 resources.

--- a/e2e/test-dra-integration.sh
+++ b/e2e/test-dra-integration.sh
@@ -6,15 +6,16 @@ export PATH=${PATH}:./bin
 # This test is using an example implementation of a DRA driver. This driver is mocking GPU resources. At our test we
 # don't care about what these resources are. We want to ensure that such resource is correctly passed in the Pod using
 # Multus configurations. A couple of notes:
-# - We explitictly don't pin the revision of the dra-example-driver to a specific commit to ensure that the integration
-#   continues to work even when the dra-example-driver is updated (which may also indicate API changes on the DRA).
+# - We explitictly pin the revision of the dra-example-driver to the branch `classic-dra` to indicate that the
+#   integration continues to work even when the dra-example-driver is updated. We know that classic-dra is supported
+#   in Kubernetes versions 1.26 to 1.30. Multus supports DRA in the aforementioned Kubernetes versions.
 # - The chart and latest is image is not published somewhere, therefore we have to build locally. This leads to slower
 #   e2e suite runs.
 echo "installing dra-example-driver"
 repo_path="repos/dra-example-driver"
 
 rm -rf $repo_path || true
-git clone https://github.com/kubernetes-sigs/dra-example-driver.git ${repo_path}
+git clone --branch classic-dra https://github.com/kubernetes-sigs/dra-example-driver.git ${repo_path}
 ${repo_path}/demo/build-driver.sh
 KIND_CLUSTER_NAME=kind ${repo_path}/demo/scripts/load-driver-image-into-kind.sh
 chart_path=${repo_path}/deployments/helm/dra-example-driver/


### PR DESCRIPTION
With Kubernetes 1.31, the DRA API will change ([1],[2]). The dra example implementation has already been updated to some extent to reflect those changes. Current e2e tests fail because of that.

With this PR, we add additional info in the docs to reflect the versions of Kubernetes that multus supports DRA and also we fix the e2e test by pinning it to the original DRA example implementation.

Next step is to adjust the multus DRA integration to the new DRA API.

**Note:** The currently opened PRs will need to be rebased on top of master once this PR is merged to ensure that e2e test is passing.

[1]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4381-dra-structured-parameters
[2]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/3063-dynamic-resource-allocation