### PR TITLE
Add resourceName field to the NetworkSelectionElement

### DIFF
--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -431,6 +431,40 @@ spec:
 EOF
 ```
 
+#### Launch pod with json annotation with resourceName
+
+The resource pool a network attachment should use is normally selected with the
+`k8s.v1.cni.cncf.io/resourceName` annotation on the NetworkAttachmentDefinition.
+The same selection can instead be set per attachment in the network selection
+element by adding `"resourceName": "<resource>"`. This lets attachments backed by
+different resource pools reference the same NetworkAttachmentDefinition, without
+creating a separate NetworkAttachmentDefinition per resource pool.
+
+```
+# Execute following command at Kubernetes master
+cat <<EOF | kubectl create -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-case-07
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[
+            { "name" : "sriov-net",
+              "resourceName": "intel.com/sriov" }
+    ]'
+spec:
+  containers:
+  - name: pod-case-07
+    image: docker.io/centos/tools:latest
+    command:
+    - /sbin/init
+EOF
+```
+
+If the NetworkAttachmentDefinition also carries a `k8s.v1.cni.cncf.io/resourceName`
+annotation and it differs from the `resourceName` set in the network selection
+element, Multus reports an error. Setting the same value in both places is allowed.
+
 ### Verifying pod network
 
 Following the example of `ip -d address` output of above pod, "pod-case-06":

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -301,12 +301,26 @@ func getKubernetesDelegate(client *ClientInfo, net *types.NetworkSelectionElemen
 		return nil, resourceMap, logging.Errorf("getKubernetesDelegate: %s", errMsg)
 	}
 
-	// Get resourceName annotation from NetworkAttachmentDefinition
+	// Get resourceName from the NetworkAttachmentDefinition annotation. It may
+	// also be set per-attachment by the NetworkSelectionElement, which lets
+	// different device pools attach to the same network without duplicating the
+	// NAD. If both are set and disagree, that is a misconfiguration.
 	deviceID := ""
-	resourceName, ok := customResource.GetAnnotations()[resourceNameAnnot]
-	if ok && pod != nil && pod.Name != "" && pod.Namespace != "" {
-		// ResourceName annotation is found; try to get device info from resourceMap
-		logging.Debugf("getKubernetesDelegate: found resourceName annotation : %s", resourceName)
+	resourceName := customResource.GetAnnotations()[resourceNameAnnot]
+	if net.ResourceNameRequest != "" {
+		if resourceName != "" && resourceName != net.ResourceNameRequest {
+			errMsg := fmt.Sprintf("conflicting resourceName for network %s: NAD annotation %q does not match NetworkSelectionElement request %q",
+				net.Name, resourceName, net.ResourceNameRequest)
+			if client != nil {
+				client.Eventf(pod, v1.EventTypeWarning, "ResourceNameConflict", errMsg)
+			}
+			return nil, resourceMap, logging.Errorf("getKubernetesDelegate: %s", errMsg)
+		}
+		resourceName = net.ResourceNameRequest
+	}
+	if resourceName != "" && pod != nil && pod.Name != "" && pod.Namespace != "" {
+		// ResourceName is set; try to get device info from resourceMap
+		logging.Debugf("getKubernetesDelegate: using resourceName : %s", resourceName)
 
 		if resourceMap == nil {
 			ck, err := kubeletclient.GetResourceClient("")

--- a/pkg/k8sclient/k8sclient_test.go
+++ b/pkg/k8sclient/k8sclient_test.go
@@ -999,6 +999,99 @@ users:
 			_, err = GetNetworkDelegates(clientInfo, fakePod, networks, netConf, nil)
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("uses resourceName requested by the NetworkSelectionElement when it matches the NAD annotation", func() {
+			// NewFakeNetAttachDefAnnotation stamps the NAD with
+			// k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
+			fakePod := testutils.NewFakePod(fakePodName, `[{"name":"net1","resourceName":"intel.com/sriov"}]`, "")
+			net1 := `{
+		"name": "net1",
+		"type": "mynet",
+		"cniVersion": "0.4.0"
+	}`
+			clientInfo := NewFakeClientInfo()
+			_, err := clientInfo.AddPod(fakePod)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = clientInfo.AddNetAttachDef(
+				testutils.NewFakeNetAttachDefAnnotation(fakePod.ObjectMeta.Namespace, "net1", net1))
+			Expect(err).NotTo(HaveOccurred())
+
+			networks, err := GetPodNetwork(fakePod)
+			Expect(err).NotTo(HaveOccurred())
+
+			netConf, err := types.LoadNetConf([]byte(genericConf))
+			Expect(err).NotTo(HaveOccurred())
+			netConf.ConfDir = tmpDir
+
+			// Pass a populated resourceMap so no kubelet ResourceClient is needed.
+			resourceMap := map[string]*types.ResourceInfo{
+				"intel.com/sriov": {DeviceIDs: []string{"0000:03:02.0"}},
+			}
+			delegates, err := GetNetworkDelegates(clientInfo, fakePod, networks, netConf, resourceMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(delegates).To(HaveLen(1))
+			Expect(delegates[0].ResourceName).To(Equal("intel.com/sriov"))
+			Expect(delegates[0].DeviceID).To(Equal("0000:03:02.0"))
+		})
+
+		It("uses resourceName requested by the NetworkSelectionElement when the NAD has no annotation", func() {
+			// NewFakeNetAttachDef creates a NAD without the resourceName annotation,
+			// so the resourceName comes solely from the NetworkSelectionElement.
+			fakePod := testutils.NewFakePod(fakePodName, `[{"name":"net1","resourceName":"intel.com/sriov"}]`, "")
+			net1 := `{
+		"name": "net1",
+		"type": "mynet",
+		"cniVersion": "0.4.0"
+	}`
+			clientInfo := NewFakeClientInfo()
+			_, err := clientInfo.AddPod(fakePod)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = clientInfo.AddNetAttachDef(
+				testutils.NewFakeNetAttachDef(fakePod.ObjectMeta.Namespace, "net1", net1))
+			Expect(err).NotTo(HaveOccurred())
+
+			networks, err := GetPodNetwork(fakePod)
+			Expect(err).NotTo(HaveOccurred())
+
+			netConf, err := types.LoadNetConf([]byte(genericConf))
+			Expect(err).NotTo(HaveOccurred())
+			netConf.ConfDir = tmpDir
+
+			resourceMap := map[string]*types.ResourceInfo{
+				"intel.com/sriov": {DeviceIDs: []string{"0000:03:02.0"}},
+			}
+			delegates, err := GetNetworkDelegates(clientInfo, fakePod, networks, netConf, resourceMap)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(delegates).To(HaveLen(1))
+			Expect(delegates[0].ResourceName).To(Equal("intel.com/sriov"))
+			Expect(delegates[0].DeviceID).To(Equal("0000:03:02.0"))
+		})
+
+		It("fails when the NetworkSelectionElement resourceName conflicts with the NAD annotation", func() {
+			// NAD annotation is intel.com/sriov; the NSE requests a different one.
+			fakePod := testutils.NewFakePod(fakePodName, `[{"name":"net1","resourceName":"nvidia.com/sriov"}]`, "")
+			net1 := `{
+		"name": "net1",
+		"type": "mynet",
+		"cniVersion": "0.4.0"
+	}`
+			clientInfo := NewFakeClientInfo()
+			_, err := clientInfo.AddPod(fakePod)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = clientInfo.AddNetAttachDef(
+				testutils.NewFakeNetAttachDefAnnotation(fakePod.ObjectMeta.Namespace, "net1", net1))
+			Expect(err).NotTo(HaveOccurred())
+
+			networks, err := GetPodNetwork(fakePod)
+			Expect(err).NotTo(HaveOccurred())
+
+			netConf, err := types.LoadNetConf([]byte(genericConf))
+			Expect(err).NotTo(HaveOccurred())
+			netConf.ConfDir = tmpDir
+
+			_, err = GetNetworkDelegates(clientInfo, fakePod, networks, netConf, nil)
+			Expect(err).To(MatchError(ContainSubstring("conflicting resourceName")))
+		})
 	})
 
 	Context("parsePodNetworkObjectName", func() {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -157,6 +157,12 @@ type NetworkSelectionElement struct {
 	BandwidthRequest *BandwidthEntry `json:"bandwidth,omitempty"`
 	// DeviceID contains an optional requested deviceID the network
 	DeviceID string `json:"deviceID,omitempty"`
+	// ResourceNameRequest contains an optional requested resource name that
+	// selects the device pool for this network attachment. When set, it takes
+	// the place of the NetworkAttachmentDefinition's
+	// k8s.v1.cni.cncf.io/resourceName annotation, allowing different device
+	// types to attach to the same network without duplicating the NAD.
+	ResourceNameRequest string `json:"resourceName,omitempty"`
 	// CNIArgs contains additional CNI arguments for the network interface
 	CNIArgs *map[string]interface{} `json:"cni-args"`
 	// GatewayRequest contains default route IP address for the pod


### PR DESCRIPTION
The resource pool a network attachment should use is normally selected with the `k8s.v1.cni.cncf.io/resourceName` annotation on the NetworkAttachmentDefinition.
The same selection can instead be set per attachment in the network selection element by adding `"resourceName": "<resource>"`. This lets attachments backed by different resource pools reference the same NetworkAttachmentDefinition, without creating a separate NetworkAttachmentDefinition per resource pool.
NAD still should set alowed resourceNames, which is similar to
creating multiple NADs with different resourceNames.

Fixes #1515 

I am not sure if I should also update https://github.com/k8snetworkplumbingwg/network-attachment-definition-client and in which order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a resource pool per network entry in pod network annotations.
  * Added support for restricting selectable resource pools with an allowlist.
  * Documented per-network resource selection, allowlists, and pod launch examples.

* **Bug Fixes**
  * Resource selection conflicts now return an error and warning event.
  * Requests for pools outside the configured allowlist are rejected with a warning event.
  * Existing behavior is preserved when requested and configured resource values match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->