### PR TITLE
Sort device id per container

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ In addition to the [quick-start guide](docs/quickstart.md), you may:
 - [How to use](docs/how-to-use.md)
 - [Quick Start Guide](docs/quickstart.md)
 - [Configuration](docs/configuration.md)
+- [Device resource assignment](docs/device-resource-assignment.md)
 - [Development and Support Information](docs/development.md)
 - [Thick Plugin](docs/thick-plugin.md)
 

--- a/docs/device-resource-assignment.md
+++ b/docs/device-resource-assignment.md
@@ -1,0 +1,67 @@
+# Device resource assignment
+
+This document describes how Multus builds the list of device IDs for a device resource, and how
+those IDs are passed to delegate CNI plugins.
+
+## Background
+
+A NetworkAttachmentDefinition (NAD) can name a device resource with the
+`k8s.v1.cni.cncf.io/resourceName` annotation:
+
+```yaml
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-a
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov_net_A
+spec:
+  config: '{ "cniVersion": "1.0.0", "name": "sriov-net-a", "type": "sriov" }'
+```
+
+Multus does not allocate devices. A device plugin advertises the resource, and kubelet assigns
+devices **per container**:
+
+```yaml
+spec:
+  containers:
+  - name: appcntr1
+    resources:
+      requests:
+        intel.com/sriov_net_A: '2'
+  - name: appcntr2
+    resources:
+      requests:
+        intel.com/sriov_net_A: '2'
+```
+
+Kubelet reports that assignment as `(pod, container, resource name) -> [device IDs]`. Multus reads
+it from the kubelet pod-resources API, or from the kubelet checkpoint file if that API is
+unavailable.
+
+For each resource name, Multus concatenates those per-container lists into one pod-wide slice.
+When a delegate network uses that resource name, Multus takes the next unused ID from the slice
+and writes it into the delegate CNI configuration as `deviceID`.
+
+## List order
+
+The slice is built as follows:
+
+1. Device IDs allocated to the **same container** for the **same resource name** are sorted.
+2. Each container's sorted IDs are appended in **container order**. Devices from different
+   containers are not mixed together.
+
+Example: kubelet allocated `0000:03:02.3` and `0000:03:02.0` to `appcntr1`, and `0000:03:02.5` and
+`0000:03:02.1` to `appcntr2`. The list for `intel.com/sriov_net_A` is:
+
+```text
+["0000:03:02.0", "0000:03:02.3", "0000:03:02.1", "0000:03:02.5"]
+```
+
+Sorting **within each container** makes the order of device IDs for that container deterministic.
+Multus does not sort across containers, so kubelet's per-container grouping is unchanged.
+
+## Related documentation
+
+* [How to use](how-to-use.md) — device plugin and Dynamic Resource Allocation (DRA) examples.
+* [Configuration](configuration.md) — Multus configuration reference.

--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -102,10 +102,11 @@ func (cp *checkpoint) GetPodResourceMap(pod *v1.Pod) (map[string]*types.Resource
 				entry = &types.ResourceInfo{}
 				resourceMap[pod.ResourceName] = entry
 			}
+			var ids []string
 			for _, v := range pod.DeviceIDs {
-				// already exists; append to it
-				entry.DeviceIDs = append(entry.DeviceIDs, v...)
+				ids = append(ids, v...)
 			}
+			entry.DeviceIDs = append(entry.DeviceIDs, types.CopyAndSortDeviceIDs(ids)...)
 		}
 	}
 	return resourceMap, nil

--- a/pkg/checkpoint/checkpoint_test.go
+++ b/pkg/checkpoint/checkpoint_test.go
@@ -132,12 +132,130 @@ var _ = Describe("Kubelet checkpoint data read operations", func() {
 			Expect(len(resourceInfo.DeviceIDs)).To(BeEquivalentTo(2))
 		})
 
