### PR TITLE
ci: update trivy-action to v0.35.0 to fix image scanning failure

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -57,7 +57,7 @@ jobs:
           provenance: false
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:latest-thick
           ignore-unfixed: true


### PR DESCRIPTION
The trivy-action@0.29.0 was trying to install Trivy v0.57.1 which no longer exists in the GitHub releases. This was causing all PR builds to fail on the "Image thick plugin" job. Update to v0.35.0 which properly installs the latest Trivy version.

Assisted by Claude Sonnet 4.5