### PR TITLE
print error of loading daemon config file

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -61,6 +61,7 @@ func main() {
 
 	daemonConf, err := cniServerConfig(*configFilePath)
 	if err != nil {
+		fmt.Printf("%s: %s\n", *configFilePath, err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
If the daemon-config.json format is incorrect, it will cause the config to fail to load, but the program will exit with code 1 without showing any error message.
Therefore, printing the error helps clearly identify the cause of the failure.

Before:
![image](https://github.com/user-attachments/assets/2f7b3608-f68d-4b6d-a115-49cdff691023)

After:
![image](https://github.com/user-attachments/assets/53389c13-0ce4-484b-aa14-45cbf6fecb43)
