### PR TITLE
e2e: Use fully qualified image name for images

### DIFF
--- a/e2e/templates/cni-install.yml.j2
+++ b/e2e/templates/cni-install.yml.j2
@@ -36,7 +36,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: install-cni-plugins
-        image: alpine
+        image: docker.io/library/alpine
         command: ["/bin/sh", "/scripts/install_cni.sh"]
         resources:
           requests:

--- a/e2e/templates/default-route1.yml.j2
+++ b/e2e/templates/default-route1.yml.j2
@@ -32,7 +32,7 @@ metadata:
 spec:
   containers:
   - name: default-route-worker1
-    image: centos:8
+    image: quay.io/centos/centos:8
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true
@@ -51,7 +51,7 @@ metadata:
 spec:
   containers:
   - name: default-route-worker2
-    image: centos:8
+    image: quay.io/centos/centos:8
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true

--- a/e2e/templates/dra-integration.yml.j2
+++ b/e2e/templates/dra-integration.yml.j2
@@ -40,7 +40,7 @@ metadata:
 spec:
   containers:
   - name: ctr0
-    image: ubuntu:22.04
+    image: docker.io/library/ubuntu:22.04
     command: ["bash", "-c"]
     args: ["export; sleep 9999"]
     resources:

--- a/e2e/templates/simple-macvlan1.yml.j2
+++ b/e2e/templates/simple-macvlan1.yml.j2
@@ -34,7 +34,7 @@ metadata:
 spec:
   containers:
   - name: macvlan-worker1
-    image: centos:8
+    image: quay.io/centos/centos:8
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true
@@ -55,7 +55,7 @@ metadata:
 spec:
   containers:
   - name: macvlan-worker2
-    image: centos:8
+    image: quay.io/centos/centos:8
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true

--- a/e2e/templates/simple-pod.yml.j2
+++ b/e2e/templates/simple-pod.yml.j2
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
   - name: simple-centos1
-    image: centos:8
+    image: quay.io/centos/centos:8
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true


### PR DESCRIPTION
CRI-O 1.34+ enforces short name mode by default, which refuses to pull images with unqualified names like 'alpine/centos:8/ubuntu' because they are ambiguous. 

This PR changes the use short name image to the fully qualified images, in order to fix image pull failures on Kubernetes 1.34+ clusters.

Fixes: #1471 