### PR TITLE
Thick client: mount multus-conf-dir

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -192,6 +192,8 @@ spec:
             - name: hostroot
               mountPath: /hostroot
               mountPropagation: HostToContainer
+            - mountPath: /etc/cni/multus/net.d
+              name: multus-conf-dir
           env:
             - name: MULTUS_NODE_NAME
               valueFrom:
@@ -247,3 +249,6 @@ spec:
         - name: host-run-netns
           hostPath:
             path: /run/netns/
+        - name: multus-conf-dir
+          hostPath:
+            path: /etc/cni/multus/net.d


### PR DESCRIPTION
Currently, the default CNI config dir is /etc/cni/multus/net.d [1]. However, pods do not mount this hostPath.
This issue only occurs when a delegate network-attachment-definition has no spec, and it therefore needs to be loaded from disk [2]. For example, when deploying Istio-cni in multus mode, the deployment creates an empty Istio-cni NAD in default namespace, while the actual config is deployed on disk.
CmdAdd fails with the following error message:
GetNetworkDelegates: failed getting the delegate: GetCNIConfig: err in GetCNIConfigFromFile: No networks found in /etc/cni/multus/net.d

[[1]](https://github.com/k8snetworkplumbingwg/multus-cni/blob/v4.2.0/pkg/types/conf.go#L38) [[2]](https://github.com/k8snetworkplumbingwg/multus-cni/blob/v4.2.0/pkg/k8sclient/k8sclient.go#L506)

Fixes issue https://github.com/k8snetworkplumbingwg/multus-cni/issues/1362.