### PR TITLE
Only wait for config waitGroup when configManager is used

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -139,7 +139,9 @@ func main() {
 		}
 	}
 
+	<-ctx.Done()
 	wg.Wait()
+
 	logging.Verbosef("multus daemon is exited")
 }
 


### PR DESCRIPTION
reopen of https://github.com/k8snetworkplumbingwg/multus-cni/pull/1398 with rebase on master

When `MultusConfigFile` is not set to `auto` (configManager is nil) the WaitGroup is initialised and then waited for, immediately exiting Multus. This PR only waits when configManager is not nil, otherwise it waits for the context to complete (which happens from the SIGINT / SIGTERM handlers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon shutdown handling to ensure ongoing operations finish cleanly before the process exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->