### PR TITLE
Remove resource limits

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -160,9 +160,6 @@ spec:
             requests:
               cpu: "100m"
               memory: "50Mi"
-            limits:
-              cpu: "100m"
-              memory: "50Mi"
           securityContext:
             privileged: true
           terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
Deployed multus causes sporadic problems where `kube-multus-ds` pods crash (get OOMKilled) causing pods scheduled on that node not to start. Requests(/limits) should be higher or limits removed - removing them in our environment was sufficient for multus to work without any issues.