### PR TITLE
[DO NOT MERGE] Tests change to net-attach-def library for gateway determination of d…

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -770,6 +770,8 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		}
 	}
 
+	logging.Debugf("!bang the whole result ON ADD: %+v", result)
+
 	return result, nil
 }
 


### PR DESCRIPTION
…efault=true in status

This is a test change to the library for determination of the default=true interface in the network-status annotation when multiple interfaces are present in the result.