### PR TITLE
Update deploy file: use install_multus to update CNI file w/o docker file change

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -199,9 +199,11 @@ spec:
         - name: install-multus-binary
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
           command:
-            - "cp"
-            - "/usr/src/multus-cni/bin/multus-shim"
-            - "/host/opt/cni/bin/multus-shim"
+            - "/usr/src/multus-cni/bin/install_multus"
+            - "-d"
+            - "/host/opt/cni/bin"
+            - "-t"
+            - "thick"
           resources:
             requests:
               cpu: "10m"

--- a/e2e/templates/multus-daemonset-thick.yml.j2
+++ b/e2e/templates/multus-daemonset-thick.yml.j2
@@ -168,9 +168,11 @@ spec:
       - name: install-multus-shim
         image: localhost:5000/multus:e2e
         command:
-          - "cp"
-          - "/usr/src/multus-cni/bin/multus-shim"
-          - "/host/opt/cni/bin/multus-shim"
+	  - "/usr/src/multus-cni/bin/install_multus"
+	  - "-d"
+          - "/host/opt/cni/bin"
+          - "-t"
+          - "thick"
         resources:
           requests:
             cpu: "10m"

--- a/e2e/templates/multus-daemonset-thick.yml.j2
+++ b/e2e/templates/multus-daemonset-thick.yml.j2
@@ -168,8 +168,8 @@ spec:
       - name: install-multus-shim
         image: localhost:5000/multus:e2e
         command:
-	        - "/usr/src/multus-cni/bin/install_multus"
-	        - "-d"
+          - "/usr/src/multus-cni/bin/install_multus"
+          - "-d"
           - "/host/opt/cni/bin"
           - "-t"
           - "thick"

--- a/e2e/templates/multus-daemonset-thick.yml.j2
+++ b/e2e/templates/multus-daemonset-thick.yml.j2
@@ -168,8 +168,8 @@ spec:
       - name: install-multus-shim
         image: localhost:5000/multus:e2e
         command:
-	  - "/usr/src/multus-cni/bin/install_multus"
-	  - "-d"
+	        - "/usr/src/multus-cni/bin/install_multus"
+	        - "-d"
           - "/host/opt/cni/bin"
           - "-t"
           - "thick"

--- a/images/Dockerfile.thick
+++ b/images/Dockerfile.thick
@@ -7,7 +7,7 @@ ADD . /usr/src/multus-cni
 RUN  cd /usr/src/multus-cni && \
      ./hack/build-go.sh
 
-FROM gcr.io/distroless/base-debian11:latest
+FROM debian:stable-slim
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 COPY --from=build /usr/src/multus-cni/LICENSE /usr/src/multus-cni/LICENSE

--- a/images/Dockerfile.thick
+++ b/images/Dockerfile.thick
@@ -7,7 +7,7 @@ ADD . /usr/src/multus-cni
 RUN  cd /usr/src/multus-cni && \
      ./hack/build-go.sh
 
-FROM debian:stable-slim
+FROM gcr.io/distroless/base-debian11:latest
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 COPY --from=build /usr/src/multus-cni/LICENSE /usr/src/multus-cni/LICENSE


### PR DESCRIPTION
This is the same PR as #1213 but since the e2e tests are failing due to the change in the docker file this reverts that change and just updates the relevant command that's broken so the maintainers can deal with their e2e tests later.