### PR TITLE
fix(test): fix test file collision in pkg/server and pkg/multus tests

### DIFF
--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -92,7 +92,7 @@ var _ = Describe(suiteName, func() {
 	})
 
 	Context("STATUS and GC commands without pod context", func() {
-		const configPath = "/tmp/foo.multus.conf"
+		const configPath = "/tmp/foo.multus.server-test.conf"
 
 		var (
 			cniServer *Server
@@ -160,7 +160,7 @@ var _ = Describe(suiteName, func() {
 			containerID = "123456789"
 			ifaceName   = "eth0"
 			podName     = "my-little-pod"
-			configPath  = "/tmp/foo.multus.conf"
+			configPath  = "/tmp/foo.multus.server-test.conf"
 		)
 
 		var (
@@ -222,7 +222,7 @@ var _ = Describe(suiteName, func() {
 			containerID = "123456789"
 			ifaceName   = "eth0"
 			podName     = "my-little-pod"
-			configPath  = "/tmp/foo.multus.conf"
+			configPath  = "/tmp/foo.multus.server-test.conf"
 		)
 
 		var (
@@ -366,7 +366,7 @@ func referenceConfig(thickPluginSocketDir string) string {
         "name": "node-cni-network",
         "type": "multus",
         "daemonSocketDir": "%s",
-        "readinessindicatorfile": "/tmp/foo.multus.conf",
+        "readinessindicatorfile": "/tmp/foo.multus.server-test.conf",
         "defaultnetworkwaitseconds": 3,
         "delegates": [{
             "name": "weave1",


### PR DESCRIPTION
**Summary**
Fix intermittent pkg/server test failure ("STATUS succeeds with CNI_ARGS unset") caused by cross-package file contention when running go test ./...

**Problem**
The pkg/server thick CNI tests (STATUS and GC commands) use a readiness indicator file at /tmp/foo.multus.conf. The pkg/multus tests use the exact same path. Since go test ./... runs test packages in parallel by default, the following race condition occurs:

  1. pkg/server starts a test that polls for /tmp/foo.multus.conf to exist (readiness indicator check)
  2. pkg/multus runs concurrently, and its AfterEach cleanup deletes /tmp/foo.multus.conf
  3. pkg/server's poll times out with: still waiting for readinessindicatorfile @ /tmp/foo.multus.conf. pollimmediate error: timed out waiting for the condition

This failure is non-deterministic — it depends on the exact timing of parallel package execution, which is why it appears as a flaky test in CI.

**Evidence**
Evidence of pre-existing flakiness in CI: https://github.com/k8snetworkplumbingwg/multus-cni/actions/runs/26890832673/job/82962012166

**Fix**
Rename the readiness indicator file path in pkg/server/thick_cni_test.go from /tmp/foo.multus.conf to /tmp/foo.multus.server-test.conf. This eliminates the collision with pkg/multus tests while preserving the same test behavior.

Fixes: https://github.com/k8snetworkplumbingwg/multus-cni/issues/1518


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated server test configuration paths to use a new, consistent test-specific file name across readiness and network file checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->