### PR TITLE
enforce copy the multus-cni

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -202,6 +202,7 @@ spec:
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
           command:
             - "cp"
+            - "-f"
             - "/usr/src/multus-cni/bin/multus-shim"
             - "/host/opt/cni/bin/multus-shim"
           resources:


### PR DESCRIPTION
is the multus-cni already there, cp is not working and wait for a user interaction. with parameter -f the copy command will be forced.