### PR TITLE
fix: return success on DEL when CNI cache is missing

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -954,33 +954,19 @@ func CmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) er
 	}
 
 	if !useCacheConf {
-		// Fetch delegates again if cache is not exist and pod info can be read
-		if os.IsNotExist(err) && pod != nil {
-			if in.ClusterNetwork != "" {
-				_, err = k8s.GetDefaultNetworks(pod, in, kubeClient, nil)
-				if err != nil {
-					return cmdErr(k8sArgs, "failed to get clusterNetwork/defaultNetworks: %v", err)
-				}
-				// First delegate is always the master plugin
-				in.Delegates[0].MasterPlugin = true
-			}
-
-			// Get pod annotation and so on
-			_, _, err := k8s.TryLoadPodDelegates(pod, in, kubeClient, nil)
-			if err != nil {
-				if len(in.Delegates) == 0 {
-					// No delegate available so send error
-					return cmdErr(k8sArgs, "failed to get delegates: %v", err)
-				}
-				// Get clusterNetwork before, so continue to delete
-				logging.Errorf("Multus: failed to get delegates: %v, but continue to delete clusterNetwork", err)
-			}
-		} else {
-			// The options to continue with a delete have been exhausted (cachefile + API query didn't work)
-			// We cannot exit with an error as this may cause a sandbox to never get deleted.
-			logging.Errorf("Multus: failed to get the cached delegates file: %v, cannot properly delete", err)
+		// If cache does not exist, ADD was never completed for this sandbox.
+		// Attempting DEL with a config reconstructed from the API will fail because
+		// delegate plugins (e.g. kube-ovn) require runtime state that only exists
+		// after a successful ADD (socket paths, cached results, etc.).
+		// Return success to allow containerd to release the sandbox name reservation.
+		if os.IsNotExist(err) {
+			logging.Verbosef("Multus: no cache found for container %s (ADD was never completed), skip DEL", args.ContainerID)
 			return nil
 		}
+		// The options to continue with a delete have been exhausted
+		// We cannot exit with an error as this may cause a sandbox to never get deleted.
+		logging.Errorf("Multus: failed to get the cached delegates file: %v, cannot properly delete", err)
+		return nil
 	}
 
 	// set CNIVersion in delegate CNI config if there is no CNIVersion and multus conf have CNIVersion.


### PR DESCRIPTION
## Summary
- When CNI ADD never completes (e.g. sandbox creation fails), no cache file is written
- On cleanup, CmdDel reconstructs delegate configs from the API and calls DEL on each plugin
- Delegate plugins fail because they require runtime state from a successful ADD
- This creates a deadlock: containerd cannot release sandbox name reservations
- Fix: return success immediately when cache file does not exist (ADD never completed)

## Problem
After a node disruption, containerd accumulates stale sandbox name reservations. When it tries
to clean them up, CNI DEL is called through multus. Without a cache file, multus reconstructs
the config from the Kubernetes API, but delegate plugins (e.g. kube-ovn) reject the config
because it lacks runtime state (socket paths, cached results) that only exists after ADD.

This causes:
1. Sandbox name reservations persist indefinitely
2. New pods cannot be created on the affected node
3. DEL retry storm overloads multus, causing ADD timeouts for new pods

## Fix
If the cache file does not exist (`os.IsNotExist`), return `nil` immediately since there is
nothing to clean up. This matches the existing graceful fallback when both cache and pod are
missing (the `else` branch at the former line 978).

## Related issues
- #1454
- #1446
- https://github.com/containerd/containerd/issues/11504

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Manual test: create a pod sandbox failure scenario, verify DEL returns success without cache