-		It("should have \"0000:03:02.3\" in deviceIDs[0]", func() {
-			Expect(resourceInfo.DeviceIDs[0]).To(BeEquivalentTo("0000:03:02.3"))
+		// Single-container allocation is sorted; container order is preserved across entries.
+		It("should have \"0000:03:02.0\" in deviceIDs[0] (per-container sorted)", func() {
+			Expect(resourceInfo.DeviceIDs[0]).To(BeEquivalentTo("0000:03:02.0"))
 		})
 
-		It("should have \"0000:03:02.0\" in deviceIDs[1]", func() {
-			Expect(resourceInfo.DeviceIDs[1]).To(BeEquivalentTo("0000:03:02.0"))
+		It("should have \"0000:03:02.3\" in deviceIDs[1] (per-container sorted)", func() {
+			Expect(resourceInfo.DeviceIDs[1]).To(BeEquivalentTo("0000:03:02.3"))
+		})
+	})
+
+	Context("Using a checkpoint file with multiple containers sharing a resource name", func() {
+		const multiContainerFile = "/tmp/kubelet_internal_checkpoint_multi_container"
+
+		var (
+			fakeCp      *fakeCheckpoint
+			resourceMap map[string]*types.ResourceInfo
+		)
+
+		BeforeEach(func() {
+			// appcntr1 and appcntr2 both get devices from intel.com/sriov_net_A,
+			// and a third entry belongs to a different pod.
+			sampleData := `{
+				"Data": {
+					"PodDeviceEntries": [
+					{
+						"PodUID": "8f5ba1b4-cc11-11e8-89df-408d5c537d23",
+						"ContainerName": "appcntr1",
+						"ResourceName": "intel.com/sriov_net_A",
+						"DeviceIDs": {"-1": [
+							"0000:03:02.3",
+							"0000:03:02.0"
+							]
+						},
+						"AllocResp": ""
+					},
+					{
+						"PodUID": "8f5ba1b4-cc11-11e8-89df-408d5c537d23",
+						"ContainerName": "appcntr2",
+						"ResourceName": "intel.com/sriov_net_A",
+						"DeviceIDs": {"-1": [
+							"0000:03:02.5",
+							"0000:03:02.1"
+							]
+						},
+						"AllocResp": ""
+					},
+					{
+						"PodUID": "8f5ba1b4-cc11-11e8-89df-408d5c537d23",
+						"ContainerName": "appcntr2",
+						"ResourceName": "intel.com/sriov_net_B",
+						"DeviceIDs": {
+							"1": ["0000:03:06.3"],
+							"0": ["0000:03:06.0"]
+						},
+						"AllocResp": ""
+					},
+					{
+						"PodUID": "970a395d-bb3b-11e8-89df-408d5c537d23",
+						"ContainerName": "appcntr1",
+						"ResourceName": "intel.com/sriov_net_A",
+						"DeviceIDs": {"-1": [
+							"0000:03:02.7"
+							]
+						},
+						"AllocResp": ""
+					}
+					],
+					"RegisteredDevices": {
+					"intel.com/sriov_net_A": [
+						"0000:03:02.0",
+						"0000:03:02.1",
+						"0000:03:02.3",
+						"0000:03:02.5",
+						"0000:03:02.7"
+					],
+					"intel.com/sriov_net_B": [
+						"0000:03:06.0",
+						"0000:03:06.3"
+					]
+					}
+				},
+				"Checksum": 0
+				}`
+
+			fakeCp = &fakeCheckpoint{fileName: multiContainerFile}
+			Expect(fakeCp.WriteToFile([]byte(sampleData))).To(Succeed())
+
+			cp, err := getCheckpoint(multiContainerFile)
+			Expect(err).NotTo(HaveOccurred())
+
+			fakePod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fakePod",
+					Namespace: "podNamespace",
+					UID:       k8sTypes.UID("8f5ba1b4-cc11-11e8-89df-408d5c537d23"),
+				},
+			}
+			resourceMap, err = cp.GetPodResourceMap(fakePod)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			Expect(fakeCp.DeleteFile()).To(Succeed())
+		})
+
+		// appcntr1's devices must stay ahead of appcntr2's so that each container's
+		// network attachments get the devices allocated to that container.
+		It("should sort within a container and keep containers in checkpoint order", func() {
+			rInfo, ok := resourceMap["intel.com/sriov_net_A"]
+			Expect(ok).To(BeTrue())
+			Expect(rInfo.DeviceIDs).To(Equal([]string{
+				"0000:03:02.0", "0000:03:02.3",
+				"0000:03:02.1", "0000:03:02.5",
+			}))
+		})
+
+		It("should sort the device IDs a container owns across NUMA nodes", func() {
+			rInfo, ok := resourceMap["intel.com/sriov_net_B"]
+			Expect(ok).To(BeTrue())
+			Expect(rInfo.DeviceIDs).To(Equal([]string{"0000:03:06.0", "0000:03:06.3"}))
+		})
+
+		It("should not include device IDs allocated to another pod", func() {
+			Expect(resourceMap["intel.com/sriov_net_A"].DeviceIDs).NotTo(ContainElement("0000:03:02.7"))
 		})
 	})
 

