### PR TITLE
Fix certificate rotation race condition in per-node certificates

### DIFF
--- a/pkg/k8sclient/kubeconfig.go
+++ b/pkg/k8sclient/kubeconfig.go
@@ -19,7 +19,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"strings"
@@ -53,6 +55,37 @@ const (
 var (
 	certUsages = []certificatesv1.KeyUsage{certificatesv1.UsageDigitalSignature, certificatesv1.UsageClientAuth}
 )
+
+// isTransientCertError determines if a certificate error is transient (e.g., due to
+// certificate rotation) and should be retried, or if it's a permanent error that
+// requires different handling.
+func isTransientCertError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// NoCertKeyError is expected when cert doesn't exist yet, not transient
+	var noCertErr *certificate.NoCertKeyError
+	if errors.As(err, &noCertErr) {
+		return false
+	}
+
+	// PathError (file not found, permission denied) could be transient during rotation
+	var pathErr *fs.PathError
+	if errors.As(err, &pathErr) {
+		return true
+	}
+
+	// PEM parsing errors indicate empty/corrupted file during rotation
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "failed to find any PEM data") ||
+		strings.Contains(errMsg, "invalid PEM") ||
+		strings.Contains(errMsg, "certificate signed by unknown authority") {
+		return true
+	}
+
+	return false
+}
 
 // getPerNodeKubeconfig creates new kubeConfig, based on bootstrap, with new certDir
 func getPerNodeKubeconfig(bootstrap *rest.Config, certDir string) *rest.Config {
@@ -148,8 +181,47 @@ func PerNodeK8sClient(nodeName, bootstrapKubeconfigFile string, certDuration tim
 	var storeErr error
 	err = wait.PollWithContext(context.TODO(), time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
 		var currentCert *tls.Certificate
-		currentCert, storeErr = certificateStore.Current()
-		return currentCert != nil && storeErr == nil, nil
+
+		// Retry transient cert errors with exponential backoff to handle
+		// certificate rotation race conditions where the symlink is temporarily
+		// removed or the file is empty during rotation.
+		backoff := wait.Backoff{
+			Duration: 100 * time.Millisecond,
+			Factor:   2.0,
+			Steps:    5,
+		}
+
+		var retryCount int
+		var firstTransientErr error
+
+		err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+			currentCert, storeErr = certificateStore.Current()
+
+			if storeErr != nil {
+				if isTransientCertError(storeErr) {
+					if firstTransientErr == nil {
+						firstTransientErr = storeErr
+					}
+					retryCount++
+					return false, nil
+				}
+				return false, storeErr
+			}
+
+			if currentCert != nil {
+				if retryCount > 0 {
+					logging.Verbosef("Certificate loaded successfully after %d retries (likely cert rotation in progress)", retryCount)
+				}
+				return true, nil
+			}
+			return false, nil
+		})
+
+		if err == nil && retryCount > 0 && currentCert == nil {
+			logging.Debugf("Exhausted %d retries for transient cert error, will retry poll: %v", retryCount, firstTransientErr)
+		}
+
+		return currentCert != nil && err == nil, nil
 	})
 	if err != nil {
 		return nil, logging.Errorf("certificate was not signed, last cert store err: %v err: %v", storeErr, err)

--- a/pkg/k8sclient/kubeconfig.go
+++ b/pkg/k8sclient/kubeconfig.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -53,6 +54,26 @@ const (
 var (
 	certUsages = []certificatesv1.KeyUsage{certificatesv1.UsageDigitalSignature, certificatesv1.UsageClientAuth}
 )
+
+// isTransientCertError determines if a certificate error is transient (e.g., due to
+// certificate rotation) and should be retried, or if it's a permanent error that
+// requires different handling.
+func isTransientCertError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+	var noCertKeyErr *certificate.NoCertKeyError
+	if errors.As(err, &noCertKeyErr) {
+		return false
+	}
+	if strings.Contains(errMsg, "no such file or directory") ||
+		strings.Contains(errMsg, "failed to find any PEM data") ||
+		strings.Contains(errMsg, "invalid PEM") {
+		return true
+	}
+	return false
+}
 
 // getPerNodeKubeconfig creates new kubeConfig, based on bootstrap, with new certDir
 func getPerNodeKubeconfig(bootstrap *rest.Config, certDir string) *rest.Config {
@@ -149,7 +170,18 @@ func PerNodeK8sClient(nodeName, bootstrapKubeconfigFile string, certDuration tim
 	err = wait.PollWithContext(context.TODO(), time.Second, 2*time.Minute, func(_ context.Context) (bool, error) {
 		var currentCert *tls.Certificate
 		currentCert, storeErr = certificateStore.Current()
-		return currentCert != nil && storeErr == nil, nil
+		if storeErr != nil {
+			var noCertKeyErr *certificate.NoCertKeyError
+			if errors.As(storeErr, &noCertKeyErr) {
+				return false, nil
+			}
+			if isTransientCertError(storeErr) {
+				logging.Verbosef("Transient cert error (likely rotation in progress), will retry: %v", storeErr)
+				return false, nil
+			}
+			return false, storeErr
+		}
+		return currentCert != nil, nil
 	})
 	if err != nil {
 		return nil, logging.Errorf("certificate was not signed, last cert store err: %v err: %v", storeErr, err)

--- a/pkg/k8sclient/kubeconfig.go
+++ b/pkg/k8sclient/kubeconfig.go
@@ -62,11 +62,15 @@ func isTransientCertError(err error) bool {
 	if err == nil {
 		return false
 	}
-	errMsg := err.Error()
 	var noCertKeyErr *certificate.NoCertKeyError
 	if errors.As(err, &noCertKeyErr) {
-		return false
+		// No cert/key currently present (initial provisioning, or rotation
+		// briefly removing the symlink) - retry.
+		return true
 	}
+	// The certificate store wraps these errors with fmt.Errorf("%v", ...) rather than
+	// %w, so errors.Is/errors.As can't unwrap them - string matching is the only option.
+	errMsg := err.Error()
 	if strings.Contains(errMsg, "no such file or directory") ||
 		strings.Contains(errMsg, "failed to find any PEM data") ||
 		strings.Contains(errMsg, "invalid PEM") {
@@ -171,10 +175,6 @@ func PerNodeK8sClient(nodeName, bootstrapKubeconfigFile string, certDuration tim
 		var currentCert *tls.Certificate
 		currentCert, storeErr = certificateStore.Current()
 		if storeErr != nil {
-			var noCertKeyErr *certificate.NoCertKeyError
-			if errors.As(storeErr, &noCertKeyErr) {
-				return false, nil
-			}
 			if isTransientCertError(storeErr) {
 				logging.Verbosef("Transient cert error (likely rotation in progress), will retry: %v", storeErr)
 				return false, nil

--- a/pkg/k8sclient/kubeconfig_test.go
+++ b/pkg/k8sclient/kubeconfig_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sclient
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/client-go/util/certificate"
+)
+
+func TestIsTransientCertError(t *testing.T) {
+	noCertKeyErr := certificate.NoCertKeyError(`no cert/key files read at "/var/lib/multus"`)
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "NoCertKeyError",
+			err:      &noCertKeyErr,
+			expected: false,
+		},
+		{
+			name:     "file not found during rotation",
+			err:      fmt.Errorf("could not convert data from \"/certs/current.pem\" into cert/key pair: open /certs/current.pem: no such file or directory"),
+			expected: true,
+		},
+		{
+			name:     "empty PEM file during rotation",
+			err:      fmt.Errorf("could not convert data from \"/certs/current.pem\" into cert/key pair: failed to find any PEM data in certificate input"),
+			expected: true,
+		},
+		{
+			name:     "invalid PEM data during rotation",
+			err:      fmt.Errorf("invalid PEM block"),
+			expected: true,
+		},
+		{
+			name:     "unrecognized error is not transient",
+			err:      fmt.Errorf("some unknown certificate error"),
+			expected: false,
+		},
+		{
+			name:     "permission denied is not transient",
+			err:      fmt.Errorf("permission denied"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTransientCertError(tt.err)
+			if got != tt.expected {
+				t.Errorf("isTransientCertError(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/k8sclient/kubeconfig_test.go
+++ b/pkg/k8sclient/kubeconfig_test.go
@@ -37,7 +37,7 @@ func TestIsTransientCertError(t *testing.T) {
 		{
 			name:     "NoCertKeyError",
 			err:      &noCertKeyErr,
-			expected: false,
+			expected: true,
 		},
 		{
 			name:     "file not found during rotation",


### PR DESCRIPTION
Add retry logic to handle transient certificate errors during daemon startup. This prevents crash-loops when pods restart during the certificate rotation window (~3 seconds) where the symlink is temporarily removed or the file is empty.

We accomplish this by retrying if we get a transient error, but still fail fast on permanent errors.

Changes:
- Add isTransientCertError() to classify errors as transient vs permanent
- Transient errors (file not found, empty/invalid PEM, and the "no cert/key present yet" case that's expected during initial provisioning or mid-rotation) are retried within the existing 2-minute CSR approval timeout, using its existing 1-second poll interval
- Other, non-transient errors (e.g. RBAC issues) fail fast instead of polling for the full 2-minute timeout
- Add verbose logging on each transient retry attempt to aid debugging

Testing
- Tested with missing certificate file during pod restart
- Pods successfully recover and start normally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate readiness handling by retrying temporary certificate errors during connection setup.
  * Added immediate failure reporting for non-recoverable certificate-store errors.
  * Continued waiting appropriately when certificates are not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->