### PR TITLE
Add connection limit for thick daemon.

### DIFF
--- a/.github/workflows/kind-e2e.yml
+++ b/.github/workflows/kind-e2e.yml
@@ -85,6 +85,10 @@ jobs:
         working-directory: ./e2e
         run: ./test-default-route1.sh
 
+      - name: Test connection limit
+        working-directory: ./e2e
+        run: ./test-connection-limit.sh
+
 #      - name: Test DRA integration
 #        working-directory: ./e2e
 #        run: ./test-dra-integration.sh

--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -168,7 +168,10 @@ func startMultusDaemon(ctx context.Context, daemonConfig *srv.ControllerNetConf,
 		return fmt.Errorf("failed to start the CNI server using socket %s. Reason: %+v", api.SocketPath(daemonConfig.SocketDir), err)
 	}
 
-	if limit := daemonConfig.ConnectionLimit; limit != nil && *limit > 0 {
+	if limit := daemonConfig.ConnectionLimit; limit != nil {
+		if *limit <= 0 {
+			return fmt.Errorf("connection limit must be greater than 0, got %d", *limit)
+		}
 		logging.Debugf("connection limit: %d", *limit)
 		l = netutil.LimitListener(l, *limit)
 	}

--- a/e2e/templates/many-pods.yml.j2
+++ b/e2e/templates/many-pods.yml.j2
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-centos1
+  labels:
+    app: many
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      app: many
+  template:
+    metadata:
+      labels:
+        app: many
+    spec:
+      containers:
+      - name: simple-centos1
+        image: centos:8
+        command: ["/bin/sleep", "10000"]
+        securityContext:
+          privileged: true

--- a/e2e/templates/multus-daemonset-thick.yml.j2
+++ b/e2e/templates/multus-daemonset-thick.yml.j2
@@ -97,7 +97,8 @@ data:
         "cniConfigDir": "/host/etc/cni/net.d",
         "multusConfigFile": "auto",
         "forceCNIVersion": true,
-        "multusAutoconfigDir": "/host/etc/cni/net.d"
+        "multusAutoconfigDir": "/host/etc/cni/net.d",
+        "connectionLimit": 1
     }
 ---
 apiVersion: apps/v1

