### PR TITLE
Thin plugin: don't wait too long for an answer from API Server

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -82,6 +82,15 @@ func (c *ClientInfo) GetPod(namespace, name string) (*v1.Pod, error) {
 	return c.Client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
+// GetPodContext gets pod from kubernetes with context
+func (c *ClientInfo) GetPodContext(ctx context.Context, namespace, name string) (*v1.Pod, error) {
+	if c.PodInformer != nil {
+		logging.Debugf("GetPod for [%s/%s] will use informer cache", namespace, name)
+		return listers.NewPodLister(c.PodInformer.GetIndexer()).Pods(namespace).Get(name)
+	}
+	return c.Client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
 // DeletePod deletes a pod from kubernetes
 func (c *ClientInfo) DeletePod(namespace, name string) error {
 	return c.Client.CoreV1().Pods(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})


### PR DESCRIPTION
If Multus plugin gets a DEL request, but the API Server is down (e.g. via 'crictl rmp'), the call takes so long, it actually never finishes. This prevents CRI-O from deleting the Pods.

Proposed fix sets a timeout for Pods().Get() using context.