### PR TITLE
Sort DeviceIDs in GetPodResourceMap for deterministic ordering

### DIFF
--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -108,5 +108,6 @@ func (cp *checkpoint) GetPodResourceMap(pod *v1.Pod) (map[string]*types.Resource
 			}
 		}
 	}
+	types.SortDeviceIDs(resourceMap)
 	return resourceMap, nil
 }

--- a/pkg/checkpoint/checkpoint_test.go
+++ b/pkg/checkpoint/checkpoint_test.go
@@ -132,12 +132,13 @@ var _ = Describe("Kubelet checkpoint data read operations", func() {
 			Expect(len(resourceInfo.DeviceIDs)).To(BeEquivalentTo(2))
 		})
 
-		It("should have \"0000:03:02.3\" in deviceIDs[0]", func() {
-			Expect(resourceInfo.DeviceIDs[0]).To(BeEquivalentTo("0000:03:02.3"))
+		// DeviceIDs are sorted for deterministic order across callers
+		It("should have \"0000:03:02.0\" in deviceIDs[0] (sorted order)", func() {
+			Expect(resourceInfo.DeviceIDs[0]).To(BeEquivalentTo("0000:03:02.0"))
 		})
 
-		It("should have \"0000:03:02.0\" in deviceIDs[1]", func() {
-			Expect(resourceInfo.DeviceIDs[1]).To(BeEquivalentTo("0000:03:02.0"))
+		It("should have \"0000:03:02.3\" in deviceIDs[1] (sorted order)", func() {
+			Expect(resourceInfo.DeviceIDs[1]).To(BeEquivalentTo("0000:03:02.3"))
 		})
 	})
 

--- a/pkg/kubeletclient/kubeletclient.go
+++ b/pkg/kubeletclient/kubeletclient.go
@@ -143,6 +143,7 @@ func (rc *kubeletClient) GetPodResourceMap(pod *v1.Pod) (map[string]*types.Resou
 			}
 		}
 	}
+	types.SortDeviceIDs(resourceMap)
 	return resourceMap, nil
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -17,6 +17,7 @@ package types
 
 import (
 	"net"
+	"sort"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types"
@@ -176,6 +177,16 @@ type K8sArgs struct {
 type ResourceInfo struct {
 	Index     int
 	DeviceIDs []string
+}
+
+// SortDeviceIDs sorts DeviceIDs in each ResourceInfo in place so that device
+// order is deterministic across GetPodResourceMap callers (e.g. Multus and OVN-Kubernetes).
+func SortDeviceIDs(resourceMap map[string]*ResourceInfo) {
+	for _, rInfo := range resourceMap {
+		if rInfo.DeviceIDs != nil {
+			sort.Strings(rInfo.DeviceIDs)
+		}
+	}
 }
 
 // ResourceClient provides a kubelet Pod resource handle


### PR DESCRIPTION
When a namespace uses a primary User-Defined Network (UDN) with a device-plugin resource (e.g. SR-IOV), OVN-Kubernetes uses the last device in the list for the primary interface while Multus assigns earlier devices to cluster-default/secondary interfaces. The kubelet and checkpoint paths build the list from map iteration, so order was non-deterministic and the "last" device could differ between callers. Sorting ensures both Multus and OVN-K8s see the same order so the last device is consistently the one reserved for the primary UDN.