### PR TITLE
Restore conflist CNINetworkConfigList fast path and fix cached DEL without load cost

### DIFF
--- a/pkg/multus/multus.go
+++ b/pkg/multus/multus.go
@@ -120,8 +120,18 @@ func getDelegateDeviceInfo(_ *types.DelegateNetConf, runtimeConf *libcni.Runtime
 	return nil, nil
 }
 
+// saveDelegates writes the pod's delegate list to the scratch cache under CNIDir
+// so CmdDel can reload it when the pod is already gone from the API. Conflist
+// delegates are prepared for cache first: housekeeping Bytes are lossy, but DEL
+// from cache uses Bytes when CNINetworkConfigList is not restored (json:"-").
 func saveDelegates(containerID, dataDir string, delegates []*types.DelegateNetConf) error {
 	logging.Debugf("saveDelegates: %s, %s, %v", containerID, dataDir, delegates)
+	for _, delegate := range delegates {
+		if err := types.PrepareDelegateForCache(delegate); err != nil {
+			return err
+		}
+	}
+
 	delegatesBytes, err := json.Marshal(delegates)
 	if err != nil {
 		return logging.Errorf("saveDelegates: error serializing delegate netconf: %v", err)
@@ -296,16 +306,25 @@ func confStatus(rt *libcni.RuntimeConf, rawNetconf []byte, multusNetconf *types.
 	return err
 }
 
-func conflistAdd(rt *libcni.RuntimeConf, rawnetconflist []byte, multusNetconf *types.NetConf, exec invoke.Exec) (cnitypes.Result, error) {
+func conflistAdd(rt *libcni.RuntimeConf, rawnetconflist []byte, cniConfList *libcni.NetworkConfigList, multusNetconf *types.NetConf, exec invoke.Exec) (cnitypes.Result, error) {
 	logging.Debugf("conflistAdd: %v, %s", rt, string(rawnetconflist))
 	// In part, adapted from K8s pkg/kubelet/dockershim/network/cni/cni.go
 	binDirs := filepath.SplitList(os.Getenv("CNI_PATH"))
 	binDirs = append([]string{multusNetconf.BinDir}, binDirs...)
 	cniNet := libcni.NewCNIConfigWithCacheDir(binDirs, multusNetconf.CNIDir, exec)
 
-	confList, err := libcni.NetworkConfFromBytes(rawnetconflist)
-	if err != nil {
-		return nil, logging.Errorf("conflistAdd: error converting the raw bytes into a conflist: %v", err)
+	var confList *libcni.NetworkConfigList
+	var err error
+
+	// This may wind up being set during parsing the default network config.
+	// In this case -- we'll use it as passed. Otherwise, we'll recalculate it.
+	if len(cniConfList.Plugins) > 0 {
+		confList = cniConfList
+	} else {
+		confList, err = libcni.NetworkConfFromBytes(rawnetconflist)
+		if err != nil {
+			return nil, logging.Errorf("conflistAdd: error converting the raw bytes into a conflist: %v", err)
+		}
 	}
 
 	result, err := cniNet.AddNetworkList(context.Background(), confList, rt)
@@ -316,16 +335,25 @@ func conflistAdd(rt *libcni.RuntimeConf, rawnetconflist []byte, multusNetconf *t
 	return result, nil
 }
 
-func conflistCheck(rt *libcni.RuntimeConf, rawnetconflist []byte, multusNetconf *types.NetConf, exec invoke.Exec) error {
+func conflistCheck(rt *libcni.RuntimeConf, rawnetconflist []byte, cniConfList *libcni.NetworkConfigList, multusNetconf *types.NetConf, exec invoke.Exec) error {
 	logging.Debugf("conflistCheck: %v, %s", rt, string(rawnetconflist))
 
 	binDirs := filepath.SplitList(os.Getenv("CNI_PATH"))
 	binDirs = append([]string{multusNetconf.BinDir}, binDirs...)
 	cniNet := libcni.NewCNIConfigWithCacheDir(binDirs, multusNetconf.CNIDir, exec)
 
-	confList, err := libcni.ConfListFromBytes(rawnetconflist)
-	if err != nil {
-		return logging.Errorf("conflistCheck: error converting the raw bytes into a conflist: %v", err)
+	var confList *libcni.NetworkConfigList
+	var err error
+
+	// This may wind up being set during parsing the default network config.
+	// In this case -- we'll use it as passed. Otherwise, we'll recalculate it.
+	if len(cniConfList.Plugins) > 0 {
+		confList = cniConfList
+	} else {
+		confList, err = libcni.NetworkConfFromBytes(rawnetconflist)
+		if err != nil {
+			return logging.Errorf("conflistCheck: error converting the raw bytes into a conflist: %v", err)
+		}
 	}
 
 	err = cniNet.CheckNetworkList(context.Background(), confList, rt)
@@ -336,16 +364,25 @@ func conflistCheck(rt *libcni.RuntimeConf, rawnetconflist []byte, multusNetconf 
 	return err
 }
 
-func conflistDel(rt *libcni.RuntimeConf, rawnetconflist []byte, multusNetconf *types.NetConf, exec invoke.Exec) error {
+func conflistDel(rt *libcni.RuntimeConf, rawnetconflist []byte, cniConfList *libcni.NetworkConfigList, multusNetconf *types.NetConf, exec invoke.Exec) error {
 	logging.Debugf("conflistDel: %v, %s", rt, string(rawnetconflist))
 	// In part, adapted from K8s pkg/kubelet/dockershim/network/cni/cni.go
 	binDirs := filepath.SplitList(os.Getenv("CNI_PATH"))
 	binDirs = append([]string{multusNetconf.BinDir}, binDirs...)
 	cniNet := libcni.NewCNIConfigWithCacheDir(binDirs, multusNetconf.CNIDir, exec)
 
-	confList, err := libcni.ConfListFromBytes(rawnetconflist)
-	if err != nil {
-		return logging.Errorf("conflistDel: error converting the raw bytes into a conflist: %v", err)
+	var confList *libcni.NetworkConfigList
+	var err error
+
+	// This may wind up being set during parsing the default network config.
+	// In this case -- we'll use it as passed. Otherwise, we'll recalculate it.
+	if len(cniConfList.Plugins) > 0 {
+		confList = cniConfList
+	} else {
+		confList, err = libcni.NetworkConfFromBytes(rawnetconflist)
+		if err != nil {
+			return logging.Errorf("conflistDel: error converting the raw bytes into a conflist: %v", err)
+		}
 	}
 
 	err = cniNet.DelNetworkList(context.Background(), confList, rt)
@@ -427,7 +464,7 @@ func DelegateAdd(exec invoke.Exec, kubeClient *k8s.ClientInfo, pod *v1.Pod, dele
 	var result cnitypes.Result
 	var err error
 	if delegate.ConfListPlugin {
-		result, err = conflistAdd(rt, delegate.Bytes, multusNetconf, exec)
+		result, err = conflistAdd(rt, delegate.Bytes, &delegate.CNINetworkConfigList, multusNetconf, exec)
 		if err != nil {
 			return nil, err
 		}
@@ -498,7 +535,7 @@ func DelegateCheck(exec invoke.Exec, delegateConf *types.DelegateNetConf, rt *li
 
 	var err error
 	if delegateConf.ConfListPlugin {
-		err = conflistCheck(rt, delegateConf.Bytes, multusNetconf, exec)
+		err = conflistCheck(rt, delegateConf.Bytes, &delegateConf.CNINetworkConfigList, multusNetconf, exec)
 		if err != nil {
 			return logging.Errorf("DelegateCheck: error invoking ConflistCheck - %q: %v", delegateConf.ConfList.Name, err)
 		}
@@ -572,7 +609,7 @@ func DelegateDel(exec invoke.Exec, pod *v1.Pod, delegateConf *types.DelegateNetC
 
 	var err error
 	if delegateConf.ConfListPlugin {
-		err = conflistDel(rt, delegateConf.Bytes, multusNetconf, exec)
+		err = conflistDel(rt, delegateConf.Bytes, &delegateConf.CNINetworkConfigList, multusNetconf, exec)
 		if err != nil {
 			return logging.Errorf("DelegateDel: error invoking ConflistDel - %q: %v", delegateConf.ConfList.Name, err)
 		}
@@ -1083,17 +1120,25 @@ func CmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) er
 	for _, v := range in.Delegates {
 		if v.ConfListPlugin && v.ConfList.CNIVersion == "" && in.CNIVersion != "" {
 			v.ConfList.CNIVersion = in.CNIVersion
-			// Inject cniVersion onto the raw bytes losslessly. Marshaling the
-			// structured ConfList (types.NetConfList) here would strip
-			// CNI-specific fields (e.g. calico's kubeconfig) and break DEL.
-			updatedBytes, injectErr := types.InjectCNIVersionInConfList(v.Bytes, in.CNIVersion)
-			if injectErr != nil {
-				// error happen but continue to delete; keep the original bytes
-				// rather than clobbering them with nil, which would feed DEL
-				// worse input than before and risk leaking the IP.
-				logging.Errorf("Multus: failed to inject cniVersion into delegate %q config: %v", v.Name, injectErr)
+			// Fresh delegates carry CNINetworkConfigList (DEL uses the fast path).
+			// Scratch-cache delegates do not (json:"-") and DEL falls back to Bytes
+			// prepared losslessly at ADD via PrepareDelegateForCache.
+			if len(v.CNINetworkConfigList.Plugins) > 0 {
+				v.CNINetworkConfigList.CNIVersion = in.CNIVersion
 			} else {
-				v.Bytes = updatedBytes
+				// Cached delegate: CNINetworkConfigList is not restored from scratch
+				// cache; inject cniVersion onto lossless Bytes without stripping fields.
+				// Marshaling the structured ConfList (types.NetConfList) here would strip
+				// CNI-specific fields (e.g. calico's kubeconfig) and break DEL.
+				updatedBytes, injectErr := types.InjectCNIVersionInConfList(v.Bytes, in.CNIVersion)
+				if injectErr != nil {
+					// error happen but continue to delete; keep the original bytes
+					// rather than clobbering them with nil, which would feed DEL
+					// worse input than before and risk leaking the IP.
+					logging.Errorf("Multus: failed to inject cniVersion into delegate %q config: %v", v.Name, injectErr)
+				} else {
+					v.Bytes = updatedBytes
+				}
 			}
 		}
 	}

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -161,12 +161,11 @@ func LoadDelegateNetConfFromConfList(confList *libcni.NetworkConfigList, netElem
 		ConfListPlugin:       true,
 	}
 
-	// Marshal the structured NetConfList for Bytes (housekeeping / cache).
-	// Conflist ADD/CHECK/DEL use CNINetworkConfigList, which retains each
-	// plugin's raw bytes from libcni.
-	pluginsBytes, err := json.Marshal(netConfList)
+	// Seed Bytes from libcni raw plugin JSON so deviceID/CNIArgs injection and
+	// re-parsing preserve plugin-specific fields (not only cnitypes.PluginConf keys).
+	pluginsBytes, err := losslessConfListBytes(confList)
 	if err != nil {
-		return nil, logging.Errorf("LoadDelegateNetConfFromConfList: error marshaling netConfList: %v", err)
+		return nil, logging.Errorf("LoadDelegateNetConfFromConfList: error rebuilding conflist bytes: %v", err)
 	}
 
 	if deviceID != "" {

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -83,43 +83,64 @@ func ConvertNetworkConfigListToNetConfList(ncList *libcni.NetworkConfigList) (*t
 	return netConfList, nil
 }
 
-// rawConfListBytes rebuilds the complete conflist JSON from a libcni
+// losslessConfListBytes rebuilds the complete conflist JSON from a libcni
 // NetworkConfigList without losing any field. It takes the list-level keys
 // from the original bytes and rebuilds the "plugins" array from each plugin's
 // raw bytes. Per-plugin raw bytes are used (instead of confList.Bytes as a
 // whole) because libcni appends plugins loaded from a subdirectory chain into
 // confList.Plugins without updating confList.Bytes; relying on confList.Bytes
 // alone would drop those appended plugins.
-func rawConfListBytes(confList *libcni.NetworkConfigList) ([]byte, error) {
-	var rawList map[string]interface{}
+func losslessConfListBytes(confList *libcni.NetworkConfigList) ([]byte, error) {
+	var rawList map[string]json.RawMessage
 	if err := json.Unmarshal(confList.Bytes, &rawList); err != nil {
-		return nil, logging.Errorf("rawConfListBytes: failed to unmarshal conflist bytes: %v", err)
+		return nil, logging.Errorf("losslessConfListBytes: failed to unmarshal conflist bytes: %v", err)
 	}
 
-	plugins := make([]interface{}, 0, len(confList.Plugins))
-	for idx, plugin := range confList.Plugins {
-		var rawPlugin map[string]interface{}
-		if err := json.Unmarshal(plugin.Bytes, &rawPlugin); err != nil {
-			return nil, logging.Errorf("rawConfListBytes: failed to unmarshal plugin #%d: %v", idx, err)
-		}
-		plugins = append(plugins, rawPlugin)
+	plugins := make([]json.RawMessage, 0, len(confList.Plugins))
+	for _, plugin := range confList.Plugins {
+		plugins = append(plugins, json.RawMessage(plugin.Bytes))
 	}
-	rawList["plugins"] = plugins
+
+	pluginsBytes, err := json.Marshal(plugins)
+	if err != nil {
+		return nil, logging.Errorf("losslessConfListBytes: failed to marshal plugins array: %v", err)
+	}
+	rawList["plugins"] = pluginsBytes
 
 	return json.Marshal(rawList)
 }
 
 // InjectCNIVersionInConfList sets the cniVersion field on a conflist JSON
-// without losing any other field. It is used on the DEL path to backfill the
-// cniVersion onto the raw bytes; marshaling the structured NetConfList instead
-// would strip CNI-specific fields and break the plugin's DEL.
+// without losing any other field. It is used on the cached DEL path to backfill
+// cniVersion onto lossless delegate Bytes.
 func InjectCNIVersionInConfList(inBytes []byte, cniVersion string) ([]byte, error) {
-	var rawConfig map[string]interface{}
+	var rawConfig map[string]json.RawMessage
 	if err := json.Unmarshal(inBytes, &rawConfig); err != nil {
 		return nil, logging.Errorf("InjectCNIVersionInConfList: failed to unmarshal inBytes: %v", err)
 	}
-	rawConfig["cniVersion"] = cniVersion
+
+	verBytes, err := json.Marshal(cniVersion)
+	if err != nil {
+		return nil, logging.Errorf("InjectCNIVersionInConfList: failed to marshal cniVersion: %v", err)
+	}
+	rawConfig["cniVersion"] = verBytes
 	return json.Marshal(rawConfig)
+}
+
+// PrepareDelegateForCache rewrites conflist delegate Bytes losslessly from
+// CNINetworkConfigList so cached DEL receives the same complete config ADD did.
+// CNINetworkConfigList is not serialized to the scratch cache (json:"-").
+func PrepareDelegateForCache(delegate *DelegateNetConf) error {
+	if !delegate.ConfListPlugin || len(delegate.CNINetworkConfigList.Plugins) == 0 {
+		return nil
+	}
+
+	pluginsBytes, err := losslessConfListBytes(&delegate.CNINetworkConfigList)
+	if err != nil {
+		return logging.Errorf("PrepareDelegateForCache: error rebuilding conflist bytes: %v", err)
+	}
+	delegate.Bytes = pluginsBytes
+	return nil
 }
 
 // LoadDelegateNetConfFromConfList converts a libcni.NetworkConfigList into a DelegateNetConf structure
@@ -134,20 +155,18 @@ func LoadDelegateNetConfFromConfList(confList *libcni.NetworkConfigList, netElem
 	}
 
 	delegateConf := &DelegateNetConf{
-		Name:           netConfList.Name,
-		ConfList:       *netConfList,
-		ConfListPlugin: true,
+		Name:                 netConfList.Name,
+		ConfList:             *netConfList,
+		CNINetworkConfigList: *confList,
+		ConfListPlugin:       true,
 	}
 
-	// Preserve the original conflist bytes losslessly. The structured
-	// NetConfList (via cnitypes.PluginConf) drops any field outside
-	// cniVersion/name/type/capabilities/ipam.type/dns, which would strip
-	// CNI-specific fields such as calico's kubeconfig/datastore_type and
-	// break the plugin's DEL (e.g. failing to release IPs). Rebuild from the
-	// libcni raw bytes instead so DEL receives the same complete config ADD did.
-	pluginsBytes, err := rawConfListBytes(confList)
+	// Marshal the structured NetConfList for Bytes (housekeeping / cache).
+	// Conflist ADD/CHECK/DEL use CNINetworkConfigList, which retains each
+	// plugin's raw bytes from libcni.
+	pluginsBytes, err := json.Marshal(netConfList)
 	if err != nil {
-		return nil, logging.Errorf("LoadDelegateNetConfFromConfList: error rebuilding conflist bytes: %v", err)
+		return nil, logging.Errorf("LoadDelegateNetConfFromConfList: error marshaling netConfList: %v", err)
 	}
 
 	if deviceID != "" {
@@ -164,6 +183,18 @@ func LoadDelegateNetConfFromConfList(confList *libcni.NetworkConfigList, netElem
 		if err != nil {
 			return nil, logging.Errorf("LoadDelegateNetConfFromConfList: failed to add cni-args in NetConfList bytes: %v", err)
 		}
+	}
+
+	// deviceID and CNIArgs are injected into pluginsBytes only; CNINetworkConfigList
+	// was copied from confList before those edits. ADD/CHECK/DEL use the fast path
+	// (CNINetworkConfigList when Plugins is non-empty), not Bytes, so re-parse once
+	// here to keep libcni and PrepareDelegateForCache aligned with the mutated JSON.
+	if deviceID != "" || (netElement != nil && netElement.CNIArgs != nil) {
+		updatedConfList, err := libcni.NetworkConfFromBytes(pluginsBytes)
+		if err != nil {
+			return nil, logging.Errorf("LoadDelegateNetConfFromConfList: error re-parsing conflist bytes: %v", err)
+		}
+		delegateConf.CNINetworkConfigList = *updatedConfList
 	}
 
 	delegateConf.Bytes = pluginsBytes

--- a/pkg/types/conf_test.go
+++ b/pkg/types/conf_test.go
@@ -1022,10 +1022,10 @@ var _ = Describe("config operations", func() {
 		Expect(netconf.IsFilterV6Gateway).To(BeFalse())
 	})
 
-	It("LoadDelegateNetConfFromConfList preserves CNI-specific fields so DEL does not leak", func() {
-		// A calico-style conflist carries fields (kubeconfig, datastore_type,
-		// policy, ...) that the structured NetConfList would drop. If they are
-		// stripped, calico's DEL fails and the IP is never released.
+	It("LoadDelegateNetConfFromConfList preserves CNI-specific fields in CNINetworkConfigList", func() {
+		// Plugin-specific fields (kubeconfig, datastore_type, ...) are dropped
+		// from the structured NetConfList Bytes, but CNINetworkConfigList retains
+		// each plugin's raw bytes for the conflist fast path.
 		conflist := `{
 			"name": "k8s-pod-network",
 			"cniVersion": "0.3.1",
@@ -1052,33 +1052,36 @@ var _ = Describe("config operations", func() {
 		delegate, err := LoadDelegateNetConfFromConfList(confList, nil, "", "")
 		Expect(err).NotTo(HaveOccurred())
 
-		var parsed map[string]interface{}
-		Expect(json.Unmarshal(delegate.Bytes, &parsed)).To(Succeed())
+		Expect(delegate.CNINetworkConfigList.Name).To(Equal("k8s-pod-network"))
+		Expect(delegate.CNINetworkConfigList.CNIVersion).To(Equal("0.3.1"))
+		Expect(delegate.CNINetworkConfigList.Plugins).To(HaveLen(2))
 
-		plugins, ok := parsed["plugins"].([]interface{})
-		Expect(ok).To(BeTrue())
-		Expect(plugins).To(HaveLen(2))
-
-		calico, ok := plugins[0].(map[string]interface{})
-		Expect(ok).To(BeTrue())
+		var calico map[string]interface{}
+		Expect(json.Unmarshal(delegate.CNINetworkConfigList.Plugins[0].Bytes, &calico)).To(Succeed())
+		Expect(calico["type"]).To(Equal("calico"))
 		Expect(calico["datastore_type"]).To(Equal("kubernetes"))
 		Expect(calico["nodename"]).To(Equal("node-1"))
 		Expect(calico["mtu"]).To(BeEquivalentTo(1500))
 		Expect(calico["policy"]).NotTo(BeNil())
-
 		k8s, ok := calico["kubernetes"].(map[string]interface{})
 		Expect(ok).To(BeTrue())
 		Expect(k8s["kubeconfig"]).To(Equal("/etc/cni/net.d/calico-kubeconfig"))
-
 		ipam, ok := calico["ipam"].(map[string]interface{})
 		Expect(ok).To(BeTrue())
 		Expect(ipam["type"]).To(Equal("calico-ipam"))
+
+		var portmap map[string]interface{}
+		Expect(json.Unmarshal(delegate.CNINetworkConfigList.Plugins[1].Bytes, &portmap)).To(Succeed())
+		Expect(portmap["type"]).To(Equal("portmap"))
+		capabilities, ok := portmap["capabilities"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(capabilities["portMappings"]).To(BeTrue())
 	})
 
-	It("LoadDelegateNetConfFromConfList keeps plugins appended from a subdirectory chain", func() {
+	It("LoadDelegateNetConfFromConfList keeps appended plugins in CNINetworkConfigList", func() {
 		// libcni appends subdirectory-chain plugins into confList.Plugins but
-		// does NOT update confList.Bytes. Rebuilding from confList.Bytes alone
-		// would drop them, so rawConfListBytes must use per-plugin Bytes.
+		// does NOT update confList.Bytes. CNINetworkConfigList carries the full
+		// plugin list for the conflist fast path.
 		base := `{
 			"name": "k8s-pod-network",
 			"cniVersion": "0.3.1",
@@ -1091,8 +1094,6 @@ var _ = Describe("config operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(confList.Plugins).To(HaveLen(1))
 
-		// Simulate a plugin appended from the subdirectory chain: present in
-		// Plugins, absent from the list-level Bytes.
 		appended, err := libcni.NetworkPluginConfFromBytes([]byte(`{"type": "bandwidth", "capabilities": {"bandwidth": true}}`))
 		Expect(err).NotTo(HaveOccurred())
 		confList.Plugins = append(confList.Plugins, appended)
@@ -1100,12 +1101,104 @@ var _ = Describe("config operations", func() {
 		delegate, err := LoadDelegateNetConfFromConfList(confList, nil, "", "")
 		Expect(err).NotTo(HaveOccurred())
 
+		Expect(delegate.CNINetworkConfigList.Plugins).To(HaveLen(2))
+		Expect(string(delegate.CNINetworkConfigList.Plugins[1].Bytes)).To(ContainSubstring("bandwidth"))
+	})
+
+	It("LoadDelegateNetConfFromConfList populates CNINetworkConfigList for fast path", func() {
+		conflist := `{
+			"name": "k8s-pod-network",
+			"cniVersion": "0.3.1",
+			"plugins": [
+				{
+					"type": "calico",
+					"kubernetes": {"kubeconfig": "/etc/cni/net.d/calico-kubeconfig"}
+				}
+			]
+		}`
+
+		confList, err := libcni.NetworkConfFromBytes([]byte(conflist))
+		Expect(err).NotTo(HaveOccurred())
+
+		delegate, err := LoadDelegateNetConfFromConfList(confList, nil, "", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(delegate.CNINetworkConfigList.Plugins).NotTo(BeEmpty())
+		Expect(string(delegate.CNINetworkConfigList.Plugins[0].Bytes)).To(ContainSubstring("/etc/cni/net.d/calico-kubeconfig"))
+	})
+
+	It("LoadDelegateNetConfFromConfList re-syncs CNINetworkConfigList when deviceID is set", func() {
+		conflist := `{
+			"name": "k8s-pod-network",
+			"cniVersion": "0.3.1",
+			"plugins": [{"type": "sriov", "ipam": {"type": "host-local"}}]
+		}`
+
+		confList, err := libcni.NetworkConfFromBytes([]byte(conflist))
+		Expect(err).NotTo(HaveOccurred())
+
+		delegate, err := LoadDelegateNetConfFromConfList(confList, nil, "0000:00:00.0", "resource1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(delegate.DeviceID).To(Equal("0000:00:00.0"))
+		Expect(delegate.CNINetworkConfigList.Plugins).NotTo(BeEmpty())
+		Expect(string(delegate.CNINetworkConfigList.Plugins[0].Bytes)).To(ContainSubstring("0000:00:00.0"))
+	})
+
+	It("PrepareDelegateForCache preserves CNI-specific fields in Bytes for cached DEL", func() {
+		conflist := `{
+			"name": "k8s-pod-network",
+			"cniVersion": "0.3.1",
+			"plugins": [
+				{
+					"type": "calico",
+					"datastore_type": "kubernetes",
+					"nodename": "node-1",
+					"mtu": 1500,
+					"policy": {"type": "k8s"},
+					"kubernetes": {"kubeconfig": "/etc/cni/net.d/calico-kubeconfig"},
+					"ipam": {"type": "calico-ipam"}
+				}
+			]
+		}`
+
+		confList, err := libcni.NetworkConfFromBytes([]byte(conflist))
+		Expect(err).NotTo(HaveOccurred())
+
+		delegate, err := LoadDelegateNetConfFromConfList(confList, nil, "", "")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Housekeeping Bytes are lossy until PrepareDelegateForCache runs.
+		var lossyParsed map[string]interface{}
+		Expect(json.Unmarshal(delegate.Bytes, &lossyParsed)).To(Succeed())
+		lossyPlugins, ok := lossyParsed["plugins"].([]interface{})
+		Expect(ok).To(BeTrue())
+		lossyCalico, ok := lossyPlugins[0].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(lossyCalico).NotTo(HaveKey("kubernetes"))
+		Expect(lossyCalico).NotTo(HaveKey("datastore_type"))
+
+		Expect(PrepareDelegateForCache(delegate)).To(Succeed())
+
 		var parsed map[string]interface{}
 		Expect(json.Unmarshal(delegate.Bytes, &parsed)).To(Succeed())
+		Expect(parsed["name"]).To(Equal("k8s-pod-network"))
+		Expect(parsed["cniVersion"]).To(Equal("0.3.1"))
 		plugins, ok := parsed["plugins"].([]interface{})
 		Expect(ok).To(BeTrue())
-		Expect(plugins).To(HaveLen(2))
-		Expect(plugins[1].(map[string]interface{})["type"]).To(Equal("bandwidth"))
+		Expect(plugins).To(HaveLen(1))
+
+		calico, ok := plugins[0].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(calico["type"]).To(Equal("calico"))
+		Expect(calico["datastore_type"]).To(Equal("kubernetes"))
+		Expect(calico["nodename"]).To(Equal("node-1"))
+		Expect(calico["mtu"]).To(BeEquivalentTo(1500))
+		Expect(calico["policy"]).NotTo(BeNil())
+		k8s, ok := calico["kubernetes"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(k8s["kubeconfig"]).To(Equal("/etc/cni/net.d/calico-kubeconfig"))
+		ipam, ok := calico["ipam"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(ipam["type"]).To(Equal("calico-ipam"))
 	})
 
 	It("InjectCNIVersionInConfList sets cniVersion without dropping fields", func() {

--- a/pkg/types/conf_test.go
+++ b/pkg/types/conf_test.go
@@ -1140,7 +1140,13 @@ var _ = Describe("config operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(delegate.DeviceID).To(Equal("0000:00:00.0"))
 		Expect(delegate.CNINetworkConfigList.Plugins).NotTo(BeEmpty())
-		Expect(string(delegate.CNINetworkConfigList.Plugins[0].Bytes)).To(ContainSubstring("0000:00:00.0"))
+
+		var plugin map[string]interface{}
+		Expect(json.Unmarshal(delegate.CNINetworkConfigList.Plugins[0].Bytes, &plugin)).To(Succeed())
+		Expect(plugin["deviceID"]).To(Equal("0000:00:00.0"))
+		ipam, ok := plugin["ipam"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(ipam["type"]).To(Equal("host-local"))
 	})
 
 	It("PrepareDelegateForCache preserves CNI-specific fields in Bytes for cached DEL", func() {
@@ -1166,15 +1172,18 @@ var _ = Describe("config operations", func() {
 		delegate, err := LoadDelegateNetConfFromConfList(confList, nil, "", "")
 		Expect(err).NotTo(HaveOccurred())
 
-		// Housekeeping Bytes are lossy until PrepareDelegateForCache runs.
-		var lossyParsed map[string]interface{}
-		Expect(json.Unmarshal(delegate.Bytes, &lossyParsed)).To(Succeed())
-		lossyPlugins, ok := lossyParsed["plugins"].([]interface{})
+		// Bytes are lossless from load; PrepareDelegateForCache aligns Bytes with
+		// CNINetworkConfigList before scratch-cache serialization.
+		var beforeCache map[string]interface{}
+		Expect(json.Unmarshal(delegate.Bytes, &beforeCache)).To(Succeed())
+		beforePlugins, ok := beforeCache["plugins"].([]interface{})
 		Expect(ok).To(BeTrue())
-		lossyCalico, ok := lossyPlugins[0].(map[string]interface{})
+		beforeCalico, ok := beforePlugins[0].(map[string]interface{})
 		Expect(ok).To(BeTrue())
-		Expect(lossyCalico).NotTo(HaveKey("kubernetes"))
-		Expect(lossyCalico).NotTo(HaveKey("datastore_type"))
+		Expect(beforeCalico["datastore_type"]).To(Equal("kubernetes"))
+		beforeK8s, ok := beforeCalico["kubernetes"].(map[string]interface{})
+		Expect(ok).To(BeTrue())
+		Expect(beforeK8s["kubeconfig"]).To(Equal("/etc/cni/net.d/calico-kubeconfig"))
 
 		Expect(PrepareDelegateForCache(delegate)).To(Succeed())
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"sort"
 
+	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types"
 	cni100 "github.com/containernetworking/cni/pkg/types/100"
 	"gopkg.in/k8snetworkplumbingwg/multus-cni.v4/pkg/logging"
@@ -100,6 +101,7 @@ type BandwidthEntry struct {
 type DelegateNetConf struct {
 	Conf                  types.NetConf
 	ConfList              types.NetConfList
+	CNINetworkConfigList  libcni.NetworkConfigList `json:"-"` // only used internal housekeeping
 	Name                  string
 	IfnameRequest         string          `json:"ifnameRequest,omitempty"`
 	MacRequest            string          `json:"macRequest,omitempty"`


### PR DESCRIPTION
PR #1521 fixed an IP leak for conflist delegates (e.g. Calico): on DEL, lossy json.Marshal(types.NetConfList) stripped plugin-specific fields such as kubeconfig and datastore_type, so delegates could not release IPs. The fix rebuilt lossless conflist Bytes via rawConfListBytes on every LoadDelegateNetConfFromConfList and removed CNINetworkConfigList, forcing conflistAdd to call libcni.NetworkConfFromBytes on every ADD. That corrected DEL correctness but reintroduced measurable overhead on the hot path (kindnet conflist on every pod): micro-benchmarks showed rawConfListBytes was noticeably slower than the prior json.Marshal(netConfList) approach, and every ADD paid an extra JSON parse where the pre-PR #1521 code passed a pre-built libcni.NetworkConfigList directly to libcni.

This change keeps correctness without paying the JSON parse cost on every load and ADD:

- Restore CNINetworkConfigList on DelegateNetConf and use it in conflistAdd, conflistCheck, and conflistDel when Plugins is non-empty, avoiding per-call NetworkConfFromBytes on the common cluster-network path.

- At load, keep cheap json.Marshal(ConfList) for housekeeping Bytes only; libcni calls use CNINetworkConfigList, which retains each plugin's raw JSON from libcni.

- Re-sync CNINetworkConfigList from pluginsBytes when deviceID or CNIArgs are injected, since those edits update Bytes but ADD/CHECK/DEL read the struct on the fast path.

- For cached DEL correctness without rawConfListBytes on load: call PrepareDelegateForCache in saveDelegates before marshaling the scratch cache. CNINetworkConfigList is not serialized (json:"-"), so DEL from cache parses Bytes; rebuilding lossless Bytes once at ADD cache write preserves Calico-style fields for that fallback.

- CmdDel: if CNINetworkConfigList is populated (fresh delegate), set CNIVersion on the struct for the fast path; if empty (scratch cache), inject cniVersion with InjectCNIVersionInConfList on lossless cached Bytes instead of lossy json.Marshal(ConfList).

Add regression tests for CNINetworkConfigList field preservation, appended subdirectory-chain plugins, deviceID re-sync, PrepareDelegateForCache, and InjectCNIVersionInConfList.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preservation of plugin-specific and list-level configuration fields during caching and network operations.
  * Ensured CNI version updates are applied reliably without losing existing configuration data.
  * Kept cached configuration synchronized after device ID and CNI argument updates.
* **Tests**
  * Added coverage verifying lossless configuration preservation, cache preparation, and updated device settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->