--- a/pkg/kubeletclient/kubeletclient.go
+++ b/pkg/kubeletclient/kubeletclient.go
@@ -144,11 +144,26 @@ func (rc *kubeletClient) GetPodResourceMap(pod *v1.Pod) (map[string]*types.Resou
 }
 
 func (rc *kubeletClient) getDevicePluginResources(devices []*podresourcesapi.ContainerDevices, resourceMap map[string]*types.ResourceInfo) {
+	// One container may have several ContainerDevices rows for the same
+	// ResourceName. Aggregate those IDs, sort once, then append so this
+	// container contributes a single deterministic list without reordering
+	// other containers already in resourceMap.
+	aggregated := map[string][]string{}
+	var resourceOrder []string
+	seen := map[string]struct{}{}
 	for _, dev := range devices {
-		if rInfo, ok := resourceMap[dev.ResourceName]; ok {
-			rInfo.DeviceIDs = append(rInfo.DeviceIDs, dev.DeviceIds...)
+		if _, ok := seen[dev.ResourceName]; !ok {
+			seen[dev.ResourceName] = struct{}{}
+			resourceOrder = append(resourceOrder, dev.ResourceName)
+		}
+		aggregated[dev.ResourceName] = append(aggregated[dev.ResourceName], dev.DeviceIds...)
+	}
+	for _, name := range resourceOrder {
+		deviceIDs := types.CopyAndSortDeviceIDs(aggregated[name])
+		if rInfo, ok := resourceMap[name]; ok {
+			rInfo.DeviceIDs = append(rInfo.DeviceIDs, deviceIDs...)
 		} else {
-			resourceMap[dev.ResourceName] = &types.ResourceInfo{DeviceIDs: dev.DeviceIds}
+			resourceMap[name] = &types.ResourceInfo{DeviceIDs: deviceIDs}
 		}
 	}
 }

--- a/pkg/kubeletclient/kubeletclient_test.go
+++ b/pkg/kubeletclient/kubeletclient_test.go
@@ -276,4 +276,130 @@ var _ = Describe("Kubelet resource endpoint data read operations", func() {
 			Expect(resourceMap).To(Equal(emptyRMap))
 		})
 	})
