### PR TITLE
Fix --multus-cni-conf-dir writing invalid "cniConf" JSON key

### DIFF
--- a/cmd/thin_entrypoint/main.go
+++ b/cmd/thin_entrypoint/main.go
@@ -476,7 +476,7 @@ func (o *Options) createMultusConfig(prevMasterConfigFileHash []byte) (string, [
 	// check MultusCNIConfDir
 	multusCNIConfDirConfig := ""
 	if o.MultusCNIConfDir != "" {
-		multusCNIConfDirConfig = fmt.Sprintf("\n        \"cniConf\": %q,", o.MultusCNIConfDir)
+		multusCNIConfDirConfig = fmt.Sprintf("\n        \"confDir\": %q,", o.MultusCNIConfDir)
 	}
 
 	// check ReadinessIndicatorFile

--- a/cmd/thin_entrypoint/main_test.go
+++ b/cmd/thin_entrypoint/main_test.go
@@ -254,7 +254,7 @@ var _ = Describe("thin entrypoint testing", func() {
         "logLevel": "debug",
         "logFile": "/tmp/foobar.log",
         "binDir": "/tmp/add_bin_dir",
-        "cniConf": "/tmp/multus/net.d",
+        "confDir": "/tmp/multus/net.d",
         "readinessindicatorfile": "/var/lib/foobar_indicator",
         "kubeconfig": "/etc/foobar_kubeconfig",
         "delegates": [
@@ -469,7 +469,7 @@ var _ = Describe("thin entrypoint testing", func() {
         "logLevel": "debug",
         "logFile": "/tmp/foobar.log",
         "binDir": "/tmp/add_bin_dir",
-        "cniConf": "/tmp/multus/net.d",
+        "confDir": "/tmp/multus/net.d",
         "readinessindicatorfile": "/var/lib/foobar_indicator",
         "kubeconfig": "/etc/foobar_kubeconfig",
         "delegates": [


### PR DESCRIPTION
## Summary
Fix the `--multus-cni-conf-dir` flag in thin_entrypoint to write the correct `"confDir"` JSON key instead of the invalid `"cniConf"` key in the generated multus config.
Fixes #1506

## Problem
The `--multus-cni-conf-dir` flag writes `"cniConf"` into the generated multus config:

```
json
{
    "type": "multus",
    "cniConf": "/etc/cni/multus/net.d",
}
```
But the NetConf struct in pkg/types/types.go expects "confDir":
Go's JSON unmarshaller silently ignores unknown keys, so "cniConf" is discarded and ConfDir always falls back to the hardcoded default /etc/cni/multus/net.d. This makes --multus-cni-conf-dir effectively a no-op, causing pod sandbox failures:

Error:
No networks found in /etc/cni/multus/net.d

## Fix
Changed the generated JSON key from "cniConf" to "confDir" in cmd/thin_entrypoint/main.go and updated test expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated Multus configuration to use the `confDir` field when a CNI config directory is provided.
  * Ensures both output formats produce the expected JSON key in the final configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->