### PR TITLE
improvement: Limit bootstrap pod list when building k8s client

### DIFF
--- a/pkg/k8sclient/kubeconfig.go
+++ b/pkg/k8sclient/kubeconfig.go
@@ -96,7 +96,7 @@ func PerNodeK8sClient(nodeName, bootstrapKubeconfigFile string, certDuration tim
 		if err != nil {
 			logging.Errorf("failed to read kubeconfig from cert manager: %v", err)
 		} else {
-			_, err := tempClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
+			_, err := tempClient.CoreV1().Pods("default").List(context.TODO(), metav1.ListOptions{})
 			// tls unknown authority error is unrecoverable error with retry
 			if err != nil {
 				if strings.Contains(err.Error(), "x509: certificate signed by unknown authority") {


### PR DESCRIPTION
Currently when a new node is brought online for the first time multus lists every pod in the cluster (without caring about the data in the response) to confirm the client is working, in large clusters this can mean the API server is needlessly returning large amounts of data back to clients, this is even worse for clusters running things like batch compute that may bring online large numbers of nodes at the same time all making these requests in ~parallel adding pressure to the API server.

Instead we can atleast limit this request to the `default` namespace which should always exist as Kubernetes does not allow it to be deleted (https://github.com/kubernetes/kubernetes/blob/8d2a5a2c9c40e3c4e6aa2804cf167ea7fe169d55/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go#L57) and since we don't care about the response returning an empty list (often no pods will run in the default namespace) is also fine.

Probably a better option would be to use a self subject access review here but I did not consider the changes required for RBAC to be worth while when this will reduce the impact of these initial calls vastly.