### PR TITLE
CVE Fix: CVE-2024-5535

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/k8snetworkplumbingwg/multus-cni.v4
 
-go 1.21
+go 1.23
 
 require (
 	github.com/blang/semver v3.5.1+incompatible

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETPLATFORM
 RUN  cd /usr/src/multus-cni && \
      ./hack/build-go.sh
 
-FROM gcr.io/distroless/base-debian11:latest
+FROM gcr.io/distroless/base-debian12:latest
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 COPY --from=build /usr/src/multus-cni/LICENSE /usr/src/multus-cni/LICENSE

--- a/images/Dockerfile.debug
+++ b/images/Dockerfile.debug
@@ -8,7 +8,7 @@ ARG TARGETPLATFORM
 RUN  cd /usr/src/multus-cni && \
      ./hack/build-go.sh
 
-FROM gcr.io/distroless/base-debian11:debug
+FROM gcr.io/distroless/base-debian12:debug
 LABEL org.opencontainers.image.source https://github.com/k8snetworkplumbingwg/multus-cni
 COPY --from=build /usr/src/multus-cni/bin /usr/src/multus-cni/bin
 COPY --from=build /usr/src/multus-cni/LICENSE /usr/src/multus-cni/LICENSE


### PR DESCRIPTION
- Bump golang version to 1.23
- Fix [CVE-2024-5535](https://security-tracker.debian.org/tracker/CVE-2024-5535):  Bump base-debian11 to base-debian12 