### PR TITLE
kubeletclient: copy dev.DeviceIds to stop SortDeviceIDs scrambling cached state

### DIFF
--- a/pkg/kubeletclient/kubeletclient.go
+++ b/pkg/kubeletclient/kubeletclient.go
@@ -152,7 +152,14 @@ func (rc *kubeletClient) getDevicePluginResources(devices []*podresourcesapi.Con
 		if rInfo, ok := resourceMap[dev.ResourceName]; ok {
 			rInfo.DeviceIDs = append(rInfo.DeviceIDs, dev.DeviceIds...)
 		} else {
-			resourceMap[dev.ResourceName] = &types.ResourceInfo{DeviceIDs: dev.DeviceIds}
+			// Copy dev.DeviceIds into a fresh slice. Storing the
+			// kubelet-owned slice directly lets SortDeviceIDs'
+			// in-place sort mutate the cached rc.resources backing
+			// array, which is a data race under concurrent
+			// GetPodResourceMap calls (#1495).
+			resourceMap[dev.ResourceName] = &types.ResourceInfo{
+				DeviceIDs: append([]string(nil), dev.DeviceIds...),
+			}
 		}
 	}
 }

--- a/pkg/kubeletclient/kubeletclient.go
+++ b/pkg/kubeletclient/kubeletclient.go
@@ -149,18 +149,17 @@ func (rc *kubeletClient) GetPodResourceMap(pod *v1.Pod) (map[string]*types.Resou
 
 func (rc *kubeletClient) getDevicePluginResources(devices []*podresourcesapi.ContainerDevices, resourceMap map[string]*types.ResourceInfo) {
 	for _, dev := range devices {
-		if rInfo, ok := resourceMap[dev.ResourceName]; ok {
-			rInfo.DeviceIDs = append(rInfo.DeviceIDs, dev.DeviceIds...)
-		} else {
-			// Copy dev.DeviceIds into a fresh slice. Storing the
-			// kubelet-owned slice directly lets SortDeviceIDs'
-			// in-place sort mutate the cached rc.resources backing
-			// array, which is a data race under concurrent
-			// GetPodResourceMap calls (#1495).
-			resourceMap[dev.ResourceName] = &types.ResourceInfo{
-				DeviceIDs: append([]string(nil), dev.DeviceIds...),
-			}
+		rInfo, ok := resourceMap[dev.ResourceName]
+		if !ok {
+			rInfo = &types.ResourceInfo{}
+			resourceMap[dev.ResourceName] = rInfo
 		}
+		// Append into a map-owned slice rather than aliasing
+		// dev.DeviceIds directly: append from an empty destination
+		// produces a fresh backing array, so SortDeviceIDs' in-place
+		// sort can't bleed back into the kubelet response / cached
+		// rc.resources backing array (#1495).
+		rInfo.DeviceIDs = append(rInfo.DeviceIDs, dev.DeviceIds...)
 	}
 }
 

--- a/pkg/kubeletclient/kubeletclient_internal_test.go
+++ b/pkg/kubeletclient/kubeletclient_internal_test.go
@@ -51,4 +51,12 @@ func TestGetDevicePluginResourcesDoesNotAliasDeviceIds(t *testing.T) {
 	if len(stored) != len(original) {
 		t.Fatalf("resourceMap slice length changed: got %d want %d", len(stored), len(original))
 	}
+	// SortDeviceIDs should have sorted the map-owned copy.
+	expectedSorted := []string{"dev-a", "dev-b", "dev-c"}
+	for i := range expectedSorted {
+		if stored[i] != expectedSorted[i] {
+			t.Fatalf("resourceMap slice not sorted at index %d: got %q want %q (full: %v)",
+				i, stored[i], expectedSorted[i], stored)
+		}
+	}
 }

--- a/pkg/kubeletclient/kubeletclient_internal_test.go
+++ b/pkg/kubeletclient/kubeletclient_internal_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 The Multus Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package kubeletclient
+
+import (
+	"testing"
+
+	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
+
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/types"
+)
+
+// TestGetDevicePluginResourcesDoesNotAliasDeviceIds is a regression
+// test for kubeletclient aliasing dev.DeviceIds into the cached
+// kubelet response, which let SortDeviceIDs's in-place sort scramble
+// rc.resources under concurrent GetPodResourceMap callers (#1495).
+func TestGetDevicePluginResourcesDoesNotAliasDeviceIds(t *testing.T) {
+	rc := &kubeletClient{}
+	// The kubelet returns DeviceIds in an arbitrary order. Pre-sort to
+	// a known shape so we can detect any subsequent mutation of the
+	// backing array.
+	original := []string{"dev-b", "dev-a", "dev-c"}
+	deviceIds := append([]string(nil), original...)
+
+	devices := []*podresourcesapi.ContainerDevices{
+		{ResourceName: "vendor.example.com/gpu", DeviceIds: deviceIds},
+	}
+	resourceMap := map[string]*types.ResourceInfo{}
+
+	rc.getDevicePluginResources(devices, resourceMap)
+
+	// Sorting the map's stored slice must not bleed back into the caller's
+	// kubelet response slice, which is a proxy for the cached
+	// rc.resources backing array.
+	types.SortDeviceIDs(resourceMap)
+
+	for i := range original {
+		if deviceIds[i] != original[i] {
+			t.Fatalf("kubelet response was mutated at index %d: got %q want %q (full: %v)",
+				i, deviceIds[i], original[i], deviceIds)
+		}
+	}
+
+	stored := resourceMap["vendor.example.com/gpu"].DeviceIDs
+	if len(stored) != len(original) {
+		t.Fatalf("resourceMap slice length changed: got %d want %d", len(stored), len(original))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1495.

`getDevicePluginResources` stored the kubelet-owned `dev.DeviceIds` slice directly in `resourceMap`. When `GetPodResourceMap` later called `types.SortDeviceIDs(resourceMap)`, `sort.Strings` mutated the slice in place; that slice shares its backing array with `rc.resources` (the cached `ListPodResourcesResponse`). So a read-only-looking `GetPodResourceMap` call ended up reordering the cache, and concurrent callers raced on that same backing array.

## Fix

Copy `dev.DeviceIds` into a fresh slice on first insert so `SortDeviceIDs` acts on map-local state. The append-into-existing branch already owns the slice (built with `append` above), and `getDRAResources` already builds `deviceIDs` locally, so neither needs changes.

## Tests

Adds `TestGetDevicePluginResourcesDoesNotAliasDeviceIds` (plain `go test`, avoids the Ginkgo `BeforeSuite` filesystem setup that is macOS-unfriendly). It pre-populates a `ContainerDevices.DeviceIds` slice with a deliberately unsorted order, runs `getDevicePluginResources` and `SortDeviceIDs`, then asserts the input slice is untouched.

- **On master:** test FAILs, `dev-b dev-a dev-c` becomes `dev-a dev-b dev-c` in the kubelet-side slice.
- **With this fix:** test PASSes and the stored resourceMap slice is the only thing sorted.

`go build ./pkg/kubeletclient/...` and `go vet ./pkg/kubeletclient/...` are clean.