### PR TITLE
Add optional pprof endpoint support to multus-daemon

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -22,12 +22,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"os/user"
 	"path/filepath"
 	"sync"
 	"syscall"
+	"time"
 
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 
@@ -155,11 +157,31 @@ func startMultusDaemon(ctx context.Context, daemonConfig *srv.ControllerNetConf,
 	}
 
 	if daemonConfig.MetricsPort != nil {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		if daemonConfig.EnablePprof != nil && *daemonConfig.EnablePprof {
+			mux.HandleFunc("/debug/pprof/", pprof.Index)
+			mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+			mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+			logging.Verbosef("pprof endpoints enabled on metrics port %d", *daemonConfig.MetricsPort)
+		}
+		metricsSrv := &http.Server{
+			Addr:              fmt.Sprintf(":%d", *daemonConfig.MetricsPort),
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		logging.Debugf("metrics port: %d", *daemonConfig.MetricsPort)
 		go utilwait.UntilWithContext(ctx, func(_ context.Context) {
-			http.Handle("/metrics", promhttp.Handler())
-			logging.Debugf("metrics port: %d", *daemonConfig.MetricsPort)
-			logging.Debugf("metrics: %s", http.ListenAndServe(fmt.Sprintf(":%d", *daemonConfig.MetricsPort), nil))
+			if err := metricsSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				logging.Debugf("metrics server error: %v", err)
+			}
 		}, 0)
+		go func() {
+			<-ctx.Done()
+			metricsSrv.Shutdown(context.Background())
+		}()
 	}
 
 	l, err := srv.GetListener(api.SocketPath(daemonConfig.SocketDir))

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -78,7 +78,8 @@ type ControllerNetConf struct {
 	LogToStderr        bool                `json:"logToStderr,omitempty"`
 	PerNodeCertificate *PerNodeCertificate `json:"perNodeCertificate,omitempty"`
 
-	MetricsPort *int `json:"metricsPort,omitempty"`
+	MetricsPort *int  `json:"metricsPort,omitempty"`
+	EnablePprof *bool `json:"enablePprof,omitempty"`
 
 	// Option to point to the path of the unix domain socket through which the
 	// multus client / server communicate.


### PR DESCRIPTION
Enable multus-daemon to expose Go pprof endpoints for runtime profiling, allowing operators to capture CPU profiles, memory heap dumps, goroutine stacks, and execution traces. This helps identify performance hot spots and memory issues in production.

pprof is gated behind a new "enablePprof" config flag and shares the existing metrics TCP port, so it is not exposed by default.

Daemon config example:

    {
        "metricsPort": 6061,
        "enablePprof": true
    }

Usage (with metricsPort 6061):

    # 30-second CPU profile
    go tool pprof http://<node>:6061/debug/pprof/profile?seconds=30

    # Memory heap dump
    go tool pprof http://<node>:6061/debug/pprof/heap

    # Goroutine stacks
    curl http://<node>:6061/debug/pprof/goroutine?debug=2

    # Execution trace (5 seconds)
    curl -o trace.out http://<node>:6061/debug/pprof/trace?seconds=5
    go tool trace trace.out

Assisted by Claude Opus 4.6