### PR TITLE
[WIP] Try older debian for ci jobs

### DIFF
--- a/images/Dockerfile.thick
+++ b/images/Dockerfile.thick
@@ -7,7 +7,7 @@ ADD . /usr/src/multus-cni
 RUN  cd /usr/src/multus-cni && \
      ./hack/build-go.sh
 
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 COPY --from=build /usr/src/multus-cni/LICENSE /usr/src/multus-cni/LICENSE


### PR DESCRIPTION
testing a theory for https://github.com/k8snetworkplumbingwg/multus-cni/pull/1213, CI jobs may have started failing when `stable-slim` started pointing to bookworm/debian12 as opposed to older bullseye/debian11