--- a/e2e/test-connection-limit.sh
+++ b/e2e/test-connection-limit.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -o errexit
+
+export PATH=${PATH}:./bin
+
+kubectl create -f yamls/many-pods.yml
+kubectl wait --for=condition=ready -l app=many --timeout=300s pod
+
+echo "cleanup resources"
+kubectl delete -f yamls/many-pods.yml

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -77,6 +77,7 @@ type ControllerNetConf struct {
 	LogLevel           string              `json:"logLevel"`
 	LogToStderr        bool                `json:"logToStderr,omitempty"`
 	PerNodeCertificate *PerNodeCertificate `json:"perNodeCertificate,omitempty"`
+	ConnectionLimit    *int                `json:"connectionLimit,omitempty"`
 
 	MetricsPort *int `json:"metricsPort,omitempty"`
 

--- a/vendor/golang.org/x/net/netutil/listen.go
+++ b/vendor/golang.org/x/net/netutil/listen.go
@@ -1,0 +1,87 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package netutil provides network utility functions, complementing the more
+// common ones in the net package.
+package netutil // import "golang.org/x/net/netutil"
+
+import (
+	"net"
+	"sync"
+)
+
+// LimitListener returns a Listener that accepts at most n simultaneous
+// connections from the provided Listener.
+func LimitListener(l net.Listener, n int) net.Listener {
+	return &limitListener{
+		Listener: l,
+		sem:      make(chan struct{}, n),
+		done:     make(chan struct{}),
+	}
+}
+
+type limitListener struct {
+	net.Listener
+	sem       chan struct{}
+	closeOnce sync.Once     // ensures the done chan is only closed once
+	done      chan struct{} // no values sent; closed when Close is called
+}
+
+// acquire acquires the limiting semaphore. Returns true if successfully
+// acquired, false if the listener is closed and the semaphore is not
+// acquired.
+func (l *limitListener) acquire() bool {
+	select {
+	case <-l.done:
+		return false
+	case l.sem <- struct{}{}:
+		return true
+	}
+}
+func (l *limitListener) release() { <-l.sem }
+
+func (l *limitListener) Accept() (net.Conn, error) {
+	if !l.acquire() {
+		// If the semaphore isn't acquired because the listener was closed, expect
+		// that this call to accept won't block, but immediately return an error.
+		// If it instead returns a spurious connection (due to a bug in the
+		// Listener, such as https://golang.org/issue/50216), we immediately close
+		// it and try again. Some buggy Listener implementations (like the one in
+		// the aforementioned issue) seem to assume that Accept will be called to
+		// completion, and may otherwise fail to clean up the client end of pending
+		// connections.
+		for {
+			c, err := l.Listener.Accept()
+			if err != nil {
+				return nil, err
+			}
+			c.Close()
+		}
+	}
+
+	c, err := l.Listener.Accept()
+	if err != nil {
+		l.release()
+		return nil, err
+	}
+	return &limitListenerConn{Conn: c, release: l.release}, nil
+}
+
+func (l *limitListener) Close() error {
+	err := l.Listener.Close()
+	l.closeOnce.Do(func() { close(l.done) })
+	return err
+}
+
+type limitListenerConn struct {
+	net.Conn
+	releaseOnce sync.Once
+	release     func()
+}
+
+func (l *limitListenerConn) Close() error {
+	err := l.Conn.Close()
+	l.releaseOnce.Do(l.release)
+	return err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -208,6 +208,7 @@ golang.org/x/net/http2/hpack
 golang.org/x/net/idna
 golang.org/x/net/internal/httpcommon
 golang.org/x/net/internal/timeseries
+golang.org/x/net/netutil
 golang.org/x/net/trace
 # golang.org/x/oauth2 v0.34.0
 ## explicit; go 1.24.0


### PR DESCRIPTION
## Summary

Adds the Connection Limit being considered below.

  - https://github.com/k8snetworkplumbingwg/multus-cni/pull/1356
  - https://github.com/k8snetworkplumbingwg/multus-cni/pull/1437
  - https://github.com/k8snetworkplumbingwg/multus-cni/pull/1458

## Related

Close: #1346

## Background

When inspecting Multus itself using pprof, memory usage typically ranges from 50-60 MiB. However, since Multus launches additional CNIs, the total memory consumption of the entire container becomes the sum of all these components.
To run multus with strict memory limits, we essentially have to limit the number of parallel processes.

```
$ CG=$(sed -n 's/^0:://p' /proc/$(pgrep multus-daemon)/cgroup)
$ sh -c 'ps -o pid,ppid,pcpu,pmem,rss,vsz,comm,args --sort=-rss -p $(paste -sd, /sys/fs/cgroup'"$CG"'/cgroup.procs)'
    PID    PPID %CPU %MEM   RSS    VSZ COMMAND         COMMAND
1704573    6275 12.3  0.0 56180 1298756 cilium-cni     /opt/cni/bin/cilium-cni
1704707    6275 12.7  0.0 56036 1298756 cilium-cni     /opt/cni/bin/cilium-cni
1704848    6275 16.2  0.0 55692 1298500 cilium-cni     /opt/cni/bin/cilium-cni
1704911    6275 20.0  0.0 55584 1299268 cilium-cni     /opt/cni/bin/cilium-cni
1704443    6275 10.4  0.0 55476 1298756 cilium-cni     /opt/cni/bin/cilium-cni
1704846    6275 13.5  0.0 55364 1298500 cilium-cni     /opt/cni/bin/cilium-cni
1705061    6275 24.0  0.0 55324 1298756 cilium-cni     /opt/cni/bin/cilium-cni
1705067    6275 20.0  0.0 55076 1297732 cilium-cni     /opt/cni/bin/cilium-cni
1704908    6275 14.2  0.0 54716 1297540 cilium-cni     /opt/cni/bin/cilium-cni
1705087    6275 20.0  0.0 54560 1297732 cilium-cni     /opt/cni/bin/cilium-cni
1704572    6275 10.9  0.0 54496 1299268 cilium-cni     /opt/cni/bin/cilium-cni
1705098    6275 20.8  0.0 54480 1298244 cilium-cni     /opt/cni/bin/cilium-cni
1705065    6275 24.0  0.0 54448 1298244 cilium-cni     /opt/cni/bin/cilium-cni
1705097    6275 20.8  0.0 54064 1297732 cilium-cni     /opt/cni/bin/cilium-cni
1704910    6275 14.2  0.0 53924 1297220 cilium-cni     /opt/cni/bin/cilium-cni
1705359    6275 55.5  0.0 53920 1297988 cilium-cni     /opt/cni/bin/cilium-cni
   6275    4648  0.0  0.0 53684 1282624 multus-daemon  /usr/src/multus-cni/bin/multus-daemon
1705066    6275 20.0  0.0 52880 1296964 cilium-cni     /opt/cni/bin/cilium-cni
```

Therefore, the best solution would be to directly incorporate the patch previously proposed by @juliusmh.
