### PR TITLE
keep thick daemon running when multusConfigFile is a path

### DIFF
--- a/cmd/multus-daemon/main.go
+++ b/cmd/multus-daemon/main.go
@@ -151,6 +151,9 @@ func main() {
 		}
 	}
 
+	// run until signalled (the WaitGroup only waits for the
+	// ConfigManager's cleanup)
+	<-ctx.Done()
 	wg.Wait()
 	logging.Verbosef("multus daemon is exited")
 }


### PR DESCRIPTION
setting multusConfigFile to a path makes the thick daemon exit 0
immediately after startup. see the commit message.

verified on a cri-o cluster: the daemon stays up, cni add and del work
through flannel and macvlan delegates, and sigterm exits cleanly.

#1366 may describe the same problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The daemon now remains running until it receives a termination signal, allowing it to shut down cleanly instead of exiting prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->