### PR TITLE
use `net.JoinHostPort` for proper IPv6 address formatting in kubeconfig

### DIFF
--- a/cmd/thin_entrypoint/main.go
+++ b/cmd/thin_entrypoint/main.go
@@ -21,6 +21,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -224,8 +225,11 @@ func (o *Options) createKubeConfig(prevCAHash, prevSATokenHash []byte) ([]byte, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("template parse error: %v", err)
 	}
+
+	kubeConfigHost := net.JoinHostPort(kubeHost, kubePort)
+
 	templateData := map[string]string{
-		"KubeConfigHost":          fmt.Sprintf("%s://[%s]:%s", kubeProtocol, kubeHost, kubePort),
+		"KubeConfigHost":          fmt.Sprintf("%s://%s", kubeProtocol, kubeConfigHost),
 		"KubeServerTLS":           tlsConfig,
 		"KubeServiceAccountToken": string(saTokenByte),
 	}


### PR DESCRIPTION
While RFC3986 requires providing IPv6 addresses in brackets, having them for IPv4 and DNS names is not required and may sometimes require workarounds on proxy side (e.g. istio).

This will set the brackets for `kubeHost` only if it's an IPv6 address.