### PR TITLE
Fix node reboot issue by using install_multus bin to update cni file

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -203,9 +203,11 @@ spec:
         - name: install-multus-binary
           image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
           command:
-            - "sh"
-            - "-c"
-            - "cp /usr/src/multus-cni/bin/multus-shim /host/opt/cni/bin/multus-shim && cp /usr/src/multus-cni/bin/passthru /host/opt/cni/bin/passthru"
+            - "/usr/src/multus-cni/bin/install_multus"
+            - "-d"
+            - "/host/opt/cni/bin"
+            - "-t"
+            - "thick"
           resources:
             requests:
               cpu: "10m"

--- a/e2e/setup_cluster.sh
+++ b/e2e/setup_cluster.sh
@@ -102,4 +102,4 @@ sleep 1
 kubectl -n kube-system wait --for=condition=ready -l name=multus pod --timeout=300s
 kubectl create -f yamls/cni-install.yml
 sleep 1
-kubectl -n kube-system wait --for=condition=ready -l name=cni-plugins pod --timeout=300s
+kubectl -n kube-system wait --for=condition=ready -l name=cni-plugins pod --timeout=400s

--- a/e2e/templates/multus-daemonset-thick.yml.j2
+++ b/e2e/templates/multus-daemonset-thick.yml.j2
@@ -170,9 +170,11 @@ spec:
       - name: install-multus-shim
         image: localhost:5000/multus:e2e
         command:
-          - "sh"
-          - "-c"
-          - "cp /usr/src/multus-cni/bin/multus-shim /host/opt/cni/bin/multus-shim && cp /usr/src/multus-cni/bin/passthru /host/opt/cni/bin/passthru"
+          - "/usr/src/multus-cni/bin/install_multus"
+          - "-d"
+          - "/host/opt/cni/bin"
+          - "-t"
+          - "thick"
         resources:
           requests:
             cpu: "10m"


### PR DESCRIPTION
There is a well known race condition that breaks clusters after node reboot described in #1221.
There PR #1213 that would fix this issue but also introduces another change which breaks the e2e tests.

This PR fixes the race condition and also updates the e2e test to wait a little longer in the setup as I noticed a little flakiness in my own tests. 