### PR TITLE
Updates to use CreateNetworkStauses from net-attach-def client, bump to v1.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/containernetworking/plugins v1.1.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-logr/logr v1.3.0 // indirect
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.0
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.1
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -825,8 +825,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jung-kurt/gofpdf v1.0.0/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.0 h1:47q2PIbDYHmOaqLxgGnvpLq96v9UKDsJfNW6j/KbfpQ=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.0/go.mod h1:KDX0bPKeuhMakcNzLf2sWXKPNZ30wH01bsY/KJZLxFY=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.1 h1:n4FpoJ6aGDx8ULfya/C4ycrMDuPZlf7AtPyrT4+rIP4=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.1/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/pkg/k8sclient/k8sclient_test.go
+++ b/pkg/k8sclient/k8sclient_test.go
@@ -1199,11 +1199,14 @@ users:
 			delegate, err := types.LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.0", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			delegateNetStatus, err := netutils.CreateNetworkStatus(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
-			GinkgoT().Logf("delegateNetStatus %+v\n", delegateNetStatus)
+			delegateNetStatuses, err := netutils.CreateNetworkStatuses(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
+			GinkgoT().Logf("delegateNetStatuses %+v\n", delegateNetStatuses)
 			Expect(err).NotTo(HaveOccurred())
 
-			netstatus := []nettypes.NetworkStatus{*delegateNetStatus}
+			netstatus := make([]nettypes.NetworkStatus, 0)
+			for _, status := range delegateNetStatuses {
+				netstatus = append(netstatus, *status)
+			}
 
 			fakePod := testutils.NewFakePod(fakePodName, "kube-system/net1", "")
 
@@ -1254,11 +1257,14 @@ users:
 			delegate, err := types.LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.0", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			delegateNetStatus, err := netutils.CreateNetworkStatus(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
-			GinkgoT().Logf("delegateNetStatus %+v\n", delegateNetStatus)
+			delegateNetStatuses, err := netutils.CreateNetworkStatuses(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
+			GinkgoT().Logf("delegateNetStatuses %+v\n", delegateNetStatuses)
 			Expect(err).NotTo(HaveOccurred())
 
-			netstatus := []nettypes.NetworkStatus{*delegateNetStatus}
+			netstatus := make([]nettypes.NetworkStatus, 0)
+			for _, status := range delegateNetStatuses {
+				netstatus = append(netstatus, *status)
+			}
 
 			fakePod := testutils.NewFakePod(fakePodName, "kube-system/net1", "")
 
@@ -1312,11 +1318,14 @@ users:
 			delegate, err := types.LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.0", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			delegateNetStatus, err := netutils.CreateNetworkStatus(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
-			GinkgoT().Logf("delegateNetStatus %+v\n", delegateNetStatus)
+			delegateNetStatuses, err := netutils.CreateNetworkStatuses(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
+			GinkgoT().Logf("delegateNetStatuses %+v\n", delegateNetStatuses)
 			Expect(err).NotTo(HaveOccurred())
 
-			netstatus := []nettypes.NetworkStatus{*delegateNetStatus}
+			netstatus := make([]nettypes.NetworkStatus, 0)
+			for _, status := range delegateNetStatuses {
+				netstatus = append(netstatus, *status)
+			}
 
 			fakePod := testutils.NewFakePod(fakePodName, "kube-system/net1", "")
 
@@ -1394,11 +1403,14 @@ users:
 			delegate, err := types.LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.0", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			delegateNetStatus, err := netutils.CreateNetworkStatus(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
-			GinkgoT().Logf("delegateNetStatus %+v\n", delegateNetStatus)
+			delegateNetStatuses, err := netutils.CreateNetworkStatuses(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
+			GinkgoT().Logf("delegateNetStatuses %+v\n", delegateNetStatuses)
 			Expect(err).NotTo(HaveOccurred())
 
-			netstatus := []nettypes.NetworkStatus{*delegateNetStatus}
+			netstatus := make([]nettypes.NetworkStatus, 0)
+			for _, status := range delegateNetStatuses {
+				netstatus = append(netstatus, *status)
+			}
 
 			fakePod := testutils.NewFakePod(fakePodName, "kube-system/net1", "")
 
@@ -1450,11 +1462,14 @@ users:
 			delegate, err := types.LoadDelegateNetConf([]byte(conf), nil, "", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			delegateNetStatus, err := netutils.CreateNetworkStatus(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
-			GinkgoT().Logf("delegateNetStatus %+v\n", delegateNetStatus)
+			delegateNetStatuses, err := netutils.CreateNetworkStatuses(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
+			GinkgoT().Logf("delegateNetStatuses %+v\n", delegateNetStatuses)
 			Expect(err).NotTo(HaveOccurred())
 
-			netstatus := []nettypes.NetworkStatus{*delegateNetStatus}
+			netstatus := make([]nettypes.NetworkStatus, 0)
+			for _, status := range delegateNetStatuses {
+				netstatus = append(netstatus, *status)
+			}
 
 			fakePod := testutils.NewFakePod(fakePodName, "kube-system/net1", "")
 
@@ -1505,11 +1520,14 @@ users:
 			delegate, err := types.LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.0", "")
 			Expect(err).NotTo(HaveOccurred())
 
-			delegateNetStatus, err := netutils.CreateNetworkStatus(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
-			GinkgoT().Logf("delegateNetStatus %+v\n", delegateNetStatus)
+			delegateNetStatuses, err := netutils.CreateNetworkStatuses(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
+			GinkgoT().Logf("delegateNetStatuses %+v\n", delegateNetStatuses)
 			Expect(err).NotTo(HaveOccurred())
 
-			netstatus := []nettypes.NetworkStatus{*delegateNetStatus}
+			netstatus := make([]nettypes.NetworkStatus, 0)
+			for _, status := range delegateNetStatuses {
+				netstatus = append(netstatus, *status)
+			}
 
 			fakePod := testutils.NewFakePod(fakePodName, "kube-system/net1", "")
 

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -738,15 +738,18 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 			logging.Debugf("CmdAdd: getDelegateDeviceInfo returned an error - err=%v", err)
 		}
 
-		// create the network status, only in case Multus as kubeconfig
+		// Create the network statuses, only in case Multus has kubeconfig
 		if kubeClient != nil && kc != nil {
 			if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAME), n.SystemNamespaces) {
-				delegateNetStatus, err := nadutils.CreateNetworkStatus(tmpResult, delegate.Name, delegate.MasterPlugin, devinfo)
+				delegateNetStatuses, err := nadutils.CreateNetworkStatuses(tmpResult, delegate.Name, delegate.MasterPlugin, devinfo)
 				if err != nil {
-					return nil, cmdErr(k8sArgs, "error setting network status: %v", err)
+					return nil, cmdErr(k8sArgs, "error setting network statuses: %v", err)
 				}
 
-				netStatus = append(netStatus, *delegateNetStatus)
+				// Append all returned statuses after dereferencing each
+				for _, status := range delegateNetStatuses {
+					netStatus = append(netStatus, *status)
+				}
 			}
 		} else if devinfo != nil {
 			// Warn that devinfo exists but could not add it to downwards API

--- a/pkg/types/conf_test.go
+++ b/pkg/types/conf_test.go
@@ -704,9 +704,9 @@ var _ = Describe("config operations", func() {
 		delegate, err := LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.0", "")
 		Expect(err).NotTo(HaveOccurred())
 
-		delegateNetStatus, err := netutils.CreateNetworkStatus(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
+		delegateNetStatuses, err := netutils.CreateNetworkStatuses(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
 
-		GinkgoT().Logf("delegateNetStatus %+v\n", delegateNetStatus)
+		GinkgoT().Logf("delegateNetStatuses %+v\n", delegateNetStatuses)
 
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -737,9 +737,9 @@ var _ = Describe("config operations", func() {
 		delegate, err := LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.0", "")
 		Expect(err).NotTo(HaveOccurred())
 		fmt.Println("result.Version: ", result.Version())
-		delegateNetStatus, err := netutils.CreateNetworkStatus(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
+		delegateNetStatuses, err := netutils.CreateNetworkStatuses(result, delegate.Conf.Name, delegate.MasterPlugin, nil)
 
-		GinkgoT().Logf("delegateNetStatus %+v\n", delegateNetStatus)
+		GinkgoT().Logf("delegateNetStatuses %+v\n", delegateNetStatuses)
 
 		Expect(err).To(HaveOccurred())
 	})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -114,7 +114,7 @@ github.com/josharian/intern
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go
-# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.0
+# github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.1
 ## explicit; go 1.21
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1


### PR DESCRIPTION
NOTE: This functionality is dependent on https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/pull/68 and will require a library update in this PR in order to be complete.

This functionality properly represents Network Status for CNI ADD results that return multiple interfaces themselves.

This approach uses a new method from the net-attach-def-client -- `CreateNetworkStatuses`, and refactors to account for the array return.

With the previous method, it's somewhat buggy. If multiple pod interfaces are present, it returns the last one -- and groups all of the IP addresses to that address.

For replication of the error yourself, and to see the fix in action, see this gist: https://gist.github.com/dougbtv/1eb8ac2d61d494b56d65a6b236a86e61

For the related suggested update to the NPWG net-attach-def specification, see this proposal @ https://docs.google.com/document/d/1DUTV-o6E6zlRTKZkxeDhAeyGrmq03qPgPbU580Rm7-g/edit