### PR TITLE
Followup PR for k8snetworkplumbingwg/multus-cni#1512 to validate command file paths after Kubernetes bump

### DIFF
--- a/cmd/kubeconfig_generator/main.go
+++ b/cmd/kubeconfig_generator/main.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"text/template"
 	"time"
 
 	"github.com/spf13/pflag"
 
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/cmdutils"
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/k8sclient"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -63,16 +63,17 @@ func main() {
 	certDurationString := pflag.StringP("cert-duration", "", "10m", "specify certificate duration")
 	helpFlag := pflag.BoolP("help", "h", false, "show help message and quit")
 
-	kubeconfigPath, err := filepath.Abs(*kubeconfigPathRaw)
-	if err != nil {
-		klog.Fatalf("illegal path %s in kubeconfigPath %s: %v", kubeconfigPath, *kubeconfigPathRaw, err)
-	}
-
 	pflag.Parse()
 	if *helpFlag {
 		pflag.PrintDefaults()
 		os.Exit(1)
 	}
+
+	kubeconfigPath, err := cmdutils.NewRootedFile(*kubeconfigPathRaw)
+	if err != nil {
+		klog.Fatalf("illegal path in kubeconfigPath %s: %v", *kubeconfigPathRaw, err)
+	}
+	defer kubeconfigPath.Close()
 
 	// check variables
 	if _, err := os.Stat(*bootstrapConfig); err != nil {
@@ -108,9 +109,9 @@ func main() {
 		klog.Fatalf("failed to start cert manager: %v", err)
 	}
 
-	fp, err := os.OpenFile(kubeconfigPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	fp, err := kubeconfigPath.Root.OpenFile(kubeconfigPath.FileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		klog.Fatalf("cannot create kubeconfig file %q: %v", kubeconfigPath, err)
+		klog.Fatalf("cannot create kubeconfig file %q: %v", kubeconfigPath.Path(), err)
 	}
 
 	// render kubeconfig
@@ -131,15 +132,15 @@ func main() {
 		klog.Fatalf("cannot save kubeconfig: %v", err)
 	}
 
-	klog.Infof("kubeconfig %q is saved", kubeconfigPath)
+	klog.Infof("kubeconfig %q is saved", kubeconfigPath.Path())
 
 	// wait for signal
 	sigterm := make(chan os.Signal, 1)
 	signal.Notify(sigterm, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
 	<-sigterm
-	klog.Infof("signal received. remove kubeconfig %q and quit.", kubeconfigPath)
-	err = os.Remove(kubeconfigPath)
+	klog.Infof("signal received. remove kubeconfig %q and quit.", kubeconfigPath.Path())
+	err = kubeconfigPath.Root.Remove(kubeconfigPath.FileName)
 	if err != nil {
-		klog.Errorf("failed to remove kubeconfig %q: %v", kubeconfigPath, err)
+		klog.Errorf("failed to remove kubeconfig %q: %v", kubeconfigPath.Path(), err)
 	}
 }

--- a/cmd/kubeconfig_generator/main.go
+++ b/cmd/kubeconfig_generator/main.go
@@ -153,6 +153,9 @@ func writeKubeconfig(kubeconfigPath *cmdutils.RootedFile, templateData map[strin
 			err = fmt.Errorf("cannot save kubeconfig file %q: %w", kubeconfigPath.Path(), closeErr)
 		}
 	}()
+	if err = fp.Chmod(0600); err != nil {
+		return fmt.Errorf("cannot set kubeconfig file mode %q: %w", kubeconfigPath.Path(), err)
+	}
 
 	templateKubeconfig, err := template.New("kubeconfig").Parse(kubeConfigTemplate)
 	if err != nil {

--- a/cmd/kubeconfig_generator/main.go
+++ b/cmd/kubeconfig_generator/main.go
@@ -75,16 +75,28 @@ func main() {
 	}
 	defer kubeconfigPath.Close()
 
-	// check variables
-	if _, err := os.Stat(*bootstrapConfig); err != nil {
-		klog.Fatalf("failed to read bootstrap config %q", *bootstrapConfig)
-	}
-	st, err := os.Stat(*certDir)
+	bootstrapConfigPath, err := cmdutils.NewRootedFile(*bootstrapConfig)
 	if err != nil {
-		klog.Fatalf("failed to find cert directory %q", *certDir)
+		klog.Fatalf("illegal path in bootstrap-config %s: %v", *bootstrapConfig, err)
+	}
+	defer bootstrapConfigPath.Close()
+
+	certDirPath, err := cmdutils.NewRootedDir(*certDir)
+	if err != nil {
+		klog.Fatalf("illegal path in certdir %s: %v", *certDir, err)
+	}
+	defer certDirPath.Close()
+
+	// check variables
+	if _, err := bootstrapConfigPath.Root.Stat(bootstrapConfigPath.FileName); err != nil {
+		klog.Fatalf("failed to read bootstrap config %q", bootstrapConfigPath.Path())
+	}
+	st, err := certDirPath.Root.Stat(".")
+	if err != nil {
+		klog.Fatalf("failed to find cert directory %q", certDirPath.Path())
 	}
 	if !st.IsDir() {
-		klog.Fatalf("cert directory %q is not directory", *certDir)
+		klog.Fatalf("cert directory %q is not directory", certDirPath.Path())
 	}
 	certDuration, err := time.ParseDuration(*certDurationString)
 	if err != nil {
@@ -97,7 +109,7 @@ func main() {
 	}
 
 	// retrieve API server from bootstrapConfig()
-	config, err := clientcmd.BuildConfigFromFlags("", *bootstrapConfig)
+	config, err := clientcmd.BuildConfigFromFlags("", bootstrapConfigPath.Path())
 	if err != nil {
 		klog.Fatalf("cannot get in-cluster config: %v", err)
 	}
@@ -105,7 +117,7 @@ func main() {
 	caData := base64.StdEncoding.EncodeToString(config.CAData)
 
 	// run certManager to create certification
-	if _, err = k8sclient.PerNodeK8sClient(nodeName, *bootstrapConfig, certDuration, *certDir); err != nil {
+	if _, err = k8sclient.PerNodeK8sClient(nodeName, bootstrapConfigPath.Path(), certDuration, certDirPath.Path()); err != nil {
 		klog.Fatalf("failed to start cert manager: %v", err)
 	}
 
@@ -121,7 +133,7 @@ func main() {
 	}
 	templateData := map[string]string{
 		"CADATA":        caData,
-		"CERTDIR":       *certDir,
+		"CERTDIR":       certDirPath.Path(),
 		"K8S_APISERVER": apiServer,
 	}
 	// genearate kubeconfig from template

--- a/cmd/kubeconfig_generator/main.go
+++ b/cmd/kubeconfig_generator/main.go
@@ -121,27 +121,13 @@ func main() {
 		klog.Fatalf("failed to start cert manager: %v", err)
 	}
 
-	fp, err := kubeconfigPath.Root.OpenFile(kubeconfigPath.FileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		klog.Fatalf("cannot create kubeconfig file %q: %v", kubeconfigPath.Path(), err)
-	}
-
-	// render kubeconfig
-	templateKubeconfig, err := template.New("kubeconfig").Parse(kubeConfigTemplate)
-	if err != nil {
-		klog.Fatalf("template parse error: %v", err)
-	}
 	templateData := map[string]string{
 		"CADATA":        caData,
 		"CERTDIR":       certDirPath.Path(),
 		"K8S_APISERVER": apiServer,
 	}
-	// genearate kubeconfig from template
-	if err = templateKubeconfig.Execute(fp, templateData); err != nil {
-		klog.Fatalf("cannot create kubeconfig: %v", err)
-	}
-	if err = fp.Close(); err != nil {
-		klog.Fatalf("cannot save kubeconfig: %v", err)
+	if err = writeKubeconfig(kubeconfigPath, templateData); err != nil {
+		klog.Fatalf("%v", err)
 	}
 
 	klog.Infof("kubeconfig %q is saved", kubeconfigPath.Path())
@@ -155,4 +141,26 @@ func main() {
 	if err != nil {
 		klog.Errorf("failed to remove kubeconfig %q: %v", kubeconfigPath.Path(), err)
 	}
+}
+
+func writeKubeconfig(kubeconfigPath *cmdutils.RootedFile, templateData map[string]string) (err error) {
+	fp, err := kubeconfigPath.Root.OpenFile(kubeconfigPath.FileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("cannot create kubeconfig file %q: %w", kubeconfigPath.Path(), err)
+	}
+	defer func() {
+		if closeErr := fp.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("cannot save kubeconfig file %q: %w", kubeconfigPath.Path(), closeErr)
+		}
+	}()
+
+	templateKubeconfig, err := template.New("kubeconfig").Parse(kubeConfigTemplate)
+	if err != nil {
+		return fmt.Errorf("template parse error: %w", err)
+	}
+	if err = templateKubeconfig.Execute(fp, templateData); err != nil {
+		return fmt.Errorf("cannot create kubeconfig: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/kubeconfig_generator/main.go
+++ b/cmd/kubeconfig_generator/main.go
@@ -136,7 +136,7 @@ func main() {
 
 	// wait for signal
 	sigterm := make(chan os.Signal, 1)
-	signal.Notify(sigterm, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
+	signal.Notify(sigterm, syscall.SIGINT, syscall.SIGTERM)
 	<-sigterm
 	klog.Infof("signal received. remove kubeconfig %q and quit.", kubeconfigPath.Path())
 	err = kubeconfigPath.Root.Remove(kubeconfigPath.FileName)

--- a/cmd/kubeconfig_generator/main_test.go
+++ b/cmd/kubeconfig_generator/main_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/cmdutils"
+)
+
+func TestWriteKubeconfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	kubeconfigFile := filepath.Join(tmpDir, "kubeconfig")
+
+	kubeconfigPath, err := cmdutils.NewRootedFile(kubeconfigFile)
+	if err != nil {
+		t.Fatalf("failed to create rooted kubeconfig path: %v", err)
+	}
+	defer kubeconfigPath.Close()
+
+	templateData := map[string]string{
+		"CADATA":        "test-ca",
+		"CERTDIR":       tmpDir,
+		"K8S_APISERVER": "https://api.example.test",
+	}
+	if err := writeKubeconfig(kubeconfigPath, templateData); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+
+	contents, err := kubeconfigPath.Root.ReadFile(kubeconfigPath.FileName)
+	if err != nil {
+		t.Fatalf("failed to read kubeconfig: %v", err)
+	}
+	for _, expected := range []string{
+		"certificate-authority-data: test-ca",
+		"server: https://api.example.test",
+		"client-certificate: " + tmpDir + "/multus-client-current.pem",
+		"client-key: " + tmpDir + "/multus-client-current.pem",
+	} {
+		if !strings.Contains(string(contents), expected) {
+			t.Fatalf("expected generated kubeconfig to contain %q, got:\n%s", expected, string(contents))
+		}
+	}
+
+	stat, err := kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
+	if err != nil {
+		t.Fatalf("failed to stat kubeconfig: %v", err)
+	}
+	if stat.Mode().Perm() != 0600 {
+		t.Fatalf("expected kubeconfig mode 0600, got %v", stat.Mode().Perm())
+	}
+}

--- a/cmd/kubeconfig_generator/main_test.go
+++ b/cmd/kubeconfig_generator/main_test.go
@@ -33,6 +33,27 @@ func TestKubeconfigGenerator(t *testing.T) {
 }
 
 var _ = Describe("kubeconfig generator", func() {
+	It("writes a new kubeconfig with private file mode", func() {
+		tmpDir, err := os.MkdirTemp("", "multus_kubeconfig_generator_tmp")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
+
+		kubeconfigPath, err := cmdutils.NewRootedFile(filepath.Join(tmpDir, "kubeconfig"))
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(kubeconfigPath.Close()).To(Succeed())
+		})
+
+		Expect(writeKubeconfig(kubeconfigPath, templateData(tmpDir))).To(Succeed())
+
+		expectKubeconfigContents(kubeconfigPath, tmpDir)
+		stat, err := kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stat.Mode().Perm()).To(Equal(os.FileMode(0600)))
+	})
+
 	It("writes kubeconfig and resets an existing permissive file mode", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_kubeconfig_generator_tmp")
 		Expect(err).NotTo(HaveOccurred())
@@ -51,29 +72,35 @@ var _ = Describe("kubeconfig generator", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(stat.Mode().Perm()).To(Equal(os.FileMode(0644)))
 
-		templateData := map[string]string{
-			"CADATA":        "test-ca",
-			"CERTDIR":       tmpDir,
-			"K8S_APISERVER": "https://api.example.test",
-		}
-		Expect(writeKubeconfig(kubeconfigPath, templateData)).To(Succeed())
+		Expect(writeKubeconfig(kubeconfigPath, templateData(tmpDir))).To(Succeed())
 
-		contents, err := kubeconfigPath.Root.ReadFile(kubeconfigPath.FileName)
-		Expect(err).NotTo(HaveOccurred())
-		for _, expected := range []string{
-			"certificate-authority-data: test-ca",
-			"server: https://api.example.test",
-			"client-certificate: " + tmpDir + "/multus-client-current.pem",
-			"client-key: " + tmpDir + "/multus-client-current.pem",
-		} {
-			Expect(string(contents)).To(ContainSubstring(expected))
-		}
-
+		expectKubeconfigContents(kubeconfigPath, tmpDir)
 		stat, err = kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(stat.Mode().Perm()).To(Equal(os.FileMode(0600)))
 	})
 })
+
+func templateData(certDir string) map[string]string {
+	return map[string]string{
+		"CADATA":        "test-ca",
+		"CERTDIR":       certDir,
+		"K8S_APISERVER": "https://api.example.test",
+	}
+}
+
+func expectKubeconfigContents(kubeconfigPath *cmdutils.RootedFile, certDir string) {
+	contents, err := kubeconfigPath.Root.ReadFile(kubeconfigPath.FileName)
+	Expect(err).NotTo(HaveOccurred())
+	for _, expected := range []string{
+		"certificate-authority-data: test-ca",
+		"server: https://api.example.test",
+		"client-certificate: " + certDir + "/multus-client-current.pem",
+		"client-key: " + certDir + "/multus-client-current.pem",
+	} {
+		Expect(string(contents)).To(ContainSubstring(expected))
+	}
+}
 
 func createExistingKubeconfig(kubeconfigPath *cmdutils.RootedFile) {
 	existingFile, err := kubeconfigPath.Root.OpenFile(kubeconfigPath.FileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)

--- a/cmd/kubeconfig_generator/main_test.go
+++ b/cmd/kubeconfig_generator/main_test.go
@@ -14,79 +14,75 @@
 
 package main
 
+// disable dot-imports only for testing
+//revive:disable:dot-imports
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/cmdutils"
 )
 
-func TestWriteKubeconfig(t *testing.T) {
-	tmpDir := t.TempDir()
-	kubeconfigFile := filepath.Join(tmpDir, "kubeconfig")
+func TestKubeconfigGenerator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "kubeconfig_generator")
+}
 
-	kubeconfigPath, err := cmdutils.NewRootedFile(kubeconfigFile)
-	if err != nil {
-		t.Fatalf("failed to create rooted kubeconfig path: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := kubeconfigPath.Close(); err != nil {
-			t.Errorf("failed to close rooted kubeconfig path: %v", err)
+var _ = Describe("kubeconfig generator", func() {
+	It("writes kubeconfig and resets an existing permissive file mode", func() {
+		tmpDir, err := os.MkdirTemp("", "multus_kubeconfig_generator_tmp")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
+
+		kubeconfigPath, err := cmdutils.NewRootedFile(filepath.Join(tmpDir, "kubeconfig"))
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(kubeconfigPath.Close()).To(Succeed())
+		})
+
+		createExistingKubeconfig(kubeconfigPath)
+		stat, err := kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stat.Mode().Perm()).To(Equal(os.FileMode(0644)))
+
+		templateData := map[string]string{
+			"CADATA":        "test-ca",
+			"CERTDIR":       tmpDir,
+			"K8S_APISERVER": "https://api.example.test",
 		}
+		Expect(writeKubeconfig(kubeconfigPath, templateData)).To(Succeed())
+
+		contents, err := kubeconfigPath.Root.ReadFile(kubeconfigPath.FileName)
+		Expect(err).NotTo(HaveOccurred())
+		for _, expected := range []string{
+			"certificate-authority-data: test-ca",
+			"server: https://api.example.test",
+			"client-certificate: " + tmpDir + "/multus-client-current.pem",
+			"client-key: " + tmpDir + "/multus-client-current.pem",
+		} {
+			Expect(string(contents)).To(ContainSubstring(expected))
+		}
+
+		stat, err = kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stat.Mode().Perm()).To(Equal(os.FileMode(0600)))
 	})
+})
 
+func createExistingKubeconfig(kubeconfigPath *cmdutils.RootedFile) {
 	existingFile, err := kubeconfigPath.Root.OpenFile(kubeconfigPath.FileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		t.Fatalf("failed to create existing kubeconfig: %v", err)
-	}
-	if _, err := existingFile.Write([]byte("existing")); err != nil {
-		t.Fatalf("failed to write existing kubeconfig: %v", err)
-	}
-	if err := existingFile.Chmod(0644); err != nil {
-		t.Fatalf("failed to set existing kubeconfig mode: %v", err)
-	}
-	if err := existingFile.Close(); err != nil {
-		t.Fatalf("failed to close existing kubeconfig: %v", err)
-	}
-	stat, err := kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
-	if err != nil {
-		t.Fatalf("failed to stat existing kubeconfig: %v", err)
-	}
-	if stat.Mode().Perm() != 0644 {
-		t.Fatalf("expected existing kubeconfig mode 0644, got %v", stat.Mode().Perm())
-	}
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		Expect(existingFile.Close()).To(Succeed())
+	}()
 
-	templateData := map[string]string{
-		"CADATA":        "test-ca",
-		"CERTDIR":       tmpDir,
-		"K8S_APISERVER": "https://api.example.test",
-	}
-	if err := writeKubeconfig(kubeconfigPath, templateData); err != nil {
-		t.Fatalf("failed to write kubeconfig: %v", err)
-	}
-
-	contents, err := kubeconfigPath.Root.ReadFile(kubeconfigPath.FileName)
-	if err != nil {
-		t.Fatalf("failed to read kubeconfig: %v", err)
-	}
-	for _, expected := range []string{
-		"certificate-authority-data: test-ca",
-		"server: https://api.example.test",
-		"client-certificate: " + tmpDir + "/multus-client-current.pem",
-		"client-key: " + tmpDir + "/multus-client-current.pem",
-	} {
-		if !strings.Contains(string(contents), expected) {
-			t.Fatalf("expected generated kubeconfig to contain %q, got:\n%s", expected, string(contents))
-		}
-	}
-
-	stat, err = kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
-	if err != nil {
-		t.Fatalf("failed to stat kubeconfig: %v", err)
-	}
-	if stat.Mode().Perm() != 0600 {
-		t.Fatalf("expected kubeconfig mode 0600, got %v", stat.Mode().Perm())
-	}
+	_, err = existingFile.Write([]byte("existing"))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(existingFile.Chmod(0644)).To(Succeed())
 }

--- a/cmd/kubeconfig_generator/main_test.go
+++ b/cmd/kubeconfig_generator/main_test.go
@@ -14,70 +14,68 @@
 
 package main
 
-// disable dot-imports only for testing
-//revive:disable:dot-imports
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/cmdutils"
 )
 
 func TestKubeconfigGenerator(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "kubeconfig_generator")
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "kubeconfig_generator")
 }
 
