### PR TITLE
Only wait for config waitGroup when configManager is used

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -127,15 +127,17 @@ func main() {
 		}
 	}()
 
-	var wg sync.WaitGroup
 	if configManager != nil {
+		var wg sync.WaitGroup
 		if err := configManager.Start(ctx, &wg); err != nil {
 			_ = logging.Errorf("failed to start config manager: %v", err)
 			os.Exit(3)
 		}
+		wg.Wait()
+	} else {
+		<-ctx.Done()
 	}
 
-	wg.Wait()
 	logging.Verbosef("multus daemon is exited")
 }
 


### PR DESCRIPTION
fixes #1366

When `MultusConfigFile` is not set to `auto` (configManager is nil) the WaitGroup is initialised and then waited for, immediately exiting Multus. This PR only waits when configManager is not nil, otherwise it waits for the context to complete (which happens from the SIGINT / SIGTERM handlers)