### PR TITLE
Add multusKeepConfig option

### DIFF
--- a/docs/thick-plugin.md
+++ b/docs/thick-plugin.md
@@ -66,6 +66,7 @@ The server configuration is encoded in JSON, and allows the following keys:
 - `"socketDir"`: Specify the location where the unix domain socket used
 for client/server communication will be located. This is the location where the
 **Daemon** will read the configuration from. Defaults to `"/run/multus"`.
+- `multusKeepConfig`: Specify whether to keep the generated multus CNI config or not. Defaults to `false`, which means that the multus config file (e.g. `/etc/cni/net.d/00-multus.conf` will be deleted automatically when the multus-daemon is deleted).
 - `"metricsPort"`: Metrics port (of multus' metric exporter); by default, no port
 is provided.
 - `"logFile"`: the path to where the daemon logs will be persisted.
@@ -89,7 +90,8 @@ Below you can see an example of the daemon configuration:
         "cniVersion": "0.3.1",
         "cniConfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",
-        "multusAutoconfigDir": "/host/etc/cni/net.d"
+        "multusAutoconfigDir": "/host/etc/cni/net.d",
+        "multusKeepConfig": true,
     }
 ```
 

--- a/pkg/server/config/generator.go
+++ b/pkg/server/config/generator.go
@@ -59,6 +59,7 @@ type MultusConf struct {
 	MultusConfigFile         string              `json:"multusConfigFile,omitempty"`
 	MultusMasterCni          string              `json:"multusMasterCNI,omitempty"`
 	MultusAutoconfigDir      string              `json:"multusAutoconfigDir,omitempty"`
+	MultusKeepConfig 	     bool                `json:"multusKeepConfig,omitempty"`
 	ForceCNIVersion          bool                `json:"forceCNIVersion,omitempty"`
 	OverrideNetworkName      bool                `json:"overrideNetworkName,omitempty"`
 }

--- a/pkg/server/config/manager.go
+++ b/pkg/server/config/manager.go
@@ -159,8 +159,11 @@ func (m *Manager) Start(ctx context.Context, wg *sync.WaitGroup) error {
 			_ = logging.Errorf("error watching file: %v", err)
 		}
 		logging.Verbosef("ConfigWatcher done")
-		logging.Verbosef("Delete old config @ %v", multusConfigFile)
-		os.Remove(multusConfigFile)
+
+		if !m.multusConfig.MultusKeepConfig {
+			logging.Verbosef("Delete old config @ %v", multusConfigFile)
+			os.Remove(multusConfigFile)
+		}
 	}()
 
 	return nil


### PR DESCRIPTION
On the basis of https://github.com/k8snetworkplumbingwg/multus-cni/issues/1387

I tried to make this change backwards compatible, so you need to enable multusKeepConfig option in order to persist `/etc/cni/net.d/00-multus.conf` configuration file. This change is really important for us, as we're using Cilium+Multus in our k8s environment and we need our services to be fault tolerant. Without this option our containers with additional interfaces will not survive node reboots.