-var _ = Describe("kubeconfig generator", func() {
-	It("writes a new kubeconfig with private file mode", func() {
+var _ = ginkgo.Describe("kubeconfig generator", func() {
+	ginkgo.It("writes a new kubeconfig with private file mode", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_kubeconfig_generator_tmp")
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(func() {
-			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(os.RemoveAll(tmpDir)).To(gomega.Succeed())
 		})
 
 		kubeconfigPath, err := cmdutils.NewRootedFile(filepath.Join(tmpDir, "kubeconfig"))
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(func() {
-			Expect(kubeconfigPath.Close()).To(Succeed())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(kubeconfigPath.Close()).To(gomega.Succeed())
 		})
 
-		Expect(writeKubeconfig(kubeconfigPath, templateData(tmpDir))).To(Succeed())
+		gomega.Expect(writeKubeconfig(kubeconfigPath, templateData(tmpDir))).To(gomega.Succeed())
 
 		expectKubeconfigContents(kubeconfigPath, tmpDir)
 		stat, err := kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(stat.Mode().Perm()).To(Equal(os.FileMode(0600)))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(stat.Mode().Perm()).To(gomega.Equal(os.FileMode(0600)))
 	})
 
-	It("writes kubeconfig and resets an existing permissive file mode", func() {
+	ginkgo.It("writes kubeconfig and resets an existing permissive file mode", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_kubeconfig_generator_tmp")
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(func() {
-			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(os.RemoveAll(tmpDir)).To(gomega.Succeed())
 		})
 
 		kubeconfigPath, err := cmdutils.NewRootedFile(filepath.Join(tmpDir, "kubeconfig"))
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(func() {
-			Expect(kubeconfigPath.Close()).To(Succeed())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(kubeconfigPath.Close()).To(gomega.Succeed())
 		})
 
 		createExistingKubeconfig(kubeconfigPath)
 		stat, err := kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(stat.Mode().Perm()).To(Equal(os.FileMode(0644)))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(stat.Mode().Perm()).To(gomega.Equal(os.FileMode(0644)))
 
-		Expect(writeKubeconfig(kubeconfigPath, templateData(tmpDir))).To(Succeed())
+		gomega.Expect(writeKubeconfig(kubeconfigPath, templateData(tmpDir))).To(gomega.Succeed())
 
 		expectKubeconfigContents(kubeconfigPath, tmpDir)
 		stat, err = kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(stat.Mode().Perm()).To(Equal(os.FileMode(0600)))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(stat.Mode().Perm()).To(gomega.Equal(os.FileMode(0600)))
 	})
 })
 
@@ -91,25 +89,25 @@ func templateData(certDir string) map[string]string {
 
 func expectKubeconfigContents(kubeconfigPath *cmdutils.RootedFile, certDir string) {
 	contents, err := kubeconfigPath.Root.ReadFile(kubeconfigPath.FileName)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	for _, expected := range []string{
 		"certificate-authority-data: test-ca",
 		"server: https://api.example.test",
 		"client-certificate: " + certDir + "/multus-client-current.pem",
 		"client-key: " + certDir + "/multus-client-current.pem",
 	} {
-		Expect(string(contents)).To(ContainSubstring(expected))
+		gomega.Expect(string(contents)).To(gomega.ContainSubstring(expected))
 	}
 }
 
 func createExistingKubeconfig(kubeconfigPath *cmdutils.RootedFile) {
 	existingFile, err := kubeconfigPath.Root.OpenFile(kubeconfigPath.FileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-	Expect(err).NotTo(HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	defer func() {
-		Expect(existingFile.Close()).To(Succeed())
+		gomega.Expect(existingFile.Close()).To(gomega.Succeed())
 	}()
 
 	_, err = existingFile.Write([]byte("existing"))
-	Expect(err).NotTo(HaveOccurred())
-	Expect(existingFile.Chmod(0644)).To(Succeed())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(existingFile.Chmod(0644)).To(gomega.Succeed())
 }

--- a/cmd/kubeconfig_generator/main_test.go
+++ b/cmd/kubeconfig_generator/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -30,7 +31,32 @@ func TestWriteKubeconfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create rooted kubeconfig path: %v", err)
 	}
-	defer kubeconfigPath.Close()
+	t.Cleanup(func() {
+		if err := kubeconfigPath.Close(); err != nil {
+			t.Errorf("failed to close rooted kubeconfig path: %v", err)
+		}
+	})
+
+	existingFile, err := kubeconfigPath.Root.OpenFile(kubeconfigPath.FileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		t.Fatalf("failed to create existing kubeconfig: %v", err)
+	}
+	if _, err := existingFile.Write([]byte("existing")); err != nil {
+		t.Fatalf("failed to write existing kubeconfig: %v", err)
+	}
+	if err := existingFile.Chmod(0644); err != nil {
+		t.Fatalf("failed to set existing kubeconfig mode: %v", err)
+	}
+	if err := existingFile.Close(); err != nil {
+		t.Fatalf("failed to close existing kubeconfig: %v", err)
+	}
+	stat, err := kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
+	if err != nil {
+		t.Fatalf("failed to stat existing kubeconfig: %v", err)
+	}
+	if stat.Mode().Perm() != 0644 {
+		t.Fatalf("expected existing kubeconfig mode 0644, got %v", stat.Mode().Perm())
+	}
 
 	templateData := map[string]string{
 		"CADATA":        "test-ca",
@@ -56,7 +82,7 @@ func TestWriteKubeconfig(t *testing.T) {
 		}
 	}
 
-	stat, err := kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
+	stat, err = kubeconfigPath.Root.Stat(kubeconfigPath.FileName)
 	if err != nil {
 		t.Fatalf("failed to stat kubeconfig: %v", err)
 	}

--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/signal"
 	"os/user"
-	"path/filepath"
 	"sync"
 	"syscall"
 	"time"
@@ -34,6 +33,7 @@ import (
 	"golang.org/x/net/netutil"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 
+	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/cmdutils"
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging"
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/multus"
 	srv "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/server"
@@ -209,34 +209,44 @@ func startMultusDaemon(ctx context.Context, daemonConfig *srv.ControllerNetConf,
 }
 
 func cniServerConfig(configFilePath string) (*srv.ControllerNetConf, error) {
-	path, err := filepath.Abs(configFilePath)
+	configPath, err := cmdutils.NewRootedFile(configFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("illegal path %s in server config path %s: %w", path, configFilePath, err)
+		return nil, fmt.Errorf("illegal path in server config path %s: %w", configFilePath, err)
 	}
+	defer configPath.Close()
 
-	configFileContents, err := os.ReadFile(path)
+	configFileContents, err := configPath.Root.ReadFile(configPath.FileName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read server config %s: %w", configPath.Path(), err)
 	}
 	return srv.LoadDaemonNetConf(configFileContents)
 }
 
 func copyUserProvidedConfig(multusConfigPath string, cniConfigDir string) error {
-	path, err := filepath.Abs(multusConfigPath)
+	srcPath, err := cmdutils.NewRootedFile(multusConfigPath)
 	if err != nil {
-		return fmt.Errorf("illegal path %s in multusConfigPath %s: %w", path, multusConfigPath, err)
+		return fmt.Errorf("illegal path in multusConfigPath %s: %w", multusConfigPath, err)
 	}
+	defer srcPath.Close()
 
-	srcFile, err := os.Open(path)
+	srcFile, err := srcPath.Root.Open(srcPath.FileName)
 	if err != nil {
-		return fmt.Errorf("failed to open (READ only) file %s: %w", path, err)
+		return fmt.Errorf("failed to open (READ only) file %s: %w", srcPath.Path(), err)
 	}
+	defer srcFile.Close()
 
-	dstFileName := cniConfigDir + "/" + filepath.Base(multusConfigPath)
-	dstFile, err := os.Create(dstFileName)
+	dstPath, err := cmdutils.NewRootedFileInDir(cniConfigDir, srcPath.FileName)
 	if err != nil {
-		return fmt.Errorf("creating copying file %s: %w", dstFileName, err)
+		return fmt.Errorf("illegal destination path in cniConfigDir %s: %w", cniConfigDir, err)
 	}
+	defer dstPath.Close()
+
+	dstFile, err := dstPath.Root.Create(dstPath.FileName)
+	if err != nil {
+		return fmt.Errorf("creating copying file %s: %w", dstPath.Path(), err)
+	}
+	defer dstFile.Close()
+
 	nBytes, err := io.Copy(dstFile, srcFile)
 	if err != nil {
 		return fmt.Errorf("error copying file: %w", err)

--- a/cmd/multus-daemon/main_test.go
+++ b/cmd/multus-daemon/main_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	srv "gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/server"
+)
+
+func TestCNIServerConfigReadsValidatedAbsolutePath(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "daemon-config.json")
+	configBytes := []byte(`{"logFile":"/etc/cni/net.d/multus.d/daemon-config.json","socketDir":"/run/multus/"}`)
+	if err := os.WriteFile(configPath, configBytes, 0600); err != nil {
+		t.Fatalf("failed to write test daemon config: %v", err)
+	}
+
+	config, err := cniServerConfig(configPath)
+	if err != nil {
+		t.Fatalf("expected daemon config to load: %v", err)
+	}
+	if config.SocketDir != "/run/multus/" {
+		t.Fatalf("expected socketDir to load, got %q", config.SocketDir)
+	}
+	if string(config.ConfigFileContents) != string(configBytes) {
+		t.Fatalf("expected config contents to be preserved")
+	}
+}
+
+func TestCNIServerConfigRejectsUnsafePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	unsafePaths := []string{
+		"",
+		"daemon-config.json",
+		tmpDir + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "daemon-config.json",
+	}
+
+	for _, unsafePath := range unsafePaths {
+		if _, err := cniServerConfig(unsafePath); err == nil {
+			t.Fatalf("expected cniServerConfig to reject %q", unsafePath)
+		}
+	}
+}
+
+func TestCopyUserProvidedConfigUsesValidatedRoots(t *testing.T) {
+	srcDir := t.TempDir()
+	destDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "multus.conf")
+	if err := os.WriteFile(srcPath, []byte("multus-config"), 0644); err != nil {
+		t.Fatalf("failed to write source config: %v", err)
+	}
+
+	if err := copyUserProvidedConfig(srcPath, destDir); err != nil {
+		t.Fatalf("expected copyUserProvidedConfig to copy config: %v", err)
+	}
+
+	copiedConfig, err := os.ReadFile(filepath.Join(destDir, "multus.conf"))
+	if err != nil {
+		t.Fatalf("failed to read copied config: %v", err)
+	}
+	if string(copiedConfig) != "multus-config" {
+		t.Fatalf("unexpected copied config: %q", copiedConfig)
+	}
+}
+
+func TestCopyUserProvidedConfigRejectsUnsafePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	validSrcPath := filepath.Join(tmpDir, "multus.conf")
+	if err := os.WriteFile(validSrcPath, []byte("multus-config"), 0644); err != nil {
+		t.Fatalf("failed to write source config: %v", err)
+	}
+
+	testCases := []struct {
+		name             string
+		multusConfigPath string
+		cniConfigDir     string
+	}{
+		{
+			name:             "empty source",
+			multusConfigPath: "",
+			cniConfigDir:     tmpDir,
+		},
+		{
+			name:             "relative source",
+			multusConfigPath: "multus.conf",
+			cniConfigDir:     tmpDir,
+		},
+		{
+			name:             "parent source",
+			multusConfigPath: tmpDir + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "multus.conf",
+			cniConfigDir:     tmpDir,
+		},
+		{
+			name:             "relative destination",
+			multusConfigPath: validSrcPath,
+			cniConfigDir:     "relative",
+		},
+		{
+			name:             "parent destination",
+			multusConfigPath: validSrcPath,
+			cniConfigDir:     tmpDir + string(os.PathSeparator) + "..",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := copyUserProvidedConfig(tc.multusConfigPath, tc.cniConfigDir); err == nil {
+				t.Fatalf("expected copyUserProvidedConfig to reject source %q and destination %q", tc.multusConfigPath, tc.cniConfigDir)
+			}
+		})
+	}
+}
+
+func TestCNIServerConfigUsesDefaultSocketDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "daemon-config.json")
+	configBytes := []byte(`{"logFile":"/etc/cni/net.d/multus.d/daemon-config.json"}`)
+	if err := os.WriteFile(configPath, configBytes, 0600); err != nil {
+		t.Fatalf("failed to write test daemon config: %v", err)
+	}
+
+	config, err := cniServerConfig(configPath)
+	if err != nil {
+		t.Fatalf("expected daemon config to load: %v", err)
+	}
+	if config.SocketDir != srv.DefaultMultusRunDir {
+		t.Fatalf("expected default socketDir %q, got %q", srv.DefaultMultusRunDir, config.SocketDir)
+	}
+}

--- a/pkg/cmdutils/utils.go
+++ b/pkg/cmdutils/utils.go
@@ -20,7 +20,112 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+// RootedFile is a validated file path split into an opened directory root and
+// a local file name for os.Root filesystem operations.
+type RootedFile struct {
+	Root     *os.Root
+	FileName string
+
+	path string
+}
+
+// NewRootedFile validates rawPath as an absolute file path and opens its parent
+// directory as a root.
+func NewRootedFile(rawPath string) (*RootedFile, error) {
+	path, err := cleanAbsolutePath(rawPath)
+	if err != nil {
+		return nil, err
+	}
+	fileName, err := cleanLocalFileName(filepath.Base(path))
+	if err != nil {
+		return nil, err
+	}
+	return openRootedFile(filepath.Dir(path), fileName)
+}
+
+// NewRootedFileInDir validates rootDir and fileName separately before opening
+// rootDir as a root.
+func NewRootedFileInDir(rootDir, fileName string) (*RootedFile, error) {
+	cleanRootDir, err := cleanAbsolutePath(rootDir)
+	if err != nil {
+		return nil, err
+	}
+	cleanFileName, err := cleanLocalFileName(fileName)
+	if err != nil {
+		return nil, err
+	}
+	return openRootedFile(cleanRootDir, cleanFileName)
+}
+
+// Path returns the cleaned absolute path for logging and error messages.
+func (r *RootedFile) Path() string {
+	return r.path
+}
+
+// Close closes the opened root directory.
+func (r *RootedFile) Close() error {
+	if r == nil || r.Root == nil {
+		return nil
+	}
+	return r.Root.Close()
+}
+
+func openRootedFile(rootDir, fileName string) (*RootedFile, error) {
+	root, err := os.OpenRoot(rootDir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open root directory %q: %w", rootDir, err)
+	}
+	return &RootedFile{
+		Root:     root,
+		FileName: fileName,
+		path:     filepath.Join(rootDir, fileName),
+	}, nil
+}
+
+func cleanAbsolutePath(rawPath string) (string, error) {
+	if rawPath == "" {
+		return "", fmt.Errorf("path must not be empty")
+	}
+	if hasParentDirComponent(rawPath) {
+		return "", fmt.Errorf("path %q must not contain parent directory references", rawPath)
+	}
+	cleanPath := filepath.Clean(rawPath)
+	if !filepath.IsAbs(cleanPath) {
+		return "", fmt.Errorf("path %q must be absolute", rawPath)
+	}
+	return cleanPath, nil
+}
+
+func cleanLocalFileName(fileName string) (string, error) {
+	if fileName == "" {
+		return "", fmt.Errorf("file name must not be empty")
+	}
+	if hasParentDirComponent(fileName) {
+		return "", fmt.Errorf("file name %q must not contain parent directory references", fileName)
+	}
+	cleanFileName := filepath.Clean(fileName)
+	if cleanFileName == "." ||
+		cleanFileName == string(os.PathSeparator) ||
+		filepath.IsAbs(cleanFileName) ||
+		cleanFileName != filepath.Base(cleanFileName) {
+		return "", fmt.Errorf("file name %q must be local", fileName)
+	}
+	return cleanFileName, nil
+}
+
+func hasParentDirComponent(path string) bool {
+	for _, component := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if component == ".." {
+			return true
+		}
+	}
+	return false
+}
 
 // CopyFileAtomic does file copy atomically
 func CopyFileAtomic(srcFilePath, destDir, tempFileName, destFileName string) error {

--- a/pkg/cmdutils/utils.go
+++ b/pkg/cmdutils/utils.go
@@ -32,6 +32,14 @@ type RootedFile struct {
 	path string
 }
 
+// RootedDir is a validated directory path opened as a root for os.Root
+// filesystem operations.
+type RootedDir struct {
+	Root *os.Root
+
+	path string
+}
+
 // NewRootedFile validates rawPath as an absolute file path and opens its parent
 // directory as a root.
 func NewRootedFile(rawPath string) (*RootedFile, error) {
@@ -60,6 +68,23 @@ func NewRootedFileInDir(rootDir, fileName string) (*RootedFile, error) {
 	return openRootedFile(cleanRootDir, cleanFileName)
 }
 
+// NewRootedDir validates rawPath as an absolute directory path and opens it as
+// a root.
+func NewRootedDir(rawPath string) (*RootedDir, error) {
+	path, err := cleanAbsolutePath(rawPath)
+	if err != nil {
+		return nil, err
+	}
+	root, err := os.OpenRoot(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open root directory %q: %w", path, err)
+	}
+	return &RootedDir{
+		Root: root,
+		path: path,
+	}, nil
+}
+
 // Path returns the cleaned absolute path for logging and error messages.
 func (r *RootedFile) Path() string {
 	return r.path
@@ -67,6 +92,20 @@ func (r *RootedFile) Path() string {
 
 // Close closes the opened root directory.
 func (r *RootedFile) Close() error {
+	if r == nil || r.Root == nil {
+		return nil
+	}
+	return r.Root.Close()
+}
+
+// Path returns the cleaned absolute directory path for logging and APIs that
+// require a path string.
+func (r *RootedDir) Path() string {
+	return r.path
+}
+
+// Close closes the opened root directory.
+func (r *RootedDir) Close() error {
 	if r == nil || r.Root == nil {
 		return nil
 	}

--- a/pkg/cmdutils/utils_test.go
+++ b/pkg/cmdutils/utils_test.go
@@ -20,6 +20,7 @@ package cmdutils
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -68,5 +69,92 @@ var _ = Describe("thin entrypoint testing", func() {
 
 		err = os.RemoveAll(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("opens cleaned absolute file paths as an os.Root and local file name", func() {
+		tmpDir, err := os.MkdirTemp("", "multus_rooted_file_tmp")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		rawPath := tmpDir + string(os.PathSeparator) + "." + string(os.PathSeparator) + "sample"
+		rootedFile, err := NewRootedFile(rawPath)
+		Expect(err).NotTo(HaveOccurred())
+		defer rootedFile.Close()
+
+		Expect(rootedFile.FileName).To(Equal("sample"))
+		Expect(rootedFile.Path()).To(Equal(filepath.Join(tmpDir, "sample")))
+
+		file, err := rootedFile.Root.OpenFile(rootedFile.FileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = file.Write([]byte("rooted"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(file.Close()).To(Succeed())
+
+		contents, err := os.ReadFile(filepath.Join(tmpDir, "sample"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(Equal([]byte("rooted")))
+	})
+
+	It("rejects unsafe rooted file paths", func() {
+		tmpDir, err := os.MkdirTemp("", "multus_rooted_file_reject_tmp")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		unsafePaths := []string{
+			"",
+			"relative.conf",
+			tmpDir + string(os.PathSeparator) + ".." + string(os.PathSeparator) + "config",
+		}
+		for _, unsafePath := range unsafePaths {
+			_, err := NewRootedFile(unsafePath)
+			Expect(err).To(HaveOccurred())
+		}
+	})
+
+	It("opens cleaned absolute directories with local file names", func() {
+		tmpDir, err := os.MkdirTemp("", "multus_rooted_dir_tmp")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		rootedFile, err := NewRootedFileInDir(tmpDir+string(os.PathSeparator)+".", "dest")
+		Expect(err).NotTo(HaveOccurred())
+		defer rootedFile.Close()
+
+		Expect(rootedFile.FileName).To(Equal("dest"))
+		Expect(rootedFile.Path()).To(Equal(filepath.Join(tmpDir, "dest")))
+
+		file, err := rootedFile.Root.Create(rootedFile.FileName)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = file.Write([]byte("dest"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(file.Close()).To(Succeed())
+
+		contents, err := os.ReadFile(filepath.Join(tmpDir, "dest"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(Equal([]byte("dest")))
+	})
+
+	It("rejects unsafe rooted directory and file name combinations", func() {
+		tmpDir, err := os.MkdirTemp("", "multus_rooted_dir_reject_tmp")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		_, err = NewRootedFileInDir("", "dest")
+		Expect(err).To(HaveOccurred())
+
+		_, err = NewRootedFileInDir("relative", "dest")
+		Expect(err).To(HaveOccurred())
+
+		_, err = NewRootedFileInDir(tmpDir+string(os.PathSeparator)+"..", "dest")
+		Expect(err).To(HaveOccurred())
+
+		_, err = NewRootedFileInDir(tmpDir, "../dest")
+		Expect(err).To(HaveOccurred())
+
+		_, err = NewRootedFileInDir(tmpDir, filepath.Join("nested", "dest"))
+		Expect(err).To(HaveOccurred())
+
+		_, err = NewRootedFileInDir(tmpDir, filepath.Join(tmpDir, "dest"))
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/cmdutils/utils_test.go
+++ b/pkg/cmdutils/utils_test.go
@@ -134,6 +134,32 @@ var _ = Describe("thin entrypoint testing", func() {
 		Expect(contents).To(Equal([]byte("dest")))
 	})
 
+	It("opens cleaned absolute directories as an os.Root", func() {
+		tmpDir, err := os.MkdirTemp("", "multus_rooted_dir_root_tmp")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		rootedDir, err := NewRootedDir(tmpDir + string(os.PathSeparator) + ".")
+		Expect(err).NotTo(HaveOccurred())
+		defer rootedDir.Close()
+
+		Expect(rootedDir.Path()).To(Equal(tmpDir))
+
+		stat, err := rootedDir.Root.Stat(".")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stat.IsDir()).To(BeTrue())
+
+		file, err := rootedDir.Root.Create("sample")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = file.Write([]byte("root"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(file.Close()).To(Succeed())
+
+		contents, err := os.ReadFile(filepath.Join(tmpDir, "sample"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(Equal([]byte("root")))
+	})
+
 	It("rejects unsafe rooted directory and file name combinations", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_rooted_dir_reject_tmp")
 		Expect(err).NotTo(HaveOccurred())
@@ -156,5 +182,21 @@ var _ = Describe("thin entrypoint testing", func() {
 
 		_, err = NewRootedFileInDir(tmpDir, filepath.Join(tmpDir, "dest"))
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("rejects unsafe rooted directories", func() {
+		tmpDir, err := os.MkdirTemp("", "multus_rooted_dir_only_reject_tmp")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		unsafeDirs := []string{
+			"",
+			"relative",
+			tmpDir + string(os.PathSeparator) + "..",
+		}
+		for _, unsafeDir := range unsafeDirs {
+			_, err := NewRootedDir(unsafeDir)
+			Expect(err).To(HaveOccurred())
+		}
 	})
 })

--- a/pkg/cmdutils/utils_test.go
+++ b/pkg/cmdutils/utils_test.go
@@ -74,12 +74,16 @@ var _ = Describe("thin entrypoint testing", func() {
 	It("opens cleaned absolute file paths as an os.Root and local file name", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_rooted_file_tmp")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.RemoveAll(tmpDir)
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
 
 		rawPath := tmpDir + string(os.PathSeparator) + "." + string(os.PathSeparator) + "sample"
 		rootedFile, err := NewRootedFile(rawPath)
 		Expect(err).NotTo(HaveOccurred())
-		defer rootedFile.Close()
+		DeferCleanup(func() {
+			Expect(rootedFile.Close()).To(Succeed())
+		})
 
 		Expect(rootedFile.FileName).To(Equal("sample"))
 		Expect(rootedFile.Path()).To(Equal(filepath.Join(tmpDir, "sample")))
@@ -98,7 +102,9 @@ var _ = Describe("thin entrypoint testing", func() {
 	It("rejects unsafe rooted file paths", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_rooted_file_reject_tmp")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.RemoveAll(tmpDir)
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
 
 		unsafePaths := []string{
 			"",
@@ -114,11 +120,15 @@ var _ = Describe("thin entrypoint testing", func() {
 	It("opens cleaned absolute directories with local file names", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_rooted_dir_tmp")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.RemoveAll(tmpDir)
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
 
 		rootedFile, err := NewRootedFileInDir(tmpDir+string(os.PathSeparator)+".", "dest")
 		Expect(err).NotTo(HaveOccurred())
-		defer rootedFile.Close()
+		DeferCleanup(func() {
+			Expect(rootedFile.Close()).To(Succeed())
+		})
 
 		Expect(rootedFile.FileName).To(Equal("dest"))
 		Expect(rootedFile.Path()).To(Equal(filepath.Join(tmpDir, "dest")))
@@ -137,11 +147,15 @@ var _ = Describe("thin entrypoint testing", func() {
 	It("opens cleaned absolute directories as an os.Root", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_rooted_dir_root_tmp")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.RemoveAll(tmpDir)
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
 
 		rootedDir, err := NewRootedDir(tmpDir + string(os.PathSeparator) + ".")
 		Expect(err).NotTo(HaveOccurred())
-		defer rootedDir.Close()
+		DeferCleanup(func() {
+			Expect(rootedDir.Close()).To(Succeed())
+		})
 
 		Expect(rootedDir.Path()).To(Equal(tmpDir))
 
@@ -163,7 +177,9 @@ var _ = Describe("thin entrypoint testing", func() {
 	It("rejects unsafe rooted directory and file name combinations", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_rooted_dir_reject_tmp")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.RemoveAll(tmpDir)
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
 
 		_, err = NewRootedFileInDir("", "dest")
 		Expect(err).To(HaveOccurred())
@@ -187,7 +203,9 @@ var _ = Describe("thin entrypoint testing", func() {
 	It("rejects unsafe rooted directories", func() {
 		tmpDir, err := os.MkdirTemp("", "multus_rooted_dir_only_reject_tmp")
 		Expect(err).NotTo(HaveOccurred())
-		defer os.RemoveAll(tmpDir)
+		DeferCleanup(func() {
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		})
 
 		unsafeDirs := []string{
 			"",


### PR DESCRIPTION
This is a follow-up to k8snetworkplumbingwg/multus-cni/#1512 for issues found while carrying the Kubernetes and Go bump into downstream.

The dependency verifier reported vendor drift for vendor/k8s.io/api/scheduling/v1alpha2/generated.proto after go mod tidy and go mod vendor. Re-running those commands on this upstream branch produced no vendor diff, so no vendor file change is included.

The security scan reported path traversal findings in kubeconfig_generator and multus-daemon because CLI-controlled paths were passed directly to file operations. This change validates those paths, requires absolute paths, rejects empty, relative, and parent-directory paths, and uses os.Root with local file names for file reads, writes, creates, and removes.

Commands run:

go mod tidy

go mod vendor

go test ./pkg/cmdutils ./cmd/kubeconfig_generator

GOOS=linux go test -c -o /private/tmp/multus-daemon.test ./cmd/multus-daemon

podman run --rm -v /Users/misalunk/go/src/github.com/k8snetworkplumbingwg/multus-cni:/workspace:Z -w /workspace -e GOCACHE=/tmp/go-build-cache -e GOFLAGS=-mod=vendor registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 go test ./pkg/cmdutils ./cmd/kubeconfig_generator ./cmd/multus-daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security and Reliability**
  * Improved validation and safe handling of kubeconfig and CNI configuration paths.
  * Rejected unsafe, relative, empty, and path-traversal inputs.
  * Improved configuration file copying, resource cleanup, and shutdown handling.
* **Bug Fixes**
  * Added clearer error diagnostics when configuration files cannot be read or written.
  * Ensured generated kubeconfig files use secure file permissions.
* **Tests**
  * Added coverage for secure path handling, file copying, kubeconfig generation, file permissions, and default socket directory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->