### PR TITLE
The e2e kind config should use api/beta for the runtimeConfig

### DIFF
--- a/.github/workflows/kind-e2e.yml
+++ b/.github/workflows/kind-e2e.yml
@@ -93,7 +93,7 @@ jobs:
         if: always()
         run: |
           mkdir -p /tmp/kind/logs
-          kind export logs --loglevel=debug /tmp/kind/logs
+          kind export logs /tmp/kind/logs -v 2147483647
 
       - name: Upload kind logs
         if: always()

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,13 +39,17 @@ cd multus-cni
 ./hack/build-go.sh
 ```
 
-## How do I run CI tests?
+## How do I run the unit tests?
 
 Multus has go unit tests (based on ginkgo framework).The following commands drive CI tests manually in your environment:
 
 ```
 sudo ./hack/test-go.sh
 ```
+
+## How do I run the e2e tests?
+
+Check the `README.md` in the `./e2e/` folder.
 
 ## What are the best practices for logging?
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -5,7 +5,7 @@
 To run the e2e test, you need the following components:
 
 - curl
-- jinjanator
+- jinjanator (optional)
 - docker
 
 ### How to test e2e
@@ -14,7 +14,23 @@ To run the e2e test, you need the following components:
 $ git clone https://github.com/k8snetworkplumbingwg/multus-cni.git
 $ cd multus-cni/e2e
 $ ./get_tools.sh
+```
+
+If you have `jinjanator` you can generate the YAML with:
+
+```
 $ ./generate_yamls.sh
+```
+
+Alternatively, if you have trouble with it, use the `sed` script.
+
+```
+$ ./e2e/sed_generate_yaml.sh
+```
+
+Then, setup the cluster
+
+```
 $ ./setup_cluster.sh
 $ ./test-simple-macvlan1.sh
 ```

--- a/e2e/get_tools.sh
+++ b/e2e/get_tools.sh
@@ -5,7 +5,7 @@ if [ ! -d bin ]; then
 	mkdir bin
 fi
 
-curl -Lo ./bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.22.0/kind-$(uname)-amd64"
+curl -Lo ./bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.27.0/kind-$(uname)-amd64"
 chmod +x ./bin/kind
 curl -Lo ./bin/kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
 chmod +x ./bin/kubectl

--- a/e2e/sed_generate_yaml.sh
+++ b/e2e/sed_generate_yaml.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ ! -d yamls ]; then
+	mkdir yamls
+fi
+
+# specify CNI version (default: 0.4.0)
+CNI_VERSION=${CNI_VERSION:-0.4.0}
+
+templates_dir="$(dirname $(readlink -f $0))/templates"
+
+# generate yaml files based on templates/*.j2 to yamls directory
+for i in `ls ${templates_dir}/*.j2`; do
+	echo "Processing $i..."
+	# Use sed to replace the placeholder with the CNI_VERSION variable
+	sed "s/{{ CNI_VERSION }}/$CNI_VERSION/g" $i > yamls/$(basename ${i%.j2})
+done

--- a/e2e/setup_cluster.sh
+++ b/e2e/setup_cluster.sh
@@ -34,14 +34,16 @@ nodes:
       nodeRegistration:
         kubeletExtraArgs:
           pod-manifest-path: "/etc/kubernetes/manifests/"
-          feature-gates: "DynamicResourceAllocation=true,KubeletPodResourcesDynamicResources=true"
+          feature-gates: "DynamicResourceAllocation=true,DRAResourceClaimDeviceStatus=true,KubeletPodResourcesDynamicResources=true"
   - role: worker
 # Required by DRA Integration
 ##
 featureGates:
   DynamicResourceAllocation: true
+  DRAResourceClaimDeviceStatus: true
+  KubeletPodResourcesDynamicResources: true
 runtimeConfig:
-  "api/alpha": "true"
+  "api/beta": "true"
 containerdConfigPatches:
 # Enable CDI as described in
 # https://github.com/container-orchestrated-devices/container-device-interface#containerd-configuration

--- a/images/Dockerfile.thick
+++ b/images/Dockerfile.thick
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM golang:1.23 as build
+FROM golang:1.23 AS build
 
 # Add everything
 ADD . /usr/src/multus-cni
@@ -8,7 +8,7 @@ RUN  cd /usr/src/multus-cni && \
      ./hack/build-go.sh
 
 FROM debian:stable-slim
-LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
+LABEL org.opencontainers.image.source=https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 COPY --from=build /usr/src/multus-cni/LICENSE /usr/src/multus-cni/LICENSE
 COPY --from=build /usr/src/multus-cni/bin/cert-approver /


### PR DESCRIPTION
Otherwise, the latest changes to DRA (which is beta in K8s 1.32) are incompatible.

Additionally, this fixes lint in the Dockerfile.

And adds a couple notes in the docs.

And lastly, bumps kind to `v0.27.0`

Fixes #1403 