### PR TITLE
Add ability to set `cleanupConfigOnExit` in the thick client config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ This is a general index of options, however note that you must set either the `c
 * `capabilities` ({}list, optional): [capabilities](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#dynamic-plugin-specific-fields-capabilities--runtime-configuration) supported by at least one of the delegates. (NOTE: Multus only supports portMappings/Bandwidth capability for cluster networks).
 * [`readinessindicatorfile`](#Default-Network-Readiness-Indicator): The path to a file whose existence denotes that the default network is ready
 message to next when some missing error. Defaults to false.
-* [`cleanupConfigOnExit`](#Cleanup-Config-On-Exit): Whether to remove the Multus CNI config file from the `cniDir` on exit. Default `true`
+* [`cleanupConfigOnExit`](#cleanup-config-on-exit): Whether to remove the Multus CNI config file from the `cniDir` on exit. Default `true`
 * `systemNamespaces` ([]string, optional): list of namespaces for Kubernetes system (namespaces listed here will not have `defaultNetworks` added)
 * `multusNamespace` (string, optional): namespace for `clusterNetwork`/`defaultNetworks` (the default value is `kube-system`)
 * `retryDeleteOnError` (bool, optional): Enable or disable delegate DEL 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ This is a general index of options, however note that you must set either the `c
 * `capabilities` ({}list, optional): [capabilities](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#dynamic-plugin-specific-fields-capabilities--runtime-configuration) supported by at least one of the delegates. (NOTE: Multus only supports portMappings/Bandwidth capability for cluster networks).
 * [`readinessindicatorfile`](#Default-Network-Readiness-Indicator): The path to a file whose existence denotes that the default network is ready
 message to next when some missing error. Defaults to false.
-* [`cleanupConfigOnExit`](#cleanup-config-on-exit): Whether to remove the Multus CNI config file from the `cniDir` on exit. Default `true`
+* [`cleanupConfigOnExit`](#cleanup-config-on-exit): Whether to remove the Multus CNI config file from the `cniConfigDir` on exit. Default `true`
 * `systemNamespaces` ([]string, optional): list of namespaces for Kubernetes system (namespaces listed here will not have `defaultNetworks` added)
 * `multusNamespace` (string, optional): namespace for `clusterNetwork`/`defaultNetworks` (the default value is `kube-system`)
 * `retryDeleteOnError` (bool, optional): Enable or disable delegate DEL 
@@ -149,7 +149,7 @@ Only one option is necessary to configure this functionality:
 
 Default: `true`
 
-When set to `true`, removes the Multus CNI config file from the `cniDir` on exit. This ensures that the K8s cluster will not try to use Multus as CNI while it is not running.
+When set to `true`, removes the Multus CNI config file from the `cniConfigDir` on exit. This ensures that the K8s cluster will not try to use Multus as CNI while it is not running.
 
 You may want to set this to `false` if your primary CNI is starting before Multus after a node reboot, causing some of your pods to not be processed by the Multus CNI and thus have some of their network interfaces missing.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,7 @@ Default: `true`
 
 When set to `true`, removes the Multus CNI config file from the `cniDir` on exit. This ensures that the K8s cluster will not try to use Multus as CNI while it is not running.
 
-You may want to se this to `false` if your primary CNI is starting before Multus after a node reboot, causing some of your pods to not be processed by the Multus CNI and thus have some of their network interfaces missing.
+You may want to set this to `false` if your primary CNI is starting before Multus after a node reboot, causing some of your pods to not be processed by the Multus CNI and thus have some of their network interfaces missing.
 
 Note that setting this to `false` may cause your pods to crash-loop until Multus starts.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,7 @@ This is a general index of options, however note that you must set either the `c
 * `capabilities` ({}list, optional): [capabilities](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#dynamic-plugin-specific-fields-capabilities--runtime-configuration) supported by at least one of the delegates. (NOTE: Multus only supports portMappings/Bandwidth capability for cluster networks).
 * [`readinessindicatorfile`](#Default-Network-Readiness-Indicator): The path to a file whose existence denotes that the default network is ready
 message to next when some missing error. Defaults to false.
+* [`cleanupConfigOnExit`](#Cleanup-Config-On-Exit): Whether to remove the Multus CNI config file from the `cniDir` on exit. Default `true`
 * `systemNamespaces` ([]string, optional): list of namespaces for Kubernetes system (namespaces listed here will not have `defaultNetworks` added)
 * `multusNamespace` (string, optional): namespace for `clusterNetwork`/`defaultNetworks` (the default value is `kube-system`)
 * `retryDeleteOnError` (bool, optional): Enable or disable delegate DEL 
@@ -144,6 +145,15 @@ Only one option is necessary to configure this functionality:
 
 *NOTE*: If `readinessindicatorfile` is unset, or is an empty string, this functionality will be disabled, and is disabled by default.
 
+### Cleanup Config On Exit
+
+Default: `true`
+
+When set to `true`, removes the Multus CNI config file from the `cniDir` on exit. This ensures that the K8s cluster will not try to use Multus as CNI while it is not running.
+
+You may want to se this to `false` if your primary CNI is starting before Multus after a node reboot, causing some of your pods to not be processed by the Multus CNI and thus have some of their network interfaces missing.
+
+Note that setting this to `false` may cause your pods to crash-loop until Multus starts.
 
 ### Logging
 

--- a/pkg/server/config/generator.go
+++ b/pkg/server/config/generator.go
@@ -52,6 +52,7 @@ type MultusConf struct {
 	NamespaceIsolation       bool                `json:"namespaceIsolation,omitempty"`
 	RawNonIsolatedNamespaces string              `json:"globalNamespaces,omitempty"`
 	ReadinessIndicatorFile   string              `json:"readinessindicatorfile,omitempty"`
+	CleanupConfigOnExit      *bool               `json:"cleanupConfigOnExit,omitempty"`
 	Type                     string              `json:"type"`
 	CniDir                   string              `json:"cniDir,omitempty"`
 	CniConfigDir             string              `json:"cniConfigDir,omitempty"`
@@ -71,11 +72,15 @@ func ParseMultusConfig(configPath string) (*MultusConf, error) {
 		return nil, fmt.Errorf("ParseMultusConfig failed to read the config file's contents: %w", err)
 	}
 
+	// Clean config by default. This matches the behaviour of older versions
+	CleanupConfigOnExit := true
+
 	multusconf := MultusConf{
-		MultusConfigFile: "auto",
-		Type:             multusPluginName,
-		Capabilities:     map[string]bool{},
-		CniConfigDir:     "/etc/cni/net.d",
+		MultusConfigFile:    "auto",
+		Type:                multusPluginName,
+		Capabilities:        map[string]bool{},
+		CniConfigDir:        "/etc/cni/net.d",
+		CleanupConfigOnExit: &CleanupConfigOnExit,
 	}
 
 	if err := json.Unmarshal(config, &multusconf); err != nil {

--- a/pkg/server/config/manager.go
+++ b/pkg/server/config/manager.go
@@ -43,6 +43,7 @@ type Manager struct {
 	multusConfigDir            string
 	multusConfigFilePath       string
 	readinessIndicatorFilePath string
+	cleanupConfigOnExit        bool
 	primaryCNIConfigPath       string
 }
 
@@ -123,6 +124,7 @@ func newManager(config MultusConf, defaultCNIPluginName string) (*Manager, error
 		multusConfigFilePath:       filepath.Join(config.CniConfigDir, multusConfigFileName),
 		primaryCNIConfigPath:       filepath.Join(config.MultusAutoconfigDir, defaultCNIPluginName),
 		readinessIndicatorFilePath: config.ReadinessIndicatorFile,
+		cleanupConfigOnExit:        *config.CleanupConfigOnExit,
 	}
 
 	if err := configManager.loadPrimaryCNIConfigFromFile(); err != nil {
@@ -159,8 +161,10 @@ func (m *Manager) Start(ctx context.Context, wg *sync.WaitGroup) error {
 			_ = logging.Errorf("error watching file: %v", err)
 		}
 		logging.Verbosef("ConfigWatcher done")
-		logging.Verbosef("Delete old config @ %v", multusConfigFile)
-		os.Remove(multusConfigFile)
+		if m.cleanupConfigOnExit {
+			logging.Verbosef("Delete old config @ %v", multusConfigFile)
+			os.Remove(multusConfigFile)
+		}
 	}()
 
 	return nil

--- a/pkg/server/config/manager.go
+++ b/pkg/server/config/manager.go
@@ -117,6 +117,11 @@ func newManager(config MultusConf, defaultCNIPluginName string) (*Manager, error
 		return nil, logging.Errorf("cannot specify %s/%s to prevent recursive config load", config.MultusAutoconfigDir, multusConfigFileName)
 	}
 
+	cleanupOnExit := true
+	if config.CleanupConfigOnExit != nil {
+		cleanupOnExit = *config.CleanupConfigOnExit
+	}
+
 	configManager := &Manager{
 		configWatcher:              watcher,
 		multusConfig:               &config,
@@ -124,7 +129,7 @@ func newManager(config MultusConf, defaultCNIPluginName string) (*Manager, error
 		multusConfigFilePath:       filepath.Join(config.CniConfigDir, multusConfigFileName),
 		primaryCNIConfigPath:       filepath.Join(config.MultusAutoconfigDir, defaultCNIPluginName),
 		readinessIndicatorFilePath: config.ReadinessIndicatorFile,
-		cleanupConfigOnExit:        *config.CleanupConfigOnExit,
+		cleanupConfigOnExit:        cleanupOnExit,
 	}
 
 	if err := configManager.loadPrimaryCNIConfigFromFile(); err != nil {


### PR DESCRIPTION
Adds ability to set `cleanupConfigOnExit` in the thick client config.

Closes #1468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control whether the old Multus configuration file is removed on exit; enabled by default to keep the system clean.
* **Documentation**
  * New documentation section explaining the cleanup-on-exit option, default behavior, risks of disabling it, and when disabling may be useful.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->