### PR TITLE
feat: add simple per plugin exec metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,11 @@
+# Metrics
+
+Multus daemon serves Prometheus metrics at `/metrics` when `metricsPort` is configured.
+Endpoint is not enabled by default.
+
+| Metric                                                         | Meaning                                    |
+| -------------------------------------------------------------- | ------------------------------------------ |
+| `multus_cni_plugin_lookup_total{plugin,outcome}`               | CNI plugin lookup attempts                 |
+| `multus_cni_plugin_execution_total{plugin,command,outcome}`    | CNI plugin execution attempts              |
+| `multus_cni_plugin_execution_duration_seconds{plugin,command}` | CNI plugin execution duration              |
+| `multus_server_request_total{handler,code,method}`             | Requests handled by the daemon HTTP server |

--- a/docs/thick-plugin.md
+++ b/docs/thick-plugin.md
@@ -67,7 +67,8 @@ The server configuration is encoded in JSON, and allows the following keys:
 for client/server communication will be located. This is the location where the
 **Daemon** will read the configuration from. Defaults to `"/run/multus"`.
 - `"metricsPort"`: Metrics port (of multus' metric exporter); by default, no port
-is provided.
+is provided. See [metrics](metrics.md).
+
 - `"logFile"`: the path to where the daemon logs will be persisted.
 - `"logLevel"`: the logging level for the multus daemon logs.
 - `"logToStderr"`: enable this to have the daemon multus logs echoed to stderr

--- a/pkg/server/metrics_exec.go
+++ b/pkg/server/metrics_exec.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+const (
+	unknownCNICommand    = "UNKNOWN"
+	metricOutcomeSuccess = "success"
+	metricOutcomeFailure = "failure"
+)
+
+// metricsExec records CNI plugin lookup and execution metrics for the daemon.
+type metricsExec struct {
+	exec    invoke.Exec
+	metrics *Metrics
+}
+
+var _ invoke.Exec = &metricsExec{}
+
+func newMetricsExec(exec invoke.Exec, metrics *Metrics) invoke.Exec {
+	if exec == nil {
+		exec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}
+
+	return &metricsExec{
+		exec:    exec,
+		metrics: metrics,
+	}
+}
+
+func (e *metricsExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+	plugin := filepath.Base(pluginPath)
+	command := cniCommand(environ)
+	start := time.Now()
+	stdout, err := e.exec.ExecPlugin(ctx, pluginPath, stdinData, environ)
+
+	outcome := metricOutcomeSuccess
+	if err != nil {
+		outcome = metricOutcomeFailure
+	}
+	e.metrics.cniExecCounter.WithLabelValues(plugin, command, outcome).Inc()
+	e.metrics.cniExecDuration.WithLabelValues(plugin, command).Observe(time.Since(start).Seconds())
+
+	return stdout, err
+}
+
+func (e *metricsExec) FindInPath(plugin string, paths []string) (string, error) {
+	pluginPath, err := e.exec.FindInPath(plugin, paths)
+
+	outcome := metricOutcomeSuccess
+	if err != nil {
+		outcome = metricOutcomeFailure
+	}
+	e.metrics.cniLookupCounter.WithLabelValues(plugin, outcome).Inc()
+
+	return pluginPath, err
+}
+
+func (e *metricsExec) Decode(jsonBytes []byte) (version.PluginInfo, error) {
+	return e.exec.Decode(jsonBytes)
+}
+
+func cniCommand(environ []string) string {
+	for _, entry := range environ {
+		command, found := strings.CutPrefix(entry, "CNI_COMMAND=")
+		if found {
+			return command
+		}
+	}
+	return unknownCNICommand
+}

--- a/pkg/server/metrics_exec_test.go
+++ b/pkg/server/metrics_exec_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Multus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+type metricsExecFake struct {
+	err     error
+	findErr error
+}
+
+var _ invoke.Exec = &metricsExecFake{}
+
+func (e *metricsExecFake) ExecPlugin(_ context.Context, _ string, _ []byte, _ []string) ([]byte, error) {
+	return []byte("{}"), e.err
+}
+
+func (e *metricsExecFake) FindInPath(_ string, _ []string) (string, error) {
+	return "", e.findErr
+}
+
+func (e *metricsExecFake) Decode(_ []byte) (version.PluginInfo, error) {
+	return nil, nil
+}
+
+func TestMetricsExec(t *testing.T) {
+	g := gomega.NewWithT(t)
+	metrics := newTestMetrics()
+	failure := errors.New("plugin failed")
+
+	_, err := newMetricsExec(&metricsExecFake{}, metrics).ExecPlugin(
+		context.Background(), "/opt/cni/bin/sriov", nil, []string{"CNI_COMMAND=ADD"},
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	_, err = newMetricsExec(&metricsExecFake{err: failure}, metrics).ExecPlugin(
+		context.Background(), "/opt/cni/bin/sriov", nil, []string{"CNI_COMMAND=ADD"},
+	)
+	g.Expect(err).To(gomega.MatchError(failure))
+
+	_, err = newMetricsExec(&metricsExecFake{}, metrics).ExecPlugin(
+		context.Background(), "/opt/cni/bin/sriov", nil, nil,
+	)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	_, err = newMetricsExec(&metricsExecFake{}, metrics).FindInPath("sriov", nil)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	_, err = newMetricsExec(&metricsExecFake{findErr: failure}, metrics).FindInPath("sriov", nil)
+	g.Expect(err).To(gomega.MatchError(failure))
+
+	g.Expect(counterValue(g, metrics.cniExecCounter.WithLabelValues("sriov", "ADD", metricOutcomeSuccess))).To(gomega.Equal(1.0))
+	g.Expect(counterValue(g, metrics.cniExecCounter.WithLabelValues("sriov", "ADD", metricOutcomeFailure))).To(gomega.Equal(1.0))
+	g.Expect(counterValue(g, metrics.cniExecCounter.WithLabelValues("sriov", unknownCNICommand, metricOutcomeSuccess))).To(gomega.Equal(1.0))
+	g.Expect(counterValue(g, metrics.cniLookupCounter.WithLabelValues("sriov", metricOutcomeSuccess))).To(gomega.Equal(1.0))
+	g.Expect(counterValue(g, metrics.cniLookupCounter.WithLabelValues("sriov", metricOutcomeFailure))).To(gomega.Equal(1.0))
+	g.Expect(histogramSampleCount(g, metrics.cniExecDuration.WithLabelValues("sriov", "ADD"))).To(gomega.Equal(uint64(2)))
+}
+
+func newTestMetrics() *Metrics {
+	return &Metrics{
+		cniLookupCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{Name: "test_cni_plugin_lookup_total"},
+			[]string{"plugin", "outcome"},
+		),
+		cniExecCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{Name: "test_cni_plugin_execution_total"},
+			[]string{"plugin", "command", "outcome"},
+		),
+		cniExecDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{Name: "test_cni_plugin_execution_duration_seconds"},
+			[]string{"plugin", "command"},
+		),
+	}
+}
+
+func counterValue(g gomega.Gomega, counter prometheus.Counter) float64 {
+	metric := &dto.Metric{}
+	g.Expect(counter.Write(metric)).To(gomega.Succeed())
+	return metric.GetCounter().GetValue()
+}
+
+func histogramSampleCount(g gomega.Gomega, observer prometheus.Observer) uint64 {
+	metric, ok := observer.(prometheus.Metric)
+	if !ok {
+		g.Expect(ok).To(gomega.BeTrue())
+		return 0
+	}
+
+	dtoMetric := &dto.Metric{}
+	g.Expect(metric.Write(dtoMetric)).To(gomega.Succeed())
+	return dtoMetric.GetHistogram().GetSampleCount()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -283,6 +283,27 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 				},
 				[]string{"handler", "code", "method"},
 			),
