### PR TITLE
Increase memory limit to 200Mi

### DIFF
--- a/deployments/multus-daemonset-crio.yml
+++ b/deployments/multus-daemonset-crio.yml
@@ -189,7 +189,7 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "200Mi"
           limits:
             cpu: "100m"
             memory: "50Mi"

--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -159,7 +159,7 @@ spec:
           resources:
             requests:
               cpu: "100m"
-              memory: "50Mi"
+              memory: "200Mi"
             limits:
               cpu: "100m"
               memory: "50Mi"

--- a/deployments/multus-daemonset.yml
+++ b/deployments/multus-daemonset.yml
@@ -188,7 +188,7 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "200Mi"
           limits:
             cpu: "100m"
             memory: "50Mi"


### PR DESCRIPTION
On system restart, especially if you run into the #1221 issue, the Multus Daemon can consume a large amount of memory causing the pod to repeatedly be OOMKilled. I think it can/should be addressed in code as reported in #1346 but for now increasing the limit at least allows the pods to start but not still not run completely out of control