### PR TITLE
Thick plugin graceful termination

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -66,11 +66,9 @@ func main() {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	sigTermCtx, sigTermCancel := context.WithCancel(ctx)
+	// Used by the server readiness handler to report not-ready once shutdown is initiated.
 	isInGracefulShutdownMode := func() bool {
-		if sigTermCtx.Err() == nil {
-			return false
-		}
-		return true
+		return sigTermCtx.Err() != nil
 	}
 
 	daemonConf, err := cniServerConfig(*configFilePath)
@@ -138,6 +136,7 @@ func main() {
 	go func() {
 		for sig := range signalCh {
 			logging.Verbosef("caught %v, stopping...", sig)
+			// Mark graceful-shutdown mode first so readiness probes fail before canceling server context.
 			sigTermCancel()
 			<-time.After(SigTermCancelAfter)
 			cancel()

--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -44,6 +44,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// SigtermCancelAfter sets the wait time to cancel after sig term
+// TODO: This could be a configuration option
+const SigTermCancelAfter = 10 * time.Second
+
 func main() {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
@@ -61,6 +65,13 @@ func main() {
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
+	sigTermCtx, sigTermCancel := context.WithCancel(ctx)
+	isInGracefulShutdownMode := func() bool {
+		if sigTermCtx.Err() == nil {
+			return false
+		}
+		return true
+	}
 
 	daemonConf, err := cniServerConfig(*configFilePath)
 	if err != nil {
@@ -109,7 +120,7 @@ func main() {
 		}
 	}
 
-	if err := startMultusDaemon(ctx, daemonConf, ignoreReadinessIndicator); err != nil {
+	if err := startMultusDaemon(ctx, daemonConf, ignoreReadinessIndicator, isInGracefulShutdownMode); err != nil {
 		logging.Panicf("failed start the multus thick-plugin listener: %v", err)
 		os.Exit(3)
 	}
@@ -127,6 +138,8 @@ func main() {
 	go func() {
 		for sig := range signalCh {
 			logging.Verbosef("caught %v, stopping...", sig)
+			sigTermCancel()
+			<-time.After(SigTermCancelAfter)
 			cancel()
 		}
 	}()
@@ -143,7 +156,7 @@ func main() {
 	logging.Verbosef("multus daemon is exited")
 }
 
-func startMultusDaemon(ctx context.Context, daemonConfig *srv.ControllerNetConf, ignoreReadinessIndicator bool) error {
+func startMultusDaemon(ctx context.Context, daemonConfig *srv.ControllerNetConf, ignoreReadinessIndicator bool, isInGracefulShutdownMode func() bool) error {
 	if user, err := user.Current(); err != nil || user.Uid != "0" {
 		return fmt.Errorf("failed to run multus-daemon with root: %v, now running in uid: %s", err, user.Uid)
 	}
@@ -152,7 +165,7 @@ func startMultusDaemon(ctx context.Context, daemonConfig *srv.ControllerNetConf,
 		return fmt.Errorf("failed to prepare the cni-socket for communicating with the shim: %w", err)
 	}
 
-	server, err := srv.NewCNIServer(daemonConfig, daemonConfig.ConfigFileContents, ignoreReadinessIndicator)
+	server, err := srv.NewCNIServer(daemonConfig, daemonConfig.ConfigFileContents, ignoreReadinessIndicator, isInGracefulShutdownMode)
 	if err != nil {
 		return fmt.Errorf("failed to create the server: %v", err)
 	}

--- a/deployments/multus-daemonset-crio.yml
+++ b/deployments/multus-daemonset-crio.yml
@@ -220,7 +220,7 @@ spec:
           mountPath: /host/usr/libexec/cni
         - name: multus-cfg
           mountPath: /tmp/multus-conf
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: run
           hostPath:

--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -229,7 +229,7 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
               mountPropagation: Bidirectional
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cni
           hostPath:

--- a/deployments/multus-daemonset.yml
+++ b/deployments/multus-daemonset.yml
@@ -232,7 +232,7 @@ spec:
             - name: cnibin
               mountPath: /host/opt/cni/bin
               mountPropagation: Bidirectional
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30
       volumes:
         - name: cni
           hostPath:

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -43,6 +43,9 @@ const (
 
 	// MultusHealthAPIEndpoint is an endpoint API clients can query to know if they can communicate w/ multus server
 	MultusHealthAPIEndpoint = "/healthz"
+
+	// MultusReadyAPIEndpoint is like health, but starts returning status 500 once a sig-term is received.
+	MultusReadyAPIEndpoint = "/readyz"
 )
 
 // DoCNI sends a CNI request to the CNI server via JSON + HTTP over a root-owned unix socket,
@@ -106,7 +109,7 @@ func CreateDelegateRequest(cniCommand, cniContainerID, cniNetNS, cniIFName, podN
 // WaitUntilAPIReady checks API readiness
 func WaitUntilAPIReady(socketPath string) error {
 	return utilwait.PollImmediate(APIReadyPollDuration, APIReadyPollTimeout, func() (bool, error) {
-		_, err := DoCNI(GetAPIEndpoint(MultusHealthAPIEndpoint), nil, SocketPath(socketPath))
+		_, err := DoCNI(GetAPIEndpoint(MultusReadyAPIEndpoint), nil, SocketPath(socketPath))
 		return err == nil, nil
 	})
 }

--- a/pkg/server/api/api_test.go
+++ b/pkg/server/api/api_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"net"
+	"net/http"
+	"testing"
+)
+
+func startTestUnixSocketServer(t *testing.T) (string, <-chan string) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	pathCh := make(chan string, 1)
+
+	listener, err := net.Listen("unix", SocketPath(tmpDir))
+	if err != nil {
+		t.Fatalf("failed to listen on unix socket: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			pathCh <- r.URL.Path
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+	t.Cleanup(func() {
+		_ = server.Close()
+	})
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	return tmpDir, pathCh
+}
+
+func TestWaitUntilAPIReadyUsesReadyzEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, pathCh := startTestUnixSocketServer(t)
+
+	if err := WaitUntilAPIReady(tmpDir); err != nil {
+		t.Fatalf("WaitUntilAPIReady returned error: %v", err)
+	}
+
+	gotPath := <-pathCh
+	if gotPath != MultusReadyAPIEndpoint {
+		t.Fatalf("expected readiness endpoint %q, got %q", MultusReadyAPIEndpoint, gotPath)
+	}
+}
+
+func TestCheckAPIReadyNowUsesHealthzEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tmpDir, pathCh := startTestUnixSocketServer(t)
+
+	if err := CheckAPIReadyNow(tmpDir); err != nil {
+		t.Fatalf("CheckAPIReadyNow returned error: %v", err)
+	}
+
+	gotPath := <-pathCh
+	if gotPath != MultusHealthAPIEndpoint {
+		t.Fatalf("expected health endpoint %q, got %q", MultusHealthAPIEndpoint, gotPath)
+	}
+}

--- a/pkg/server/api/api_test.go
+++ b/pkg/server/api/api_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"testing"
@@ -16,9 +17,6 @@ func startTestUnixSocketServer(t *testing.T) (string, <-chan string) {
 	if err != nil {
 		t.Fatalf("failed to listen on unix socket: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = listener.Close()
-	})
 
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -26,13 +24,32 @@ func startTestUnixSocketServer(t *testing.T) (string, <-chan string) {
 			w.WriteHeader(http.StatusOK)
 		}),
 	}
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- server.Serve(listener)
+	}()
+
 	t.Cleanup(func() {
-		_ = server.Close()
+		if err := server.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			t.Errorf("failed to close test server: %v", err)
+		}
+		serveErr := <-serveErrCh
+		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			t.Errorf("test server Serve() failed: %v", serveErr)
+		}
+		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+			t.Errorf("failed to close test listener: %v", err)
+		}
 	})
 
-	go func() {
-		_ = server.Serve(listener)
-	}()
+	select {
+	case serveErr := <-serveErrCh:
+		if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			t.Fatalf("test server Serve() failed during startup: %v", serveErr)
+		}
+	default:
+	}
 
 	return tmpDir, pathCh
 }

--- a/pkg/server/api/shim.go
+++ b/pkg/server/api/shim.go
@@ -67,6 +67,7 @@ func CmdCheck(args *skel.CmdArgs) error {
 
 // CmdDel implements the CNI spec DEL command handler
 func CmdDel(args *skel.CmdArgs) error {
+	// DEL uses healthz (not readyz) so cleanup can still proceed during graceful shutdown.
 	_, _, err := postRequest(args, CheckAPIReadyNow)
 	if err != nil {
 		// No error in DEL (as of CNI spec)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -360,11 +360,11 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 			}
 
 			if !isInGracefulShutdownMode() {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				w.Header().Set("Content-Type", "application/json")
 			} else {
-				w.WriteHeader(http.StatusInternalServerError)
 				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
 			}
 		})))
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -299,7 +299,7 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 	router.HandleFunc(api.MultusCNIAPIEndpoint, promhttp.InstrumentHandlerCounter(s.metrics.requestCounter.MustCurryWith(prometheus.Labels{"handler": api.MultusCNIAPIEndpoint}),
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
-				http.Error(w, fmt.Sprintf("Method not allowed"), http.StatusMethodNotAllowed)
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 				return
 			}
 
@@ -321,7 +321,7 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 	router.HandleFunc(api.MultusDelegateAPIEndpoint, promhttp.InstrumentHandlerCounter(s.metrics.requestCounter.MustCurryWith(prometheus.Labels{"handler": api.MultusDelegateAPIEndpoint}),
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
-				http.Error(w, fmt.Sprintf("Method not allowed"), http.StatusMethodNotAllowed)
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 				return
 			}
 
@@ -343,7 +343,7 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 	router.HandleFunc(api.MultusHealthAPIEndpoint, promhttp.InstrumentHandlerCounter(s.metrics.requestCounter.MustCurryWith(prometheus.Labels{"handler": api.MultusHealthAPIEndpoint}),
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodGet && r.Method != http.MethodPost {
-				http.Error(w, fmt.Sprintf("Method not allowed"), http.StatusMethodNotAllowed)
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 				return
 			}
 
@@ -352,10 +352,10 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 		})))
 
 	// handle for '/readyz'
-	router.HandleFunc(api.MultusReadyAPIEndpoint, promhttp.InstrumentHandlerCounter(s.metrics.requestCounter.MustCurryWith(prometheus.Labels{"handler": api.MultusHealthAPIEndpoint}),
+	router.HandleFunc(api.MultusReadyAPIEndpoint, promhttp.InstrumentHandlerCounter(s.metrics.requestCounter.MustCurryWith(prometheus.Labels{"handler": api.MultusReadyAPIEndpoint}),
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodGet && r.Method != http.MethodPost {
-				http.Error(w, fmt.Sprintf("Method not allowed"), http.StatusMethodNotAllowed)
+				http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 				return
 			}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -216,7 +216,7 @@ func isPerNodeCertEnabled(config *PerNodeCertificate) (bool, error) {
 }
 
 // NewCNIServer creates and returns a new Server object which will listen on a socket in the given path
-func NewCNIServer(daemonConfig *ControllerNetConf, serverConfig []byte, ignoreReadinessIndicator bool) (*Server, error) {
+func NewCNIServer(daemonConfig *ControllerNetConf, serverConfig []byte, ignoreReadinessIndicator bool, isInGracefulShutdownMode func() bool) (*Server, error) {
 	var kubeClient *k8s.ClientInfo
 	enabled, err := isPerNodeCertEnabled(daemonConfig.PerNodeCertificate)
 	if enabled {
@@ -258,10 +258,10 @@ func NewCNIServer(daemonConfig *ControllerNetConf, serverConfig []byte, ignoreRe
 		logging.Verbosef("server configured with chroot: %s", daemonConfig.ChrootDir)
 	}
 
-	return newCNIServer(daemonConfig.SocketDir, kubeClient, exec, serverConfig, ignoreReadinessIndicator)
+	return newCNIServer(daemonConfig.SocketDir, kubeClient, exec, serverConfig, ignoreReadinessIndicator, isInGracefulShutdownMode)
 }
 
-func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, servConfig []byte, ignoreReadinessIndicator bool) (*Server, error) {
+func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, servConfig []byte, ignoreReadinessIndicator bool, isInGracefulShutdownMode func() bool) (*Server, error) {
 	informerFactory, podInformer := newPodInformer(kubeClient.Client, os.Getenv("MULTUS_NODE_NAME"))
 	netdefInformerFactory, netdefInformer := newNetDefInformer(kubeClient.NetClient)
 	kubeClient.SetK8sClientInformers(podInformer, netdefInformer)
@@ -349,6 +349,23 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
+		})))
+
+	// handle for '/readyz'
+	router.HandleFunc(api.MultusReadyAPIEndpoint, promhttp.InstrumentHandlerCounter(s.metrics.requestCounter.MustCurryWith(prometheus.Labels{"handler": api.MultusHealthAPIEndpoint}),
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet && r.Method != http.MethodPost {
+				http.Error(w, fmt.Sprintf("Method not allowed"), http.StatusMethodNotAllowed)
+				return
+			}
+
+			if !isInGracefulShutdownMode() {
+				w.WriteHeader(http.StatusOK)
+				w.Header().Set("Content-Type", "application/json")
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Header().Set("Content-Type", "application/json")
+			}
 		})))
 
 	// this handle for the rest of above

--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -338,7 +338,7 @@ func createFakePod(k8sClient *k8s.ClientInfo, podName string) error {
 func startCNIServer(ctx context.Context, runDir string, k8sClient *k8s.ClientInfo, servConfig []byte) (*Server, error) {
 	const period = 0
 
-	cniServer, err := newCNIServer(runDir, k8sClient, &fakeExec{}, servConfig, true)
+	cniServer, err := newCNIServer(runDir, k8sClient, &fakeExec{}, servConfig, true, func() bool { return false })
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This revives the stale PR https://github.com/k8snetworkplumbingwg/multus-cni/pull/1338

This PR introduces graceful shutdown functionality to the Multus daemon by adding a /readyz endpoint alongside the existing /healthz. The /readyz endpoint starts returning 500 once a SIGTERM is received, indicating the daemon is in shutdown mode. During this time, CNI requests can still be processed for a short window. The daemonset configs have been updated to increase terminationGracePeriodSeconds from 10 to 30 seconds, ensuring we have a bit more time for these clean shutdowns.

This addresses a race condition during pod transitions where the readiness check might return true, but a subsequent CNI request could fail if the daemon shuts down too quickly. By introducing the /readyz endpoint and delaying the shutdown, we can handle ongoing CNI requests more gracefully, reducing the risk of disruptions during critical transitions.

Major thanks to @deads2k for the find, identification, fix, and of course, the explanations. Appreciate it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a readiness endpoint that reports when the service is entering graceful shutdown.
  * Readiness polling now uses the dedicated readiness check, while health checks remain available for ongoing operations.

* **Bug Fixes**
  * Improved graceful shutdown handling by allowing active operations time to complete.
  * Extended the pod termination grace period from 10 to 30 seconds for more reliable shutdowns.
  * Cleanup operations can continue while the service is gracefully shutting down.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->