### PR TITLE
shim: use single-shot readiness check for CNI STATUS

### DIFF
--- a/pkg/server/api/shim.go
+++ b/pkg/server/api/shim.go
@@ -86,7 +86,7 @@ func CmdGC(args *skel.CmdArgs) error {
 
 // CmdStatus implements the CNI spec STATUS command handler
 func CmdStatus(args *skel.CmdArgs) error {
-	_, _, err := postRequest(args, WaitUntilAPIReady)
+	_, _, err := postRequest(args, CheckAPIReadyNow)
 	if err != nil {
 		return logging.Errorf("CmdStatus (shim): %v", err)
 	}


### PR DESCRIPTION
## Summary

- Use `CheckAPIReadyNow` instead of `WaitUntilAPIReady` for STATUS in the shim

STATUS is a plugin-level health check. If the daemon isn't responding, it should fail immediately rather than polling `/healthz` every 100ms for up to 60 seconds. `CmdDel` already uses `CheckAPIReadyNow` for the same reason.

This eliminates one unnecessary HTTP round-trip per STATUS call and prevents 60-second stalls when the daemon is down. Since CRI-O calls STATUS periodically, it will naturally retry on the next cycle.

**Context:** Adding STATUS monitoring in CRI-O at 5-second intervals caused a 115% CPU increase. This change is the first step in reducing that overhead.

## Test plan

- [ ] Verify existing STATUS tests pass (`pkg/multus/multus_cni100_test.go`, `pkg/server/thick_cni_test.go`)
- [ ] Confirm STATUS returns error immediately when daemon socket is unavailable (instead of blocking 60s)
- [ ] Confirm STATUS succeeds when daemon is running


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status checks now return immediately instead of waiting for full API readiness, making command responses faster and more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->