### PR TITLE
Fix: prevent stuck init container due to existing/busy multus binary

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -202,6 +202,7 @@ spec:
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
           command:
             - "cp"
+            - "-f"
             - "/usr/src/multus-cni/bin/multus-shim"
             - "/host/opt/cni/bin/multus-shim"
           resources:


### PR DESCRIPTION
Fixes https://github.com/k8snetworkplumbingwg/multus-cni/issues/1221