### PR TITLE
e2e: Replace EOL CentOS 8 with CentOS Stream 9 in test templates

### DIFF
--- a/e2e/templates/default-route1.yml.j2
+++ b/e2e/templates/default-route1.yml.j2
@@ -32,7 +32,7 @@ metadata:
 spec:
   containers:
   - name: default-route-worker1
-    image: quay.io/centos/centos:8
+    image: quay.io/centos/centos:stream9
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true
@@ -51,7 +51,7 @@ metadata:
 spec:
   containers:
   - name: default-route-worker2
-    image: quay.io/centos/centos:8
+    image: quay.io/centos/centos:stream9
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true

--- a/e2e/templates/simple-macvlan1.yml.j2
+++ b/e2e/templates/simple-macvlan1.yml.j2
@@ -34,7 +34,7 @@ metadata:
 spec:
   containers:
   - name: macvlan-worker1
-    image: quay.io/centos/centos:8
+    image: quay.io/centos/centos:stream9
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true
@@ -55,7 +55,7 @@ metadata:
 spec:
   containers:
   - name: macvlan-worker2
-    image: quay.io/centos/centos:8
+    image: quay.io/centos/centos:stream9
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true

--- a/e2e/templates/simple-pod.yml.j2
+++ b/e2e/templates/simple-pod.yml.j2
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
   - name: simple-centos1
-    image: quay.io/centos/centos:8
+    image: quay.io/centos/centos:stream9
     command: ["/bin/sleep", "10000"]
     securityContext:
       privileged: true


### PR DESCRIPTION
Replace quay.io/centos/centos:8 with quay.io/centos/centos:stream9 in e2e test templates to address end-of-life concerns.

Fixes #1500

**Note to reviewers:**
also quay.io/centos/centos:8 does not support the s390x architecture, which leads to failures on s390x arch.
https://quay.io/repository/centos/centos?tab=tags
