### PR TITLE
always attempt a live pod get on miss to confirm its really not there

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -91,6 +91,11 @@ func (c *ClientInfo) GetPodContext(ctx context.Context, namespace, name string) 
 	return c.Client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 }
 
+// GetPodAPILiveQuery does a live API query for the pod, instead of using informers, for cases when a failure occurred, as to prevent a cache miss.
+func (c *ClientInfo) GetPodAPILiveQuery(namespace, name string) (*v1.Pod, error) {
+	return c.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
 // DeletePod deletes a pod from kubernetes
 func (c *ClientInfo) DeletePod(namespace, name string) error {
 	return c.Client.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -558,9 +558,7 @@ func GetPod(kubeClient *k8s.ClientInfo, k8sArgs *types.K8sArgs, isDel bool) (*v1
 		// Try one more time to get the pod directly from the apiserver;
 		// TODO: figure out why static pods don't show up via the informer
 		// and always hit this case.
-		ctx, cancel := context.WithTimeout(context.TODO(), pollDuration)
-		defer cancel()
-		pod, err = kubeClient.GetPodContext(ctx, podNamespace, podName)
+		pod, err = kubeClient.GetPodAPILiveQuery(podNamespace, podName)
 		if err != nil {
 			return nil, cmdErr(k8sArgs, "error waiting for pod: %v", err)
 		}


### PR DESCRIPTION
From [openshift pull request](https://github.com/openshift/multus-cni/pull/246):

> This makes sure that stale caches never result in NotFound errors.

It was explained to me that informers are almost always are more efficient, and in most cases will work, but a live lookup is appropriate after a number of failures.

This happens only on the retry portion, so we're still getting the benefits of informers, but, on a retry situation, we don't get a cache miss.