### PR TITLE
pkg/multus: downcast empty CNI result to requested cniVersion

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -768,12 +768,13 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		if stderrors.Is(err, errPodNotFound) {
 			emptyResult := emptyCNIResult(args, n.CNIVersion)
 			logging.Verbosef("CmdAdd: Warning: pod [%s/%s] not found, exiting with empty CNI result: %v", k8sArgs.K8S_POD_NAMESPACE, k8sArgs.K8S_POD_NAME, emptyResult)
-			// Downcast to the types package matching n.CNIVersion so skel's
-			// response conversion path calls the right convertFrom*/To*
-			// converter. Returning a *cni100.Result with CNIVersion 0.3.1
-			// trips convertFrom04x's type assertion to *types040.Result
-			// and panics (#1497).
-			if n.CNIVersion != "" {
+			// emptyCNIResult already returns a *cni100.Result, so 1.x
+			// configs don't need conversion. For older cniVersions
+			// (0.3.x / 0.4.0) we must downcast so skel's response
+			// conversion path calls the right convertFrom*/To* converter;
+			// otherwise convertFrom04x's type assertion to *types040.Result
+			// panics (#1497).
+			if n.CNIVersion != "" && !strings.HasPrefix(n.CNIVersion, "1.") {
 				versioned, convErr := emptyResult.GetAsVersion(n.CNIVersion)
 				if convErr != nil {
 					return nil, cmdErr(k8sArgs, "failed to downcast empty CNI result to cniVersion %q: %v", n.CNIVersion, convErr)

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -768,6 +768,18 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		if stderrors.Is(err, errPodNotFound) {
 			emptyResult := emptyCNIResult(args, n.CNIVersion)
 			logging.Verbosef("CmdAdd: Warning: pod [%s/%s] not found, exiting with empty CNI result: %v", k8sArgs.K8S_POD_NAMESPACE, k8sArgs.K8S_POD_NAME, emptyResult)
+			// Downcast to the types package matching n.CNIVersion so skel's
+			// response conversion path calls the right convertFrom*/To*
+			// converter. Returning a *cni100.Result with CNIVersion 0.3.1
+			// trips convertFrom04x's type assertion to *types040.Result
+			// and panics (#1497).
+			if n.CNIVersion != "" {
+				versioned, convErr := emptyResult.GetAsVersion(n.CNIVersion)
+				if convErr != nil {
+					return nil, cmdErr(k8sArgs, "failed to downcast empty CNI result to cniVersion %q: %v", n.CNIVersion, convErr)
+				}
+				return versioned, nil
+			}
 			return emptyResult, nil
 		}
 		return nil, err

--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -768,6 +768,19 @@ func CmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		if stderrors.Is(err, errPodNotFound) {
 			emptyResult := emptyCNIResult(args, n.CNIVersion)
 			logging.Verbosef("CmdAdd: Warning: pod [%s/%s] not found, exiting with empty CNI result: %v", k8sArgs.K8S_POD_NAMESPACE, k8sArgs.K8S_POD_NAME, emptyResult)
+			// emptyCNIResult already returns a *cni100.Result, so 1.x+
+			// configs don't need conversion. For older cniVersions
+			// (0.3.x / 0.4.0) we must downcast so skel's response
+			// conversion path calls the right convertFrom*/To* converter;
+			// otherwise convertFrom04x's type assertion to *types040.Result
+			// panics (#1497).
+			if isGte10, _ := cniversion.GreaterThanOrEqualTo(n.CNIVersion, "1.0.0"); n.CNIVersion != "" && !isGte10 {
+				versioned, convErr := emptyResult.GetAsVersion(n.CNIVersion)
+				if convErr != nil {
+					return nil, cmdErr(k8sArgs, "failed to downcast empty CNI result to cniVersion %q: %v", n.CNIVersion, convErr)
+				}
+				return versioned, nil
+			}
 			return emptyResult, nil
 		}
 		return nil, err

--- a/pkg/multus/multus_cni100_test.go
+++ b/pkg/multus/multus_cni100_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
 	cni100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
@@ -1290,6 +1291,40 @@ var _ = Describe("multus operations cniVersion 1.1.0 config", func() {
 		r, ok := result.(*cni100.Result)
 		Expect(ok).To(BeTrue())
 		Expect(r.CNIVersion).To(Equal("1.1.0"))
+		Expect(fExec.addIndex).To(Equal(0))
+	})
+
+	It("returns empty add result downcast to 0.4.0 cniVersion when pod is not found", func() {
+		// Regression for #1497: with cniVersion < 1.0.0 the empty CNI
+		// result used to be *cni100.Result, which trips convertFrom04x's
+		// type assertion to *types040.Result and panics when the
+		// response passes through skel.
+		args := &skel.CmdArgs{
+			ContainerID: "123456789",
+			Netns:       testNS.Path(),
+			IfName:      "eth0",
+			Args:        "K8S_POD_NAME=missing-pod;K8S_POD_NAMESPACE=default",
+			StdinData: []byte(`{
+	    "name": "node-cni-network",
+	    "type": "multus",
+	    "kubeconfig": "/etc/kubernetes/node-kubeconfig.yaml",
+	    "cniVersion": "0.4.0",
+	    "delegates": [{
+	        "name": "weave1",
+	        "cniVersion": "0.4.0",
+	        "type": "weave-net"
+	    }]
+	}`),
+		}
+
+		fExec := newFakeExec()
+		fKubeClient := NewFakeClientInfo()
+
+		result, err := CmdAdd(args, fExec, fKubeClient)
+		Expect(err).NotTo(HaveOccurred())
+		r, ok := result.(*types040.Result)
+		Expect(ok).To(BeTrue())
+		Expect(r.CNIVersion).To(Equal("0.4.0"))
 		Expect(fExec.addIndex).To(Equal(0))
 	})
 


### PR DESCRIPTION
## Summary

Fixes #1497.

`emptyCNIResult` always returns a `*cni100.Result`. When the pod-not-found branch set `CNIVersion` to `0.3.1` / `0.4.0` and handed that to skel, the containernetworking/cni conversion chain dispatched to `convertFrom04x`, which type-asserts the incoming `types.Result` to `*types040.Result` and panics because we gave it a `*cni100.Result`.

The earlier fix [ccfd8f5](https://github.com/k8snetworkplumbingwg/multus-cni/commit/ccfd8f5feae846aa32697b90ba7bc12cb8893c9d) hardcoded `1.0.0` to paper over the class mismatch; [921191d](https://github.com/k8snetworkplumbingwg/multus-cni/commit/921191dece729c8f25f6aaad51f7f31b29677a4a) reverted that so the response would round-trip through the user's configured version again. The panic regressed along with the revert.

## Fix

Call `emptyResult.GetAsVersion(n.CNIVersion)` so the returned Result's concrete type matches whatever `convertFrom*`/`convertTo*` the caller will run:

- For `1.x` configs the Result stays `*cni100.Result` (existing `1.1.0` test still asserts on that type).
- For `0.3.x` / `0.4.0` configs it now returns a `*types040.Result` that `convertFrom04x` can safely assert.

If `n.CNIVersion` is unset, we keep the existing behaviour (return `*cni100.Result` as-is).

## Tests

Adds `It("returns empty add result downcast to 0.4.0 cniVersion when pod is not found", ...)` that drives pod-not-found through `CmdAdd` with `cniVersion: 0.4.0` and asserts the returned Result is a `*types040.Result` with `CNIVersion "0.4.0"`. `go vet ./pkg/multus/...` clean under `GOOS=linux`; the existing `1.1.0` variant stays green.
