### PR TITLE
Revert "Suppress error message in cmdDel, in thick plugin"

### DIFF
--- a/pkg/server/api/shim.go
+++ b/pkg/server/api/shim.go
@@ -68,8 +68,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 func CmdDel(args *skel.CmdArgs) error {
 	_, _, err := postRequest(args, CheckAPIReadyNow)
 	if err != nil {
-		// No error in DEL (as of CNI spec)
-		logging.Errorf("CmdDel (shim): %v", err)
+		return logging.Errorf("CmdDel (shim): %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This reverts commit 5d64ec3367eaa3f066ee3613abdb8eae36bcc7b8.

Multus shall return an error to the caller if a DEL fails.
