### PR TITLE
entrypoint: add --force-config-watch flag

### DIFF
--- a/cmd/thin_entrypoint/main.go
+++ b/cmd/thin_entrypoint/main.go
@@ -55,6 +55,7 @@ type Options struct {
 	MultusLogFile            string
 	OverrideNetworkName      bool
 	CleanupConfigOnExit      bool
+	ForceConfigWatch         bool
 	RenameConfFile           bool
 	ReadinessIndicatorFile   string
 	AdditionalBinDir         string
@@ -89,6 +90,7 @@ func (o *Options) addFlags() {
 	fs.StringVar(&o.MultusLogFile, "multus-log-file", "", "multus log file")
 	fs.BoolVar(&o.OverrideNetworkName, "override-network-name", false, "override network name from master cni file (used only with --multus-conf-file=auto)")
 	fs.BoolVar(&o.CleanupConfigOnExit, "cleanup-config-on-exit", false, "cleanup config file on exit")
+	fs.BoolVar(&o.ForceConfigWatch, "force-config-watch", false, "watch for config changes even when --cleanup-config-on-exit is false (used only with --multus-conf-file=auto)")
 	fs.BoolVar(&o.SkipMultusConfWatch, "skip-config-watch", false, "dont watch for config (master cni and kubeconfig) changes (used only with --multus-conf-file=auto)")
 	fs.BoolVar(&o.RenameConfFile, "rename-conf-file", false, "rename master config file to invalidate (used only with --multus-conf-file=auto)")
 	fs.StringVar(&o.ReadinessIndicatorFile, "readiness-indicator-file", "", "readiness indicator file (used only with --multus-conf-file=auto)")
@@ -620,7 +622,7 @@ func main() {
 		defer cleanupMultusConf(&opt)
 	}
 
-	watchChanges := opt.CleanupConfigOnExit && opt.MultusConfFile == "auto" && !opt.SkipMultusConfWatch
+	watchChanges := (opt.CleanupConfigOnExit || opt.ForceConfigWatch) && opt.MultusConfFile == "auto" && !opt.SkipMultusConfWatch
 	if watchChanges {
 		fmt.Printf("Entering watch loop...\n")
 		masterConfigExists := true

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -631,8 +631,9 @@ You can also enable watching independently of `--cleanup-config-on-exit` using:
 
     --force-config-watch
 
-When `--force-config-watch` is set (together with `--multus-conf-file=auto`), the entrypoint will watch and regenerate the Multus configuration on changes
-without deleting it on exit. This is useful when you want live config updates but do not need the cleanup-on-exit behavior.
+When `--force-config-watch` is set (together with `--multus-conf-file=auto`), the entrypoint will watch and regenerate the Multus configuration on changes.
+The generated configuration remains on exit only when `--cleanup-config-on-exit` is not set. If both flags are enabled, cleanup on exit still deletes the
+generated configuration. This is useful when you want live config updates but do not need the cleanup-on-exit behavior.
 
 Additionally when using CRIO, you may wish to have the CNI config file that's used as the source for `--multus-conf-file=auto` renamed. This boolean option when set to true automatically renames the file with a `.old` suffix to the original filename.
 

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -627,6 +627,13 @@ master CNI configuration and kubeconfig. when such change detected, the script w
 
     --skip-config-watch
 
+You can also enable watching independently of `--cleanup-config-on-exit` using:
+
+    --force-config-watch
+
+When `--force-config-watch` is set (together with `--multus-conf-file=auto`), the entrypoint will watch and regenerate the Multus configuration on changes
+without deleting it on exit. This is useful when you want live config updates but do not need the cleanup-on-exit behavior.
+
 Additionally when using CRIO, you may wish to have the CNI config file that's used as the source for `--multus-conf-file=auto` renamed. This boolean option when set to true automatically renames the file with a `.old` suffix to the original filename.
 
     --rename-conf-file=true


### PR DESCRIPTION
## Motivation

The config watch loop (which regenerates the Multus config when the master CNI config or kubeconfig changes) was previously gated on `--cleanup-config-on-exit=true`. This forced users who wanted live config watching to also opt into config cleanup on pod exit -- two independent behaviors that were unnecessarily coupled.

## Change

A new `--force-config-watch` flag is added to the thin entrypoint. When set (together with `--multus-conf-file=auto`), the watch loop runs regardless of `--cleanup-config-on-exit`. The condition becomes:

```
(CleanupConfigOnExit || ForceConfigWatch) && MultusConfFile == "auto" && !SkipMultusConfWatch
```

- `--cleanup-config-on-exit` behavior is unchanged.
- `--skip-config-watch` continues to suppress watching in both cases.
- Documentation in `docs/how-to-use.md` is updated to describe the new flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `--force-config-watch` option to monitor and regenerate configuration changes independently of cleanup behavior.
  * Generated configuration files now remain available on exit unless cleanup is explicitly enabled.

* **Documentation**
  * Documented the new option and its behavior with automatic configuration generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->