+			cniLookupCounter: prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "multus_cni_plugin_lookup_total",
+					Help: "Counter of CNI plugin lookups",
+				},
+				[]string{"plugin", "outcome"},
+			),
+			cniExecCounter: prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: "multus_cni_plugin_execution_total",
+					Help: "Counter of CNI plugin process executions",
+				},
+				[]string{"plugin", "command", "outcome"},
+			),
+			cniExecDuration: prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{
+					Name: "multus_cni_plugin_execution_duration_seconds",
+					Help: "Duration of CNI plugin process executions",
+				},
+				[]string{"plugin", "command"},
+			),
 		},
 		informerFactory:          informerFactory,
 		podInformer:              podInformer,
@@ -290,10 +311,15 @@ func newCNIServer(rundir string, kubeClient *k8s.ClientInfo, exec invoke.Exec, s
 		netdefInformer:           netdefInformer,
 		ignoreReadinessIndicator: ignoreReadinessIndicator,
 	}
+
+	s.exec = newMetricsExec(s.exec, s.metrics)
 	s.SetKeepAlivesEnabled(false)
 
 	// register metrics
 	prometheus.MustRegister(s.metrics.requestCounter)
+	prometheus.MustRegister(s.metrics.cniLookupCounter)
+	prometheus.MustRegister(s.metrics.cniExecCounter)
+	prometheus.MustRegister(s.metrics.cniExecDuration)
 
 	// handle for '/cni'
 	router.HandleFunc(api.MultusCNIAPIEndpoint, promhttp.InstrumentHandlerCounter(s.metrics.requestCounter.MustCurryWith(prometheus.Labels{"handler": api.MultusCNIAPIEndpoint}),

--- a/pkg/server/thick_cni_test.go
+++ b/pkg/server/thick_cni_test.go
@@ -358,6 +358,9 @@ func startCNIServer(ctx context.Context, runDir string, k8sClient *k8s.ClientInf
 // in unit-testing.
 func unregisterMetrics(server *Server) {
 	ExpectWithOffset(1, prometheus.Unregister(server.metrics.requestCounter)).To(BeTrue())
+	ExpectWithOffset(1, prometheus.Unregister(server.metrics.cniLookupCounter)).To(BeTrue())
+	ExpectWithOffset(1, prometheus.Unregister(server.metrics.cniExecCounter)).To(BeTrue())
+	ExpectWithOffset(1, prometheus.Unregister(server.metrics.cniExecDuration)).To(BeTrue())
 }
 
 func referenceConfig(thickPluginSocketDir string) string {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -42,7 +42,10 @@ const (
 
 // Metrics represents server's metrics.
 type Metrics struct {
-	requestCounter *prometheus.CounterVec
+	requestCounter   *prometheus.CounterVec
+	cniLookupCounter *prometheus.CounterVec
+	cniExecCounter   *prometheus.CounterVec
+	cniExecDuration  *prometheus.HistogramVec
 }
 
 // Server represents an HTTP server listening to a unix socket. It will handle


### PR DESCRIPTION
This PR adds per-plugin prometheus metrics to daemon mode.

Metrics are collected at cni executor boundary, so they cover each plugin in a conflist independently. Labels are deliberately bounded to avoid high-cardinality series from pod, namespace, NAD, interface etc. 

Described in docs/metrics.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for CNI plugin lookups, execution outcomes, and execution duration.
  * Metrics include plugin names, commands, result labels, and daemon HTTP request counts.
  * Metrics are disabled by default and can be enabled through the daemon’s `metricsPort` configuration.
  * Added documentation for configuring and using the Multus daemon metrics endpoint.

* **Bug Fixes**
  * Improved metrics handling when the CNI command is unavailable by reporting it as `UNKNOWN`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->