+
+	Context("GetPodResourceMap() DeviceID ordering", func() {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-name", Namespace: "pod-namespace"},
+		}
+
+		It("sorts IDs within a container and does not mutate kubelet-owned slices", func() {
+			c0IDs := []string{"0000:03:00.5", "0000:03:00.1"}
+			rc := &kubeletClient{
+				resources: []*podresourcesapi.PodResources{
+					{
+						Name:      "pod-name",
+						Namespace: "pod-namespace",
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name: "ctr-0",
+								Devices: []*podresourcesapi.ContainerDevices{
+									{ResourceName: "sriov", DeviceIds: c0IDs},
+								},
+							},
+							{
+								Name: "ctr-1",
+								Devices: []*podresourcesapi.ContainerDevices{
+									{ResourceName: "sriov", DeviceIds: []string{"0000:03:00.9"}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			resourceMap, err := rc.GetPodResourceMap(pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resourceMap["sriov"].DeviceIDs).To(Equal([]string{"0000:03:00.1", "0000:03:00.5", "0000:03:00.9"}))
+			Expect(c0IDs).To(Equal([]string{"0000:03:00.5", "0000:03:00.1"}))
+		})
+
+		It("does not reorder devices across containers", func() {
+			rc := &kubeletClient{
+				resources: []*podresourcesapi.PodResources{
+					{
+						Name:      "pod-name",
+						Namespace: "pod-namespace",
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name: "ctr-0",
+								Devices: []*podresourcesapi.ContainerDevices{
+									{ResourceName: "sriov", DeviceIds: []string{"0000:03:00.5"}},
+								},
+							},
+							{
+								Name: "ctr-1",
+								Devices: []*podresourcesapi.ContainerDevices{
+									{ResourceName: "sriov", DeviceIds: []string{"0000:03:00.1"}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			resourceMap, err := rc.GetPodResourceMap(pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resourceMap["sriov"].DeviceIDs).To(Equal([]string{"0000:03:00.5", "0000:03:00.1"}))
+		})
+
+		// Each container requests two devices of the same resource name. IDs are
+		// sorted inside a container; container blocks stay in kubelet order.
+		It("sorts within each container when both have multiple devices of the same resource", func() {
+			rc := &kubeletClient{
+				resources: []*podresourcesapi.PodResources{
+					{
+						Name:      "pod-name",
+						Namespace: "pod-namespace",
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name: "ctr-0",
+								Devices: []*podresourcesapi.ContainerDevices{
+									{ResourceName: "sriov", DeviceIds: []string{"0000:03:02.3", "0000:03:02.0"}},
+								},
+							},
+							{
+								Name: "ctr-1",
+								Devices: []*podresourcesapi.ContainerDevices{
+									{ResourceName: "sriov", DeviceIds: []string{"0000:03:02.5", "0000:03:02.1"}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			resourceMap, err := rc.GetPodResourceMap(pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resourceMap["sriov"].DeviceIDs).To(Equal([]string{
+				"0000:03:02.0", "0000:03:02.3",
+				"0000:03:02.1", "0000:03:02.5",
+			}))
+		})
+
+		It("aggregates then sorts multiple ContainerDevices rows for the same resource on one container", func() {
+			rc := &kubeletClient{
+				resources: []*podresourcesapi.PodResources{
+					{
+						Name:      "pod-name",
+						Namespace: "pod-namespace",
+						Containers: []*podresourcesapi.ContainerResources{
+							{
+								Name: "ctr-0",
+								Devices: []*podresourcesapi.ContainerDevices{
+									{ResourceName: "sriov", DeviceIds: []string{"0000:03:00.5", "0000:03:00.1"}},
+									{ResourceName: "sriov", DeviceIds: []string{"0000:03:00.9", "0000:03:00.2"}},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			resourceMap, err := rc.GetPodResourceMap(pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resourceMap["sriov"].DeviceIDs).To(Equal([]string{
+				"0000:03:00.1", "0000:03:00.2", "0000:03:00.5", "0000:03:00.9",
+			}))
+		})
+	})
 })

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -17,6 +17,7 @@ package types
 
 import (
 	"net"
+	"sort"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/types"
@@ -176,6 +177,18 @@ type K8sArgs struct {
 type ResourceInfo struct {
 	Index     int
 	DeviceIDs []string
+}
+
+// CopyAndSortDeviceIDs returns a sorted copy of ids. Callers use this to
+// stabilize order within one container's allocation without mutating kubelet
+// state or reordering devices across containers.
+func CopyAndSortDeviceIDs(ids []string) []string {
+	if ids == nil {
+		return nil
+	}
+	out := append([]string(nil), ids...)
+	sort.Strings(out)
+	return out
 }
 
 // ResourceClient provides a kubelet Pod resource handle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Device IDs are now sorted consistently within each container while preserving container order.
  * Device assignments from multiple entries are correctly combined without reordering devices across containers.
  * Input device lists remain unchanged during processing.

* **Documentation**
  * Added documentation explaining device ID collection, ordering, and delegate configuration.
  * Added the device resource assignment guide to the comprehensive documentation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->