### PR TITLE
fix: dockerfile change cmd to entrypoint

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -18,4 +18,5 @@ COPY --from=build /usr/src/multus-cni/bin/install_multus /
 COPY --from=build /usr/src/multus-cni/bin/thin_entrypoint /
 COPY --from=build /usr/src/multus-cni/bin/kubeconfig_generator /
 COPY --from=build /usr/src/multus-cni/bin/cert-approver /
-CMD ["/thin_entrypoint"]
+
+ENTRYPOINT ["/thin_entrypoint"]

--- a/images/Dockerfile.debug
+++ b/images/Dockerfile.debug
@@ -18,4 +18,5 @@ COPY --from=build /usr/src/multus-cni/bin/install_multus /
 COPY --from=build /usr/src/multus-cni/bin/thin_entrypoint /
 COPY --from=build /usr/src/multus-cni/bin/kubeconfig_generator /
 COPY --from=build /usr/src/multus-cni/bin/cert-approver /
-CMD ["/thin_entrypoint"]
+
+ENTRYPOINT ["/thin_entrypoint"]


### PR DESCRIPTION
Pretty simple change. Would allow Kubernetes deployments to specify just args instead of both command + args.