### PR TITLE
fix error checking in validateIfName

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -189,7 +189,7 @@ func validateIfName(nsname string, ifname string) error {
 	err = podNs.Do(func(_ ns.NetNS) error {
 		_, err := netlink.LinkByName(ifname)
 		if err != nil {
-			if err.Error() == "Link not found" {
+			if _, ok := err.(netlink.LinkNotFoundError); ok {
 				return nil
 			}
 			return err

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -189,7 +189,7 @@ func validateIfName(nsname string, ifname string) error {
 	err = podNs.Do(func(_ ns.NetNS) error {
 		_, err := netlink.LinkByName(ifname)
 		if err != nil {
-			var lnf netlink.LinkNotFoundError
+			var lnf *netlink.LinkNotFoundError
 			if stderrors.As(err, &lnf) {
 				return nil
 			}

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -189,7 +189,7 @@ func validateIfName(nsname string, ifname string) error {
 	err = podNs.Do(func(_ ns.NetNS) error {
 		_, err := netlink.LinkByName(ifname)
 		if err != nil {
-			var lnf *netlink.LinkNotFoundError
+			var lnf netlink.LinkNotFoundError
 			if stderrors.As(err, &lnf) {
 				return nil
 			}

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -189,7 +189,8 @@ func validateIfName(nsname string, ifname string) error {
 	err = podNs.Do(func(_ ns.NetNS) error {
 		_, err := netlink.LinkByName(ifname)
 		if err != nil {
-			if _, ok := err.(netlink.LinkNotFoundError); ok {
+			var lnf netlink.LinkNotFoundError
+			if stderrors.As(err, &lnf) {
 				return nil
 			}
 			return err


### PR DESCRIPTION
In some cases, calling `netlink.LinkByName(ifname)` with a non-existent `ifname` returns an error with the message "Link %s not found". As a result, `validateIfName` incorrectly fails in this scenario.

This PR addresses the issue by handling the "link not found" case properly.