### PR TITLE
Use stable tag for deployment quickstart

### DIFF
--- a/deployments/multus-daemonset-thick.yml
+++ b/deployments/multus-daemonset-thick.yml
@@ -164,7 +164,7 @@ spec:
       serviceAccountName: multus
       containers:
         - name: kube-multus
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:stable-thick
           command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
           resources:
             requests:
@@ -211,7 +211,7 @@ spec:
                   fieldPath: spec.nodeName
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:stable-thick
           command:
             - "/usr/src/multus-cni/bin/install_multus"
             - "-d"

--- a/deployments/multus-daemonset.yml
+++ b/deployments/multus-daemonset.yml
@@ -191,7 +191,7 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot
+        image: ghcr.io/k8snetworkplumbingwg/multus-cni:stable
         command: ["/thin_entrypoint"]
         args:
         - "--multus-conf-file=auto"
@@ -216,7 +216,7 @@ spec:
           mountPath: /tmp/multus-conf
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:stable
           command: ["/install_multus"]
           args:
             - "--type"


### PR DESCRIPTION
Use the `stable` and `stable-thick` tags for the quick-start deployment instead of the unstable `snapshot` and `snapshot-thick`.

This should prevent new users from deploying the bleeding-edge snapshot release.

I've been using the following kustomize patch to override the tag, if it helps anyone:
```yaml
# multus-version.yaml: Use the stable release of Multus instead of the latest tag.
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: kube-multus-ds
  namespace: kube-system
spec:
  template:
    spec:
      containers:
        - name: kube-multus
          image: ghcr.io/k8snetworkplumbingwg/multus-cni:stable-thick
      initContainers:
        - name: install-multus-binary
          image: ghcr.io/k8snetworkplumbingwg/multus-cni:stable-thick
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Multus deployment images to use stable releases instead of snapshot builds.
  * Applied the stable image updates to both standard and thick deployment variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->