### PR TITLE
[multus] use shortPollTimeout when calling APIserver for pods

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -606,7 +606,7 @@ func GetPod(kubeClient *k8s.ClientInfo, k8sArgs *types.K8sArgs, isDel bool) (*v1
 		// Try one more time to get the pod directly from the apiserver;
 		// TODO: figure out why static pods don't show up via the informer
 		// and always hit this case.
-		ctx, cancel := context.WithTimeout(context.TODO(), pollDuration)
+		ctx, cancel := context.WithTimeout(context.TODO(), shortPollTimeout)
 		defer cancel()
 		pod, err = kubeClient.GetPodAPILiveQuery(ctx, podNamespace, podName)
 		if err != nil {


### PR DESCRIPTION
Existing implementation uses very short timeout (50 or 250ms) when falling back to GetPodAPILiveQuery().
In some environments it results in increased number of `error waiting for pod` errors.
Increasing it to `shortPollTimeout     = 2500 * time.Millisecond`