### PR TITLE
test: fix MonitorPluginConfiguration test writing to missing system path

### DIFF
--- a/pkg/server/config/manager_test.go
+++ b/pkg/server/config/manager_test.go
@@ -60,8 +60,9 @@ var _ = Describe("Configuration Manager", func() {
 			"cniVersion": %q,
 			"multusAutoconfigDir": %q,
 			"multusMasterCNI": %q,
+			"cniConfigDir": %q,
 			"forceCNIVersion": false
-		}`, defaultCniConfig, cniVersion, multusConfigDir, primaryCNIPluginName)
+		}`, defaultCniConfig, cniVersion, multusConfigDir, primaryCNIPluginName, multusConfigDir)
 		multusConfFileName := fmt.Sprintf("%s/10-testcni.conf", multusConfigDir)
 		Expect(os.WriteFile(multusConfFileName, []byte(multusConfFile), 0755)).To(Succeed())
 


### PR DESCRIPTION
The `Check MonitorPluginConfiguration` test was failing because the configuration manager attempted to write `00-multus.conf` to `/etc/cni/net.d/`, which does not exist in the test environment.

The `Manager` struct sets `multusConfigFilePath` using `config.CniConfigDir`, which defaults to `/etc/cni/net.d` when not explicitly set. The test's `BeforeEach` created a temporary directory and used it for `multusAutoconfigDir`, but never set `cniConfigDir`, so the manager's output path still pointed at the system directory.

The fix adds `"cniConfigDir"` to the test's multus config JSON in `BeforeEach`, pointing it at the same temporary directory. This ensures `PersistMultusConfig` writes to a path that exists, and the temporary directory is fully cleaned up in `AfterEach`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration coverage to include the CNI configuration directory when constructing Multus configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->